### PR TITLE
mrc-2912 replace readlink with realpath

### DIFF
--- a/scripts/build-and-run.sh
+++ b/scripts/build-and-run.sh
@@ -1,6 +1,6 @@
 set -ex
 
-HERE=$(readlink -f "$(dirname $0)")
+HERE=$(realpath "$(dirname $0)")
 . $HERE/build.sh
 
 npm run serve --prefix=app/server


### PR DESCRIPTION
Readlink is not supported in Mac so I replaced it with realpath which works on Ubuntu and Mac .