### PR TITLE
mrc-3148 Collapsible left and right panels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm run test:unit --prefix=app/static
       - name: Run browser tests
         run: |
-          npx playwright install
+          npx playwright install --prefix=app/static
           npm run e2e-test --prefix=app/static
       - name: Lint back end
         run: npm run lint --prefix=app/server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm run test:unit --prefix=app/static
       - name: Run browser tests
         run: |
-          npx playwright install --prefix=app/static
+          (cd app/static && npx playwright install)
           npm run e2e-test --prefix=app/static
       - name: Lint back end
         run: npm run lint --prefix=app/server

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -25228,8 +25228,7 @@
     "vue-feather": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vue-feather/-/vue-feather-2.0.0.tgz",
-      "integrity": "sha512-GBvxJWu2ycGTpB8duYWnc5S/TwWPPb2G5Ft2NbkwK1vZkUDUOTYqIb4Nh1HOL6A37Isfrd0Guun0lesS97PfxA==",
-      "dev": true
+      "integrity": "sha512-GBvxJWu2ycGTpB8duYWnc5S/TwWPPb2G5Ft2NbkwK1vZkUDUOTYqIb4Nh1HOL6A37Isfrd0Guun0lesS97PfxA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -9224,6 +9224,12 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
+      "dev": true
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -12687,6 +12693,16 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
+      }
+    },
+    "feather-icons": {
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.0.tgz",
+      "integrity": "sha512-Y7VqN9FYb8KdaSF0qD1081HCkm0v4Eq/fpfQYQnubpqi0hXx14k+gF9iqtRys1SIcTEi97xDi/fmsPFZ8xo0GQ==",
+      "dev": true,
+      "requires": {
+        "classnames": "^2.2.5",
+        "core-js": "^3.1.3"
       }
     },
     "figgy-pudding": {
@@ -25208,6 +25224,12 @@
           "dev": true
         }
       }
+    },
+    "vue-feather": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vue-feather/-/vue-feather-2.0.0.tgz",
+      "integrity": "sha512-GBvxJWu2ycGTpB8duYWnc5S/TwWPPb2G5Ft2NbkwK1vZkUDUOTYqIb4Nh1HOL6A37Isfrd0Guun0lesS97PfxA==",
+      "dev": true
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -44,9 +44,11 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-vue": "^8.4.1",
     "eslint-plugin-vuejs-accessibility": "^1.1.1",
+    "feather-icons": "^4.29.0",
     "node-sass": "^6.0.1",
     "sass-loader": "^10.2.1",
     "typescript": "^4.5.5",
+    "vue-feather": "^2.0.0",
     "vue-jest": "^5.0.0-alpha.10",
     "vue-loader": "^17.0.0",
     "webpack": "^4.46.0"

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -21,6 +21,7 @@
     "dopri": "^0.0.8",
     "plotly.js": "^2.11.1",
     "vue": "^3.2.29",
+    "vue-feather": "^2.0.0",
     "vuex": "^4.0.2"
   },
   "devDependencies": {
@@ -48,7 +49,6 @@
     "node-sass": "^6.0.1",
     "sass-loader": "^10.2.1",
     "typescript": "^4.5.5",
-    "vue-feather": "^2.0.0",
     "vue-jest": "^5.0.0-alpha.10",
     "vue-loader": "^17.0.0",
     "webpack": "^4.46.0"

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -1,0 +1,88 @@
+<template>
+    <div :class="modeClass">
+        <div class="wodin-left">
+           left
+        </div><div class="wodin-right">
+            right
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+    import { computed, defineComponent, ref } from "vue";
+
+    export enum PanelsMode {
+        Left, Right, Both
+    }
+
+    export default defineComponent({
+        name: "ErrorsAlert",
+        setup() {
+            //TODO: add slots
+
+            const mode = ref<PanelsMode>(PanelsMode.Both);
+
+            const modeClass = computed(() => {
+                switch(mode.value) {
+                    case PanelsMode.Left:
+                        return "wodin-mode-left";
+                    case PanelsMode.Both:
+                        return "wodin-mode-both";
+                    case PanelsMode.Right:
+                        return "wodin-mode-right";
+                }
+            });
+
+            return {
+                modeClass
+            }
+        }
+    });
+</script>
+
+<style scoped lang="scss">
+
+    /*for testing*/
+    .wodin-left {
+        height: 200px;
+        background-color: #ffecb5;
+    }
+
+    .wodin-right {
+        height: 200px;
+        background-color: #d3d3d4;
+    }
+
+    $handleWidth: 2rem;
+    $fullWidth: calc(100% - 2rem);
+    .wodin-mode-left {
+        .wodin-left {
+            width: $fullWidth;
+        }
+
+        .wodin-right {
+            width: $handleWidth;
+        }
+    }
+
+    .wodin-mode-both {
+        .wodin-left {
+            width: 30%
+        }
+
+        .wodin-right {
+            width: 70%;
+        }
+    }
+
+    .wodin-mode-right {
+        .wodin-left {
+            width: $handleWidth;
+        }
+
+        .wodin-right {
+            width: $fullWidth;
+        }
+    }
+
+</style>

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -77,6 +77,7 @@ export default defineComponent({
         };
 
         return {
+            mode,
             modeClass,
             canCollapseLeft,
             canCollapseRight,

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -46,18 +46,13 @@ export default defineComponent({
         const leftAnimateClass = ref("");
         const rightAnimateClass = ref("");
 
-        const modeClass = computed(() => {
-            switch (mode.value) {
-            case PanelsMode.Left:
-                return "wodin-mode-left";
-            case PanelsMode.Both:
-                return "wodin-mode-both";
-            case PanelsMode.Right:
-                return "wodin-mode-right";
-            default:
-                throw new Error("Unknown mode");
-            }
-        });
+        const modeClassMap: Record<PanelsMode, string> = {
+            [PanelsMode.Both]: "wodin-mode-both",
+            [PanelsMode.Left]: "wodin-mode-left",
+            [PanelsMode.Right]: "wodin-mode-right"
+        };
+
+        const modeClass = computed(() => modeClassMap[mode.value]);
 
         const canCollapseLeft = computed(() => mode.value !== PanelsMode.Right);
         const canCollapseRight = computed(() => mode.value !== PanelsMode.Left);

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="modeClass">
-        <div class="wodin-left">
+        <div class="wodin-left" :class="leftAnimateClass">
             <span class="wodin-collapse-controls">
                 <span v-if="canCollapseLeft" @click="collapseLeft()" class="collapse-control" id="collapse-left">
                     <vue-feather type="chevron-left"></vue-feather>
@@ -16,7 +16,7 @@
                 <slot name="left"></slot>
             </div>
         </div>
-        <div class="wodin-right">
+        <div class="wodin-right" :class="rightAnimateClass">
             <div class="view-right" @click="collapseLeft()">
                 View Charts
             </div>
@@ -43,6 +43,8 @@ export default defineComponent({
     },
     setup() {
         const mode = ref<PanelsMode>(PanelsMode.Both);
+        const leftAnimateClass = ref("");
+        const rightAnimateClass = ref("");
 
         const modeClass = computed(() => {
             switch (mode.value) {
@@ -68,8 +70,24 @@ export default defineComponent({
             }
         };
 
-        const collapseLeft = () => collapse(PanelsMode.Left, PanelsMode.Right);
-        const collapseRight = () => collapse(PanelsMode.Right, PanelsMode.Left);
+        const getAnimateClass = (left: boolean, leftward: boolean) => {
+            const panel = left ? "l" : "r";
+            const movement = (left && leftward) || (!left && !leftward) ? "collapse" : "expand";
+            const amount = mode.value == PanelsMode.Both ? "partial" : "full";
+            return `slide-${panel}-panel-${movement}-${amount}`;
+        };
+
+        const collapseLeft = () => {
+            collapse(PanelsMode.Left, PanelsMode.Right);
+            leftAnimateClass.value = getAnimateClass(true, true);
+            rightAnimateClass.value = getAnimateClass(false, true);
+        };
+
+        const collapseRight = () => {
+            collapse(PanelsMode.Right, PanelsMode.Left);
+            leftAnimateClass.value = getAnimateClass(true, false);
+            rightAnimateClass.value = getAnimateClass(false, false);
+        };
 
         return {
             mode,
@@ -77,7 +95,9 @@ export default defineComponent({
             canCollapseLeft,
             canCollapseRight,
             collapseLeft,
-            collapseRight
+            collapseRight,
+            leftAnimateClass,
+            rightAnimateClass
         };
     }
 });
@@ -87,6 +107,11 @@ export default defineComponent({
     $handleWidth: 3rem;
     $fullWidth: calc(100% - 4rem);
     $fullHeight: calc(100vh - 5rem);
+
+    $leftBothModeWidth: 30%;
+    $rightBothModeWidth: 70%;
+
+    $animationDuration: 0.5s;
 
     $dark-grey: #777;
 
@@ -138,11 +163,11 @@ export default defineComponent({
 
     .wodin-mode-both {
         .wodin-left {
-            width: 30%
+            width: $leftBothModeWidth;
         }
 
         .wodin-right {
-            width: 70%;
+            width: $rightBothModeWidth;
         }
 
         .view-left, .view-right {
@@ -168,10 +193,110 @@ export default defineComponent({
         }
     }
 
+    @keyframes show-content-after-anim {
+        0% { opacity: 0; }
+        99% { opacity: 0; }
+        100% { opacity: 1; }
+    }
+
+    @keyframes l-panel-collapse-full {
+        from { width: $leftBothModeWidth }
+        to { width: $handleWidth }
+    }
+    .slide-l-panel-collapse-full {
+        animation: l-panel-collapse-full;
+        animation-duration: $animationDuration;
+
+        .view-left {
+            animation: show-content-after-anim;
+            animation-duration: $animationDuration;
+        }
+    }
+
+    @keyframes l-panel-collapse-partial {
+        from { width: $fullWidth }
+        to { width: $leftBothModeWidth }
+    }
+    .slide-l-panel-collapse-partial {
+        animation: l-panel-collapse-partial;
+        animation-duration: $animationDuration;
+    }
+
+    @keyframes l-panel-expand-full {
+        from { width: $leftBothModeWidth }
+        to { width: $fullWidth }
+    }
+    .slide-l-panel-expand-full {
+        animation: l-panel-expand-full;
+        animation-duration: $animationDuration;
+    }
+
+    @keyframes l-panel-expand-partial {
+        from { width: $handleWidth }
+        to { width: $leftBothModeWidth }
+    }
+    .slide-l-panel-expand-partial {
+        animation: l-panel-expand-partial;
+        animation-duration: $animationDuration;
+
+        .wodin-content {
+            animation: show-content-after-anim;
+            animation-duration: $animationDuration;
+        }
+    }
+
+    @keyframes r-panel-collapse-full {
+        from { width: $rightBothModeWidth }
+        to { width: $handleWidth }
+    }
+    .slide-r-panel-collapse-full {
+        animation: r-panel-collapse-full;
+        animation-duration: $animationDuration;
+
+        .view-right {
+            animation: show-content-after-anim;
+            animation-duration: $animationDuration;
+        }
+    }
+
+    @keyframes r-panel-collapse-partial {
+        from { width: $fullWidth }
+        to { width: $rightBothModeWidth }
+    }
+    .slide-r-panel-collapse-partial {
+        animation: r-panel-collapse-partial;
+        animation-duration: $animationDuration;
+    }
+
+    @keyframes r-panel-expand-full {
+        from { width: $rightBothModeWidth }
+        to { width: $fullWidth }
+    }
+    .slide-r-panel-expand-full {
+        animation: r-panel-expand-full;
+        animation-duration: $animationDuration;
+    }
+
+    @keyframes r-panel-expand-partial {
+        from { width: $handleWidth }
+        to { width: $rightBothModeWidth }
+    }
+    .slide-r-panel-expand-partial {
+        animation: r-panel-expand-partial;
+        animation-duration: $animationDuration;
+
+        .wodin-content {
+            animation: show-content-after-anim;
+            animation-duration: $animationDuration;
+        }
+    }
+
     .wodin-collapse-controls {
         float: right;
         margin-top: 0.5rem;
         margin-right: 1rem;
+        overflow: hidden;
+        white-space: nowrap;
 
         .collapse-control {
             cursor: pointer;

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -12,7 +12,7 @@
             <div class="view-left" @click="collapseRight()">
                 View Options
             </div>
-            <div class="wodin-content">
+            <div class="wodin-content" id="wodin-content-left">
                 <slot name="left"></slot>
             </div>
         </div>
@@ -20,7 +20,7 @@
             <div class="view-right" @click="collapseLeft()">
                 View Charts
             </div>
-            <div class="wodin-content">
+            <div class="wodin-content" id="wodin-content-right">
                 <slot name="right"></slot>
             </div>
         </div>

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -1,22 +1,46 @@
 <template>
     <div :class="modeClass">
         <div class="wodin-left">
-           left
-        </div><div class="wodin-right">
-            right
+            <span class="wodin-collapse-controls">
+                <span v-if="canCollapseLeft" @click="collapseLeft()" class="collapse-control" id="collapse-left">
+                    <vue-feather type="chevron-left"></vue-feather>
+                </span>
+                <span v-if="canCollapseRight" @click="collapseRight()" class="collapse-control" id="collapse-right">
+                    <vue-feather type="chevron-right"></vue-feather>
+                </span>
+            </span>
+            <div class="view-left" @click="collapseRight()">
+                View Options
+            </div>
+            <div class="wodin-content">
+                <slot name="left"></slot>
+            </div>
+        </div>
+        <div class="wodin-right">
+            <div class="view-right" @click="collapseLeft()">
+                View Charts
+            </div>
+            <div class="wodin-content">
+                <slot name="right"></slot>
+            </div>
         </div>
     </div>
+    <div style="clear:both;"></div>
 </template>
 
 <script lang="ts">
     import { computed, defineComponent, ref } from "vue";
+    import VueFeather from "vue-feather";
 
     export enum PanelsMode {
         Left, Right, Both
     }
 
     export default defineComponent({
-        name: "ErrorsAlert",
+        name: "WodinPanels",
+        components: {
+            VueFeather
+        },
         setup() {
             //TODO: add slots
 
@@ -33,28 +57,70 @@
                 }
             });
 
+            const canCollapseLeft = computed(() => mode.value !== PanelsMode.Right);
+            const canCollapseRight = computed(() => mode.value !== PanelsMode.Left);
+
+            const collapseLeft = () => {
+                if (mode.value === PanelsMode.Left) {
+                    mode.value = PanelsMode.Both;
+                } else if (mode.value == PanelsMode.Both) {
+                    mode.value = PanelsMode.Right;
+                }
+            };
+
+            const collapseRight = () => {
+                if (mode.value === PanelsMode.Right) {
+                    mode.value = PanelsMode.Both;
+                } else if (mode.value == PanelsMode.Both) {
+                    mode.value = PanelsMode.Left;
+                }
+            };
+
             return {
-                modeClass
+                modeClass,
+                canCollapseLeft,
+                canCollapseRight,
+                collapseLeft,
+                collapseRight
             }
         }
     });
 </script>
 
 <style scoped lang="scss">
+    $handleWidth: 3rem;
+    $fullWidth: calc(100% - 3rem);
+    $fullHeight: calc(100vh - 3rem);
 
-    /*for testing*/
+    $dark-grey: #777;
+
+    .wodin-left, .wodin-right {
+        float: left;
+        height: $fullHeight;
+        overflow: auto;
+    }
+
     .wodin-left {
-        height: 200px;
-        background-color: #ffecb5;
+        border-right-style: solid;
+        border-right-width: 1px;
+        border-radius: 0 1rem 0 0;
+        border-color: $dark-grey;
     }
 
-    .wodin-right {
-        height: 200px;
-        background-color: #d3d3d4;
+    .view-left, .view-right {
+        cursor: pointer;
+        width: 10rem;
+        color: $dark-grey;
     }
 
-    $handleWidth: 2rem;
-    $fullWidth: calc(100% - 2rem);
+    .view-left {
+        transform: rotate(90deg) translate(6rem, 2.7rem);
+    }
+
+    .view-right {
+        transform: rotate(90deg) translate(6rem, 4rem);
+    }
+
     .wodin-mode-left {
         .wodin-left {
             width: $fullWidth;
@@ -62,6 +128,14 @@
 
         .wodin-right {
             width: $handleWidth;
+
+            .wodin-content {
+                display: none;
+            }
+        }
+
+        .view-left {
+            display: none;
         }
     }
 
@@ -73,16 +147,38 @@
         .wodin-right {
             width: 70%;
         }
+
+        .view-left, .view-right {
+            display: none;
+        }
     }
 
     .wodin-mode-right {
         .wodin-left {
             width: $handleWidth;
+
+            .wodin-content {
+                display: none;
+            }
         }
 
         .wodin-right {
             width: $fullWidth;
         }
+
+        .view-right {
+            display: none;
+        }
     }
 
+    .wodin-collapse-controls {
+        float: right;
+        margin-top: 0.5rem;
+        margin-right: 1rem;
+
+        .collapse-control {
+            cursor: pointer;
+            color: $dark-grey;
+        }
+    }
 </style>

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -42,8 +42,6 @@
             VueFeather
         },
         setup() {
-            //TODO: add slots
-
             const mode = ref<PanelsMode>(PanelsMode.Both);
 
             const modeClass = computed(() => {
@@ -89,15 +87,16 @@
 
 <style scoped lang="scss">
     $handleWidth: 3rem;
-    $fullWidth: calc(100% - 3rem);
-    $fullHeight: calc(100vh - 3rem);
+    $fullWidth: calc(100% - 4rem);
+    $fullHeight: calc(100vh - 5rem);
 
     $dark-grey: #777;
 
     .wodin-left, .wodin-right {
         float: left;
         height: $fullHeight;
-        overflow: auto;
+        overflow-y: auto;
+        overflow-x: hidden;
     }
 
     .wodin-left {

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -60,21 +60,16 @@ export default defineComponent({
         const canCollapseLeft = computed(() => mode.value !== PanelsMode.Right);
         const canCollapseRight = computed(() => mode.value !== PanelsMode.Left);
 
-        const collapseLeft = () => {
-            if (mode.value === PanelsMode.Left) {
+        const collapse = (expandedMode: PanelsMode, collapsedMode: PanelsMode) => {
+            if (mode.value === expandedMode) {
                 mode.value = PanelsMode.Both;
             } else if (mode.value === PanelsMode.Both) {
-                mode.value = PanelsMode.Right;
+                mode.value = collapsedMode;
             }
         };
 
-        const collapseRight = () => {
-            if (mode.value === PanelsMode.Right) {
-                mode.value = PanelsMode.Both;
-            } else if (mode.value === PanelsMode.Both) {
-                mode.value = PanelsMode.Left;
-            }
-        };
+        const collapseLeft = () => collapse(PanelsMode.Left, PanelsMode.Right);
+        const collapseRight = () => collapse(PanelsMode.Right, PanelsMode.Left);
 
         return {
             mode,

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -73,7 +73,7 @@ export default defineComponent({
         const getAnimateClass = (left: boolean, leftward: boolean) => {
             const panel = left ? "l" : "r";
             const movement = (left && leftward) || (!left && !leftward) ? "collapse" : "expand";
-            const amount = mode.value == PanelsMode.Both ? "partial" : "full";
+            const amount = mode.value === PanelsMode.Both ? "partial" : "full";
             return `slide-${panel}-panel-${movement}-${amount}`;
         };
 

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -29,60 +29,62 @@
 </template>
 
 <script lang="ts">
-    import { computed, defineComponent, ref } from "vue";
-    import VueFeather from "vue-feather";
+import { computed, defineComponent, ref } from "vue";
+import VueFeather from "vue-feather";
 
-    export enum PanelsMode {
+export enum PanelsMode {
         Left, Right, Both
     }
 
-    export default defineComponent({
-        name: "WodinPanels",
-        components: {
-            VueFeather
-        },
-        setup() {
-            const mode = ref<PanelsMode>(PanelsMode.Both);
+export default defineComponent({
+    name: "WodinPanels",
+    components: {
+        VueFeather
+    },
+    setup() {
+        const mode = ref<PanelsMode>(PanelsMode.Both);
 
-            const modeClass = computed(() => {
-                switch(mode.value) {
-                    case PanelsMode.Left:
-                        return "wodin-mode-left";
-                    case PanelsMode.Both:
-                        return "wodin-mode-both";
-                    case PanelsMode.Right:
-                        return "wodin-mode-right";
-                }
-            });
-
-            const canCollapseLeft = computed(() => mode.value !== PanelsMode.Right);
-            const canCollapseRight = computed(() => mode.value !== PanelsMode.Left);
-
-            const collapseLeft = () => {
-                if (mode.value === PanelsMode.Left) {
-                    mode.value = PanelsMode.Both;
-                } else if (mode.value == PanelsMode.Both) {
-                    mode.value = PanelsMode.Right;
-                }
-            };
-
-            const collapseRight = () => {
-                if (mode.value === PanelsMode.Right) {
-                    mode.value = PanelsMode.Both;
-                } else if (mode.value == PanelsMode.Both) {
-                    mode.value = PanelsMode.Left;
-                }
-            };
-
-            return {
-                modeClass,
-                canCollapseLeft,
-                canCollapseRight,
-                collapseLeft,
-                collapseRight
+        const modeClass = computed(() => {
+            switch (mode.value) {
+            case PanelsMode.Left:
+                return "wodin-mode-left";
+            case PanelsMode.Both:
+                return "wodin-mode-both";
+            case PanelsMode.Right:
+                return "wodin-mode-right";
+            default:
+                throw new Error("Unknown mode");
             }
-        }
-    });
+        });
+
+        const canCollapseLeft = computed(() => mode.value !== PanelsMode.Right);
+        const canCollapseRight = computed(() => mode.value !== PanelsMode.Left);
+
+        const collapseLeft = () => {
+            if (mode.value === PanelsMode.Left) {
+                mode.value = PanelsMode.Both;
+            } else if (mode.value === PanelsMode.Both) {
+                mode.value = PanelsMode.Right;
+            }
+        };
+
+        const collapseRight = () => {
+            if (mode.value === PanelsMode.Right) {
+                mode.value = PanelsMode.Both;
+            } else if (mode.value === PanelsMode.Both) {
+                mode.value = PanelsMode.Left;
+            }
+        };
+
+        return {
+            modeClass,
+            canCollapseLeft,
+            canCollapseRight,
+            collapseLeft,
+            collapseRight
+        };
+    }
+});
 </script>
 
 <style scoped lang="scss">

--- a/app/static/src/app/components/basic/BasicApp.vue
+++ b/app/static/src/app/components/basic/BasicApp.vue
@@ -3,11 +3,16 @@
         <div class="row">
             <div class="col-12">
                 <h1>{{title}}</h1>
-                <div id="app-type">App Type: {{appType}}</div>
-                <div id="basic-prop">Basic Prop: {{basicProp}}</div>
-                <wodin-panels></wodin-panels>
-                <run-model-plot></run-model-plot>
-                <errors-alert></errors-alert>
+                <wodin-panels>
+                    <template v-slot:left>
+                        <div id="app-type">App Type: {{appType}}</div>
+                        <div id="basic-prop">Basic Prop: {{basicProp}}</div>
+                    </template>
+                    <template v-slot:right>
+                        <run-model-plot></run-model-plot>
+                        <errors-alert></errors-alert>
+                    </template>
+                </wodin-panels>
             </div>
         </div>
     </div>

--- a/app/static/src/app/components/basic/BasicApp.vue
+++ b/app/static/src/app/components/basic/BasicApp.vue
@@ -5,6 +5,7 @@
                 <h1>{{title}}</h1>
                 <div id="app-type">App Type: {{appType}}</div>
                 <div id="basic-prop">Basic Prop: {{basicProp}}</div>
+                <wodin-panels></wodin-panels>
                 <run-model-plot></run-model-plot>
                 <errors-alert></errors-alert>
             </div>
@@ -18,6 +19,7 @@ import { useStore } from "vuex";
 import { BasicAction } from "../../store/basic/actions";
 import RunModelPlot from "../run/RunModelPlot.vue";
 import ErrorsAlert from "../ErrorsAlert.vue";
+import WodinPanels from "../WodinPanels.vue";
 import { ModelAction } from "../../store/model/actions";
 
 export default defineComponent({
@@ -27,7 +29,8 @@ export default defineComponent({
     },
     components: {
         RunModelPlot,
-        ErrorsAlert
+        ErrorsAlert,
+        WodinPanels
     },
     setup(props) {
         const store = useStore();

--- a/app/static/src/app/components/run/RunModelPlot.vue
+++ b/app/static/src/app/components/run/RunModelPlot.vue
@@ -37,6 +37,10 @@ export default defineComponent({
             }
         };
 
+        const config = {
+            responsive: true
+        }
+
         const relayout = async (event: PlotRelayoutEvent) => {
             let data;
             if (event["xaxis.autorange"] === true) {
@@ -57,7 +61,7 @@ export default defineComponent({
             };
 
             const el = plot.value as HTMLElement;
-            await react(el, data, layout);
+            await react(el, data, layout, config);
         };
 
         const drawPlot = () => {
@@ -66,7 +70,7 @@ export default defineComponent({
                 const layout = {
                     margin: { t: 0 }
                 };
-                newPlot(el as HTMLElement, baseData.value as Data[], layout);
+                newPlot(el as HTMLElement, baseData.value as Data[], layout, config);
                 (el as EventEmitter).on("plotly_relayout", relayout);
             }
         };

--- a/app/static/src/app/components/run/RunModelPlot.vue
+++ b/app/static/src/app/components/run/RunModelPlot.vue
@@ -98,6 +98,7 @@ export default defineComponent({
         return {
             plot,
             relayout,
+            resize,
             solution
         };
     }

--- a/app/static/src/app/components/run/RunModelPlot.vue
+++ b/app/static/src/app/components/run/RunModelPlot.vue
@@ -10,7 +10,7 @@ import {
 import { useStore } from "vuex";
 import { EventEmitter } from "events";
 import {
-    Data, newPlot, react, PlotRelayoutEvent
+    Data, newPlot, react, PlotRelayoutEvent, Plots
 } from "plotly.js";
 import { ModelAction } from "../../store/model/actions";
 
@@ -39,7 +39,7 @@ export default defineComponent({
 
         const config = {
             responsive: true
-        }
+        };
 
         const relayout = async (event: PlotRelayoutEvent) => {
             let data;
@@ -64,6 +64,10 @@ export default defineComponent({
             await react(el, data, layout, config);
         };
 
+        const resize = () => {
+            Plots.resize(plot.value as HTMLElement);
+        };
+
         const drawPlot = () => {
             if (baseData.value) {
                 const el = plot.value as unknown;
@@ -72,6 +76,7 @@ export default defineComponent({
                 };
                 newPlot(el as HTMLElement, baseData.value as Data[], layout, config);
                 (el as EventEmitter).on("plotly_relayout", relayout);
+                new ResizeObserver(resize).observe(el as HTMLElement);
             }
         };
 

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -1,2 +1,10 @@
 @import "../../node_modules/bootstrap/scss/bootstrap.scss";
 
+.container {
+  max-width: 100%;
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+
+

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -2,9 +2,6 @@
 
 .container {
   max-width: 100%;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
-
-
-

--- a/app/static/tests/e2e/basic.etest.ts
+++ b/app/static/tests/e2e/basic.etest.ts
@@ -5,6 +5,71 @@ test.describe("Basic app tests", () => {
         await page.goto("/apps/day1");
     });
 
+    const expectBothMode = async (page: Page) => {
+        expect(await page.locator(".wodin-mode-both .wodin-left .wodin-content #app-type").textContent()).toBe("App Type: basic");
+        expect(await page.locator(".wodin-mode-both .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
+        expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
+        expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
+    };
+
+    const expectRightMode = async (page: Page) => {
+        expect(await page.locator(".wodin-mode-right .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
+        expect(await page.locator(".wodin-mode-right .wodin-left .wodin-content").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-collapse-controls #collapse-left").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        expect(await page.locator(".wodin-left .view-left")).toBeVisible();
+        expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
+
+    };
+
+    const expectLeftMode = async (page: Page) => {
+        expect(await page.locator(".wodin-mode-left .wodin-right .wodin-content").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-mode-left .wodin-left .wodin-content")).toBeVisible();
+        expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
+        expect(await page.locator(".wodin-collapse-controls #collapse-right").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
+        expect(await page.locator(".wodin-right .view-right")).toBeVisible();
+
+    };
+
+    test("can collapse and expand left panel", async ({  page }) => {
+        await expectBothMode(page);
+
+        await page.click("#collapse-left");
+        await expectRightMode(page);
+
+        await page.click("#collapse-right");
+        await expectBothMode(page);
+    });
+
+    test("can collapse and expand right panel", async ({  page }) => {
+        await expectBothMode(page);
+
+        await page.click("#collapse-right");
+        await expectLeftMode(page);
+
+        await page.click("#collapse-left");
+        await expectBothMode(page);
+    });
+
+    test("'View Options' shows both panels", async ({ page }) => {
+        await page.click("#collapse-left");
+
+        expect(await page.innerText(".view-left")).toBe("View Options");
+        await page.click(".view-left");
+        await expectBothMode(page);
+    });
+
+    test("'View Charts' shows both panels", async ({ page }) => {
+        await page.click("#collapse-right");
+
+        expect(await page.innerText(".view-right")).toBe("View Charts");
+        await page.click(".view-right");
+        await expectBothMode(page);
+    });
+
     test("renders plot", async ({ page }) => {
         const plotSelector = ".js-plotly-plot";
 

--- a/app/static/tests/e2e/basic.etest.ts
+++ b/app/static/tests/e2e/basic.etest.ts
@@ -6,7 +6,8 @@ test.describe("Basic app tests", () => {
     });
 
     const expectBothMode = async (page: Page) => {
-        expect(await page.locator(".wodin-mode-both .wodin-left .wodin-content #app-type").textContent()).toBe("App Type: basic");
+        expect(await page.locator(".wodin-mode-both .wodin-left .wodin-content #app-type").textContent())
+            .toBe("App Type: basic");
         expect(await page.locator(".wodin-mode-both .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
         expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
         expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
@@ -21,7 +22,6 @@ test.describe("Basic app tests", () => {
         expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
         expect(await page.locator(".wodin-left .view-left")).toBeVisible();
         expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
-
     };
 
     const expectLeftMode = async (page: Page) => {
@@ -31,10 +31,9 @@ test.describe("Basic app tests", () => {
         expect(await page.locator(".wodin-collapse-controls #collapse-right").isHidden()).toBe(true);
         expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
         expect(await page.locator(".wodin-right .view-right")).toBeVisible();
-
     };
 
-    test("can collapse and expand left panel", async ({  page }) => {
+    test("can collapse and expand left panel", async ({ page }) => {
         await expectBothMode(page);
 
         await page.click("#collapse-left");
@@ -44,7 +43,7 @@ test.describe("Basic app tests", () => {
         await expectBothMode(page);
     });
 
-    test("can collapse and expand right panel", async ({  page }) => {
+    test("can collapse and expand right panel", async ({ page }) => {
         await expectBothMode(page);
 
         await page.click("#collapse-right");

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -1,17 +1,20 @@
 // Mock the import of plotly to prevent errors
+
 jest.mock("plotly.js", () => ({}));
 /* eslint-disable import/first */
 import Vuex from "vuex";
-import { shallowMount } from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import ErrorsAlert from "../../../../src/app/components/ErrorsAlert.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState } from "../../../mocks";
+import { mockBasicState, mockModelState } from "../../../mocks";
 import { BasicAction } from "../../../../src/app/store/basic/actions";
 import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
+import { ModelAction } from "../../../../src/app/store/model/actions";
+import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 
 describe("BasicApp", () => {
-    const getWrapper = (mockFetchConfig = jest.fn()) => {
+    const getWrapper = (mockFetchConfig = jest.fn(), shallow = true) => {
         const state = mockBasicState({
             config: {
                 basicProp: "Test basic prop value"
@@ -25,23 +28,51 @@ describe("BasicApp", () => {
             state,
             actions: {
                 [BasicAction.FetchConfig]: mockFetchConfig
+            },
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: mockModelState(),
+                    actions: {
+                        [ModelAction.FetchOdinUtils]: jest.fn(),
+                        [ModelAction.FetchOdin]: jest.fn()
+                    }
+                },
+                errors: {
+                    namespaced: true,
+                    state: {
+                        errors: []
+                    }
+                }
             }
         });
-        return shallowMount(BasicApp, {
+
+        const options = {
             global: {
                 plugins: [store]
             },
             props
-        });
+        };
+
+        if (shallow) {
+            return shallowMount(BasicApp, options);
+        }
+        return mount(BasicApp, options);
     };
 
     it("renders as expected", () => {
-        const wrapper = getWrapper();
+        const wrapper = getWrapper(jest.fn(), false);
         expect(wrapper.find("h1").text()).toBe("Test Title");
-        expect(wrapper.find("#app-type").text()).toBe("App Type: basic");
-        expect(wrapper.find("#basic-prop").text()).toBe("Basic Prop: Test basic prop value");
-        expect(wrapper.findComponent(ErrorsAlert).exists()).toBe(true);
-        expect(wrapper.findComponent(RunModelPlot).exists()).toBe(true);
+
+        const wodinPanels = wrapper.findComponent(WodinPanels);
+
+        const leftPanel = wodinPanels.find(".wodin-left");
+        expect(leftPanel.find("#app-type").text()).toBe("App Type: basic");
+        expect(leftPanel.find("#basic-prop").text()).toBe("Basic Prop: Test basic prop value");
+
+        const rightPanel = wodinPanels.find(".wodin-right");
+        expect(rightPanel.findComponent(ErrorsAlert).exists()).toBe(true);
+        expect(rightPanel.findComponent(RunModelPlot).exists()).toBe(true);
     });
 
     it("invokes FetchConfig action", () => {

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -1,5 +1,4 @@
 // Mock the import of plotly to prevent errors
-
 jest.mock("plotly.js", () => ({}));
 /* eslint-disable import/first */
 import Vuex from "vuex";

--- a/app/static/tests/unit/components/run/runModelPlot.test.ts
+++ b/app/static/tests/unit/components/run/runModelPlot.test.ts
@@ -1,7 +1,12 @@
 // Mock the import of plotly so we can mock Plotly methods
+import { Root } from "plotly.js";
+
 jest.mock("plotly.js", () => ({
     newPlot: jest.fn(),
-    react: jest.fn()
+    react: jest.fn(),
+    Plots: {
+        resize: jest.fn()
+    }
 }));
 
 /* eslint-disable import/first */
@@ -17,6 +22,12 @@ import { mockBasicState, mockModelState } from "../../../mocks";
 describe("RunModelPlot", () => {
     const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
     const mockPlotlyReact = jest.spyOn(plotly, "react");
+
+    const mockObserve = jest.fn();
+    function mockResizeObserver(this: any) {
+        this.observe = mockObserve;
+    }
+    (global.ResizeObserver as any) = mockResizeObserver;
 
     const getStore = (odinUtils = null, odin = null, mockRunModel = jest.fn) => {
         return new Vuex.Store<BasicState>({
@@ -242,5 +253,28 @@ describe("RunModelPlot", () => {
         await relayout(relayoutEvent);
 
         expect(mockPlotlyReact).not.toHaveBeenCalled();
+    });
+
+    it("initialises ResizeObserver", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        const divElement = wrapper.find("div").element;
+        (divElement as any).on = jest.fn();
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        expect(mockObserve).toHaveBeenCalledWith(divElement);
+    });
+
+    it("resize method resizes Plot", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        const divElement = wrapper.find("div").element;
+        (divElement as any).on = jest.fn();
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        (wrapper.vm as any).resize();
+        expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
     });
 });

--- a/app/static/tests/unit/components/run/runModelPlot.test.ts
+++ b/app/static/tests/unit/components/run/runModelPlot.test.ts
@@ -1,6 +1,4 @@
 // Mock the import of plotly so we can mock Plotly methods
-import { Root } from "plotly.js";
-
 jest.mock("plotly.js", () => ({
     newPlot: jest.fn(),
     react: jest.fn(),

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -1,13 +1,12 @@
-import {shallowMount, VueWrapper} from "@vue/test-utils";
+import { shallowMount, VueWrapper } from "@vue/test-utils";
 import WodinPanels from "../../../src/app/components/WodinPanels.vue";
 
 describe("WodinPaneks", () => {
-
     const getWrapper = () => {
         return shallowMount(WodinPanels, {
             slots: {
-                left: `<div id="l-slot-content">LEFT</div>`,
-                right: `<div id="r-slot-content">RIGHT</div>`
+                left: "<div id=\"l-slot-content\">LEFT</div>",
+                right: "<div id=\"r-slot-content\">RIGHT</div>"
             }
         });
     };
@@ -38,8 +37,8 @@ describe("WodinPaneks", () => {
 
     it("has expected slot content", () => {
         const wrapper = getWrapper();
-        expect(wrapper.find("#wodin-content-left").html()).toContain(`<div id="l-slot-content">LEFT</div>`);
-        expect(wrapper.find("#wodin-content-right").html()).toContain(`<div id="r-slot-content">RIGHT</div>`);
+        expect(wrapper.find("#wodin-content-left").html()).toContain("<div id=\"l-slot-content\">LEFT</div>");
+        expect(wrapper.find("#wodin-content-right").html()).toContain("<div id=\"r-slot-content\">RIGHT</div>");
     });
 
     it("defaults to Both mode", () => {

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -45,22 +45,32 @@ describe("WodinPaneks", () => {
     it("defaults to Both mode", () => {
         const wrapper = getWrapper();
         testBothMode(wrapper);
+        expect(wrapper.find(".wodin-left").classes()).toStrictEqual(["wodin-left"]);
+        expect(wrapper.find(".wodin-right").classes()).toStrictEqual(["wodin-right"]);
     });
 
     it("clicking left then right buttons switches mode as expected", async () => {
         const wrapper = getWrapper();
         await wrapper.find("#collapse-left").trigger("click");
         testRightMode(wrapper);
+        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-collapse-full");
+        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-expand-full");
         await wrapper.find("#collapse-right").trigger("click");
         testBothMode(wrapper);
+        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-expand-partial");
+        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-collapse-partial");
     });
 
     it("clicking right then left buttons switches mode as expected", async () => {
         const wrapper = getWrapper();
         await wrapper.find("#collapse-right").trigger("click");
         testLeftMode(wrapper);
+        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-expand-full");
+        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-collapse-full");
         await wrapper.find("#collapse-left").trigger("click");
         testBothMode(wrapper);
+        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-collapse-partial");
+        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-expand-partial");
     });
 
     it("clicking on 'View Options' switches mode as expected", async () => {

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -1,0 +1,79 @@
+import {shallowMount, VueWrapper} from "@vue/test-utils";
+import WodinPanels from "../../../src/app/components/WodinPanels.vue";
+
+describe("WodinPaneks", () => {
+
+    const getWrapper = () => {
+        return shallowMount(WodinPanels, {
+            slots: {
+                left: `<div id="l-slot-content">LEFT</div>`,
+                right: `<div id="r-slot-content">RIGHT</div>`
+            }
+        });
+    };
+
+    const testBothMode = (wrapper: VueWrapper) => {
+        const containerDiv = wrapper.find("div.wodin-mode-both");
+        expect(containerDiv.exists()).toBe(true);
+
+        expect(containerDiv.find("#collapse-left").exists()).toBe(true);
+        expect(containerDiv.find("#collapse-right").exists()).toBe(true);
+    };
+
+    const testRightMode = (wrapper: VueWrapper) => {
+        const containerDiv = wrapper.find("div.wodin-mode-right");
+        expect(containerDiv.exists()).toBe(true);
+
+        expect(containerDiv.find("#collapse-left").exists()).toBe(false);
+        expect(containerDiv.find("#collapse-right").exists()).toBe(true);
+    };
+
+    const testLeftMode = (wrapper: VueWrapper) => {
+        const containerDiv = wrapper.find("div.wodin-mode-left");
+        expect(containerDiv.exists()).toBe(true);
+
+        expect(containerDiv.find("#collapse-left").exists()).toBe(true);
+        expect(containerDiv.find("#collapse-right").exists()).toBe(false);
+    };
+
+    it("has expected slot content", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("#wodin-content-left").html()).toContain(`<div id="l-slot-content">LEFT</div>`);
+        expect(wrapper.find("#wodin-content-right").html()).toContain(`<div id="r-slot-content">RIGHT</div>`);
+    });
+
+    it("defaults to Both mode", () => {
+        const wrapper = getWrapper();
+        testBothMode(wrapper);
+    });
+
+    it("clicking left then right buttons switches mode as expected", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find("#collapse-left").trigger("click");
+        testRightMode(wrapper);
+        await wrapper.find("#collapse-right").trigger("click");
+        testBothMode(wrapper);
+    });
+
+    it("clicking right then left buttons switches mode as expected", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find("#collapse-right").trigger("click");
+        testLeftMode(wrapper);
+        await wrapper.find("#collapse-left").trigger("click");
+        testBothMode(wrapper);
+    });
+
+    it("clicking on 'View Options' switches mode as expected", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find("#collapse-left").trigger("click");
+        await wrapper.find(".view-left").trigger("click");
+        testBothMode(wrapper);
+    });
+
+    it("clicking on 'View Charts' switches mode as expected", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find("#collapse-right").trigger("click");
+        await wrapper.find(".view-right").trigger("click");
+        testBothMode(wrapper);
+    });
+});

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -1,4 +1,5 @@
 import { shallowMount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
 import WodinPanels from "../../../src/app/components/WodinPanels.vue";
 
 describe("WodinPaneks", () => {
@@ -74,5 +75,18 @@ describe("WodinPaneks", () => {
         await wrapper.find("#collapse-right").trigger("click");
         await wrapper.find(".view-right").trigger("click");
         testBothMode(wrapper);
+    });
+
+    it("throws error on unknown mode", async () => {
+        const wrapper = getWrapper();
+        let errorThrown = false;
+        try {
+            (wrapper.vm as any).mode = "nonexistent";
+            await nextTick();
+        } catch (error: any) {
+            expect(error.message).toBe("Unknown mode");
+            errorThrown = true;
+        }
+        expect(errorThrown).toBe(true);
     });
 });

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -1,5 +1,4 @@
 import { shallowMount, VueWrapper } from "@vue/test-utils";
-import { nextTick } from "vue";
 import WodinPanels from "../../../src/app/components/WodinPanels.vue";
 
 describe("WodinPaneks", () => {
@@ -12,29 +11,20 @@ describe("WodinPaneks", () => {
         });
     };
 
-    const testBothMode = (wrapper: VueWrapper) => {
-        const containerDiv = wrapper.find("div.wodin-mode-both");
+    const testMode = (wrapper: VueWrapper, containerClass: string, collapsibleLeft: boolean,
+        collapsibleRight: boolean) => {
+        const containerDiv = wrapper.find(`div.${containerClass}`);
         expect(containerDiv.exists()).toBe(true);
 
-        expect(containerDiv.find("#collapse-left").exists()).toBe(true);
-        expect(containerDiv.find("#collapse-right").exists()).toBe(true);
+        expect(containerDiv.find("#collapse-left").exists()).toBe(collapsibleLeft);
+        expect(containerDiv.find("#collapse-right").exists()).toBe(collapsibleRight);
     };
 
-    const testRightMode = (wrapper: VueWrapper) => {
-        const containerDiv = wrapper.find("div.wodin-mode-right");
-        expect(containerDiv.exists()).toBe(true);
+    const testBothMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-both", true, true);
 
-        expect(containerDiv.find("#collapse-left").exists()).toBe(false);
-        expect(containerDiv.find("#collapse-right").exists()).toBe(true);
-    };
+    const testRightMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-right", false, true);
 
-    const testLeftMode = (wrapper: VueWrapper) => {
-        const containerDiv = wrapper.find("div.wodin-mode-left");
-        expect(containerDiv.exists()).toBe(true);
-
-        expect(containerDiv.find("#collapse-left").exists()).toBe(true);
-        expect(containerDiv.find("#collapse-right").exists()).toBe(false);
-    };
+    const testLeftMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-left", true, false);
 
     it("has expected slot content", () => {
         const wrapper = getWrapper();
@@ -85,18 +75,5 @@ describe("WodinPaneks", () => {
         await wrapper.find("#collapse-right").trigger("click");
         await wrapper.find(".view-right").trigger("click");
         testBothMode(wrapper);
-    });
-
-    it("throws error on unknown mode", async () => {
-        const wrapper = getWrapper();
-        let errorThrown = false;
-        try {
-            (wrapper.vm as any).mode = "nonexistent";
-            await nextTick();
-        } catch (error: any) {
-            expect(error.message).toBe("Unknown mode");
-            errorThrown = true;
-        }
-        expect(errorThrown).toBe(true);
     });
 });


### PR DESCRIPTION
Adds a component for the basic layout shown in the [mockups](https://docs.google.com/presentation/d/1uJqH_TR_v1F-hGkmkEKGduS7uGx2xrwbqVZ_DMZTA8w/edit) with left and right panels which can be collapsed/expanded with < and > buttons and 'View options'/'View charts' labels when collapsed.

The content to go in the panels is specified by the parent using 'left' and 'right' named slots. 

The component has been added the the 'Basic' app type only (i.e. the `BasicApp` component only), with placeholder basic app info being placed in the left panel (to be replaced in future with Code and Options tabs) and the proof of concept chart in the the right panel (to be replaced in future with real model visualisations). (The initial set of epics implement the Basic app type - Model Fit and Stochastic apps to be implemented later.) 

To test, run `./scripts/build-and-run.sh` then browse to http://localhost:3000/apps/day1 - you should see the panels and collapse/expand should work as expected. 

One side effect of this change seems to be that the traces and modebar in the plotly chart overlap - I'm inclined to fix this in the later tickets when we implement the real visualisation when the Chart component will no doubt need to change anyway.  