### PR TITLE
mrc-3252 Basic Model Parameters UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /app/static/coverage/
 /app/static/dist/
 /app/static/tmp/
+/app/static/test-results

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -2567,6 +2567,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+    },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.8.1.tgz",

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@monaco-editor/loader": "^1.3.2",
+    "@popperjs/core": "^2.11.5",
     "axios": "^0.26.0",
     "bootstrap": "^5.1.3",
     "dopri": "^0.0.8",

--- a/app/static/playwright.config.ts
+++ b/app/static/playwright.config.ts
@@ -6,8 +6,8 @@ const config: PlaywrightTestConfig = {
         baseURL: "http://localhost:3000",
         screenshot: "only-on-failure"
     },
-    retries: 1,
-    timeout: 10000
+    timeout: 10000,
+    workers: 1
 };
 
 export default config;

--- a/app/static/src/app/components/VerticalCollapse.vue
+++ b/app/static/src/app/components/VerticalCollapse.vue
@@ -4,8 +4,8 @@
     <a data-bs-toggle="collapse"
        :href="'#' + collapseId"
        role="button"
-       aria-expanded="false"
-       aria-controls="collapseExample"
+       aria-expanded="true"
+       :aria-controls="collapseId"
        @click="toggleCollapse">
       <vue-feather :type="iconType"></vue-feather>
     </a>
@@ -30,7 +30,7 @@ export default defineComponent({
         VueFeather
     },
     setup() {
-        const collapsed = ref(false);
+        const collapsed = ref(false); // default to expanded view
 
         const toggleCollapse = () => {
             collapsed.value = !collapsed.value;
@@ -40,8 +40,7 @@ export default defineComponent({
 
         return {
             toggleCollapse,
-            iconType,
-            collapsed
+            iconType
         };
     }
 });

--- a/app/static/src/app/components/VerticalCollapse.vue
+++ b/app/static/src/app/components/VerticalCollapse.vue
@@ -2,7 +2,7 @@
   <div class="collapse-title p-2">
     {{title}}
     <a data-bs-toggle="collapse"
-       :href="'#' + collapseId"
+       :href="`#${collapseId}`"
        role="button"
        aria-expanded="true"
        :aria-controls="collapseId"

--- a/app/static/src/app/components/VerticalCollapse.vue
+++ b/app/static/src/app/components/VerticalCollapse.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="collapse-title p-2">
+    {{title}}
+    <a data-bs-toggle="collapse"
+       :href="'#' + collapseId"
+       role="button"
+       aria-expanded="false"
+       aria-controls="collapseExample"
+       @click="toggleCollapse">
+      <vue-feather :type="iconType"></vue-feather>
+    </a>
+  </div>
+  <div class="collapse show" :id="collapseId">
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+import { defineComponent, ref, computed } from "vue";
+import "bootstrap";
+import VueFeather from "vue-feather";
+
+export default defineComponent({
+    name: "VerticalCollapse",
+    props: {
+        title: String,
+        collapseId: String
+    },
+    components: {
+        VueFeather
+    },
+    setup() {
+        const collapsed = ref(false);
+
+        const toggleCollapse = () => {
+            collapsed.value = !collapsed.value;
+        };
+
+        const iconType = computed(() => (collapsed.value ? "chevron-down" : "chevron-up"));
+
+        return {
+            toggleCollapse,
+            iconType,
+            collapsed
+        };
+    }
+});
+</script>
+
+<style scoped lang="scss">
+  .collapse-title {
+    background-color: #e8ebee;
+    font-weight: bold;
+
+    a {
+      float: right;
+      color: #777;
+    }
+  }
+</style>

--- a/app/static/src/app/components/VerticalCollapse.vue
+++ b/app/static/src/app/components/VerticalCollapse.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="collapse-title p-2">
-    {{title}}
-    <a data-bs-toggle="collapse"
-       :href="`#${collapseId}`"
-       role="button"
-       aria-expanded="true"
-       :aria-controls="collapseId"
-       @click="toggleCollapse">
-      <vue-feather :type="iconType"></vue-feather>
-    </a>
-  </div>
+  <a data-bs-toggle="collapse"
+     :href="`#${collapseId}`"
+     role="button"
+     aria-expanded="true"
+     :aria-controls="collapseId"
+     @click="toggleCollapse">
+    <div class="collapse-title p-2">
+        {{title}}
+        <vue-feather class="collapse-icon" :type="iconType"></vue-feather>
+    </div>
+  </a>
   <div class="collapse show" :id="collapseId">
     <slot></slot>
   </div>
@@ -47,13 +47,18 @@ export default defineComponent({
 </script>
 
 <style scoped lang="scss">
-  .collapse-title {
-    background-color: #e8ebee;
-    font-weight: bold;
+  a {
+    text-decoration: none;
 
-    a {
-      float: right;
-      color: #777;
+    .collapse-title {
+      background-color: #e8ebee;
+      font-weight: bold;
+      color: #000;
+
+      .collapse-icon {
+        float: right;
+        color: #777;
+      }
     }
   }
 </style>

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -1,19 +1,19 @@
 <template>
     <div>
         <vertical-collapse title="Model Parameters" collapse-id="model-params">
-          <div>Param1: Value 1</div>
-          <div>Param2: Value 2</div>
-          <div>Param3: Value 3</div>
+          <parameter-values></parameter-values>
         </vertical-collapse>
     </div>
 </template>
 
 <script lang="ts">
 import VerticalCollapse from "../VerticalCollapse.vue";
+import ParameterValues from "./ParameterValues.vue";
 
 export default {
     name: "OptionsTab",
     components: {
+        ParameterValues,
         VerticalCollapse
     }
 };

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -1,12 +1,20 @@
 <template>
     <div>
-        Coming soon: Options editor.
+        <vertical-collapse title="Model Parameters" collapse-id="model-params">
+          <div>Param1: Value 1</div>
+          <div>Param2: Value 2</div>
+          <div>Param3: Value 3</div>
+        </vertical-collapse>
     </div>
 </template>
 
 <script lang="ts">
+import VerticalCollapse from "../VerticalCollapse.vue";
+
 export default {
-    name: "OptionsTab"
+    name: "OptionsTab",
+    components: {
+        VerticalCollapse
+    }
 };
 </script>
-s

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="container">
-    <div v-for="paramName in paramNames" class="row" :key="paramName">
+    <div v-for="paramName in paramNames" class="row my-2" :key="paramName">
       <div class="col-6">
-        <label>{{paramName}}</label>
+        <label class="col-form-label">{{paramName}}</label>
       </div>
       <div class="col-6">
-        <input type="number" :value="paramValues[paramName]"/>
+        <input class="form-control" type="number" :value="paramValues[paramName]" @input="updateValue($event, paramName)"/>
       </div>
     </div>
   </div>
@@ -20,11 +20,18 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const paramValues = computed(() => store.state.model.parameterValues);
-        const paramNames = computed(() => Object.keys(paramValues.value)); //TODO: use rank
+        const paramNames = computed(() => Object.keys(paramValues.value)); // TODO: use rank
+
+        const updateValue = (e: Event, paramName: string) => {
+            const newValue = parseFloat((e.target as HTMLInputElement).value);
+            console.log("new value: " + newValue);
+            store.commit("model/UpdateParameterValues", { [paramName]: newValue });
+        };
 
         return {
             paramValues,
-            paramNames
+            paramNames,
+            updateValue
         };
     }
 });

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -38,4 +38,3 @@ export default defineComponent({
     }
 });
 </script>
-

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -5,7 +5,10 @@
         <label class="col-form-label">{{paramName}}</label>
       </div>
       <div class="col-6">
-        <input class="form-control" type="number" :value="paramValues[paramName]" @input="updateValue($event, paramName)"/>
+        <input class="form-control parameter-input"
+               type="number"
+               :value="paramValues[paramName]"
+               @input="updateValue($event, paramName)"/>
       </div>
     </div>
   </div>
@@ -36,3 +39,4 @@ export default defineComponent({
     }
 });
 </script>
+

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -27,7 +27,6 @@ export default defineComponent({
 
         const updateValue = (e: Event, paramName: string) => {
             const newValue = parseFloat((e.target as HTMLInputElement).value);
-            console.log("new value: " + newValue);
             store.commit("model/UpdateParameterValues", { [paramName]: newValue });
         };
 

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -17,6 +17,7 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
+import { ModelMutation } from "../../store/model/mutations";
 
 export default defineComponent({
     name: "ParameterValues",
@@ -27,7 +28,7 @@ export default defineComponent({
 
         const updateValue = (e: Event, paramName: string) => {
             const newValue = parseFloat((e.target as HTMLInputElement).value);
-            store.commit("model/UpdateParameterValues", { [paramName]: newValue });
+            store.commit(`model/${ModelMutation.UpdateParameterValues}`, { [paramName]: newValue });
         };
 
         return {

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -23,7 +23,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const paramValues = computed(() => store.state.model.parameterValues);
-        const paramNames = computed(() => Object.keys(paramValues.value)); // TODO: use rank
+        const paramNames = computed(() => Object.keys(paramValues.value));
 
         const updateValue = (e: Event, paramName: string) => {
             const newValue = parseFloat((e.target as HTMLInputElement).value);

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="container">
+    <div v-for="paramName in paramNames" class="row" :key="paramName">
+      <div class="col-6">
+        <label>{{paramName}}</label>
+      </div>
+      <div class="col-6">
+        <input type="number" :value="paramValues[paramName]"/>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import { useStore } from "vuex";
+
+export default defineComponent({
+    name: "ParameterValues",
+    setup() {
+        const store = useStore();
+        const paramValues = computed(() => store.state.model.parameterValues);
+        const paramNames = computed(() => Object.keys(paramValues.value)); //TODO: use rank
+
+        return {
+            paramValues,
+            paramNames
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -43,7 +43,6 @@ export default defineComponent({
         };
 
         watch(odinSolution, () => {
-            console.log("odin solution updated");
             // force inputs to update when model is run to show actual values
             paramKeys.value = timestampParamNames();
         });

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -3,7 +3,8 @@
     <div>
       <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
     </div>
-    <div class="run-update-msg text-danger text-center">{{updateMsg}}</div>
+    <div class="run-update-msg text-danger text-center">{{updateCodeMsg}}</div>
+    <div class="run-update-msg text-danger text-center">{{updateParamsMsg}}</div>
     <run-model-plot :fade-plot="!!updateMsg"></run-model-plot>
   </div>
 </template>
@@ -25,20 +26,28 @@ export default defineComponent({
         const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin);
 
         const runModel = () => store.dispatch(`model/${ModelAction.RunModel}`);
-        const updateMsg = computed(() => {
-            const { requiredAction } = store.state.model;
-            if (requiredAction === RequiredModelAction.Compile) {
+        const updateCodeMsg = computed(() => {
+            const { requiredCodeAction } = store.state.model;
+            if (requiredCodeAction === RequiredModelAction.Compile) {
                 return "Code has been updated. Compile code and Run Model to view graph for latest code.";
             }
-            if (requiredAction === RequiredModelAction.Run) {
+            if (requiredCodeAction === RequiredModelAction.Run) {
                 return "Code has been recompiled. Run Model to view graph for latest code.";
+            }
+            return "";
+        });
+        const updateParamsMsg = computed(() => {
+            const { requiredParamsAction } = store.state.model;
+            if (requiredParamsAction === RequiredModelAction.Run) {
+                return "Parameters have been updated. Run Model to view graph for latest parameters.";
             }
             return "";
         });
 
         return {
             canRunModel,
-            updateMsg,
+            updateCodeMsg,
+            updateParamsMsg,
             runModel
         };
     }

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -29,7 +29,8 @@ export default defineComponent({
         const requiredAction = computed(() => store.state.model.requiredAction);
 
         // Enable run button if model has initialised and compile is not required
-        const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin && requiredAction.value !== RequiredModelAction.Compile);
+        const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin
+            && requiredAction.value !== RequiredModelAction.Compile);
 
         const runModel = () => store.dispatch(`model/${ModelAction.RunModel}`);
         const updateMsg = computed(() => {

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -23,13 +23,13 @@ export default defineComponent({
     setup() {
         const store = useStore();
 
-        const requiredAction = computed(() => store.state.model.requiredACtion);
+        const requiredAction = computed(() => store.state.model.requiredAction);
 
         // Enable run button if model has initialised and compile is not required
         const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin && requiredAction.value !== RequiredModelAction.Compile);
 
         const runModel = () => store.dispatch(`model/${ModelAction.RunModel}`);
-        const updateCodeMsg = computed(() => {
+        const updateMsg = computed(() => {
             if (requiredAction.value === RequiredModelAction.Compile) {
                 return "Model code has been updated. Compile code and Run Model to view updated graph.";
             }
@@ -41,7 +41,7 @@ export default defineComponent({
 
         return {
             canRunModel,
-            updateCodeMsg,
+            updateMsg,
             runModel
         };
     }

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -3,8 +3,7 @@
     <div>
       <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
     </div>
-    <div class="run-update-msg text-danger text-center">{{updateCodeMsg}}</div>
-    <div class="run-update-msg text-danger text-center">{{updateParamsMsg}}</div>
+    <div class="run-update-msg text-danger text-center">{{updateMsg}}</div>
     <run-model-plot :fade-plot="!!updateMsg"></run-model-plot>
   </div>
 </template>
@@ -23,23 +22,19 @@ export default defineComponent({
     },
     setup() {
         const store = useStore();
-        const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin);
+
+        const requiredAction = computed(() => store.state.model.requiredACtion);
+
+        // Enable run button if model has initialised and compile is not required
+        const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin && requiredAction.value !== RequiredModelAction.Compile);
 
         const runModel = () => store.dispatch(`model/${ModelAction.RunModel}`);
         const updateCodeMsg = computed(() => {
-            const { requiredCodeAction } = store.state.model;
-            if (requiredCodeAction === RequiredModelAction.Compile) {
-                return "Code has been updated. Compile code and Run Model to view graph for latest code.";
+            if (requiredAction.value === RequiredModelAction.Compile) {
+                return "Model code has been updated. Compile code and Run Model to view updated graph.";
             }
-            if (requiredCodeAction === RequiredModelAction.Run) {
-                return "Code has been recompiled. Run Model to view graph for latest code.";
-            }
-            return "";
-        });
-        const updateParamsMsg = computed(() => {
-            const { requiredParamsAction } = store.state.model;
-            if (requiredParamsAction === RequiredModelAction.Run) {
-                return "Parameters have been updated. Run Model to view graph for latest parameters.";
+            if (requiredAction.value === RequiredModelAction.Run) {
+                return "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.";
             }
             return "";
         });
@@ -47,7 +42,6 @@ export default defineComponent({
         return {
             canRunModel,
             updateCodeMsg,
-            updateParamsMsg,
             runModel
         };
     }

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -26,7 +26,7 @@ const fetchOdin = async (context: ActionContext<ModelState, AppState>) => {
         .withError(`errors/${ErrorsMutation.AddError}` as ErrorsMutation, true)
         .post<OdinModelResponse>("/odin/model", { model })
         .then(() => {
-            commit(ModelMutation.SetRequiredAction, RequiredModelAction.Compile);
+            commit(ModelMutation.SetRequiredCodeAction, RequiredModelAction.Compile);
         });
 };
 
@@ -48,8 +48,8 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
         });
         commit(ModelMutation.SetParameterValues, newValues);
 
-        if (state.requiredAction === RequiredModelAction.Compile) {
-            commit(ModelMutation.SetRequiredAction, RequiredModelAction.Run);
+        if (state.requiredCodeAction === RequiredModelAction.Compile) {
+            commit(ModelMutation.SetRequiredCodeAction, RequiredModelAction.Run);
         }
     }
 };
@@ -57,17 +57,20 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
 const runModel = async (context: ActionContext<ModelState, AppState>) => {
     const { state, commit } = context;
     if (state.odinRunner && state.odin) {
-        const parameters = {};
+        const parameters = state.parameterValues;
         const start = 0;
 
-        // TODO: these values will come from state when UI elements are implemented
+        // TODO: this value will come from state when UI elements are implemented
         const end = 100;
         const control = {};
         const solution = state.odinRunner(dopri.Dopri, state.odin, parameters, start, end, control);
         commit(ModelMutation.SetOdinSolution, solution);
 
-        if (state.requiredAction === RequiredModelAction.Run) {
-            commit(ModelMutation.SetRequiredAction, null);
+        if (state.requiredCodeAction === RequiredModelAction.Run) {
+            commit(ModelMutation.SetRequiredCodeAction, null);
+        }
+        if (state.requiredParamsAction === RequiredModelAction.Run) {
+            commit(ModelMutation.SetRequiredParamsAction, null);
         }
     }
 };

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -26,7 +26,7 @@ const fetchOdin = async (context: ActionContext<ModelState, AppState>) => {
         .withError(`errors/${ErrorsMutation.AddError}` as ErrorsMutation, true)
         .post<OdinModelResponse>("/odin/model", { model })
         .then(() => {
-            commit(ModelMutation.SetRequiredCodeAction, RequiredModelAction.Compile);
+            commit(ModelMutation.SetRequiredAction, RequiredModelAction.Compile);
         });
 };
 
@@ -48,8 +48,8 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
         });
         commit(ModelMutation.SetParameterValues, newValues);
 
-        if (state.requiredCodeAction === RequiredModelAction.Compile) {
-            commit(ModelMutation.SetRequiredCodeAction, RequiredModelAction.Run);
+        if (state.requiredAction === RequiredModelAction.Compile) {
+            commit(ModelMutation.SetRequiredAction, RequiredModelAction.Run);
         }
     }
 };
@@ -66,11 +66,8 @@ const runModel = async (context: ActionContext<ModelState, AppState>) => {
         const solution = state.odinRunner(dopri.Dopri, state.odin, parameters, start, end, control);
         commit(ModelMutation.SetOdinSolution, solution);
 
-        if (state.requiredCodeAction === RequiredModelAction.Run) {
-            commit(ModelMutation.SetRequiredCodeAction, null);
-        }
-        if (state.requiredParamsAction === RequiredModelAction.Run) {
-            commit(ModelMutation.SetRequiredParamsAction, null);
+        if (state.requiredAction === RequiredModelAction.Run) {
+            commit(ModelMutation.SetRequiredAction, null);
         }
     }
 };

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -5,8 +5,9 @@ import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
 import { AppState } from "../AppState";
 import { ErrorsMutation } from "../errors/mutations";
-import { Odin, OdinModelResponse } from "../../types/responseTypes";
+import {Odin, OdinModelResponse, OdinParameter} from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
+import {Dict} from "../../types/utilTypes";
 
 export enum ModelAction {
     FetchOdinRunner = "FetchOdinRunner",
@@ -34,6 +35,19 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
     if (state.odinModelResponse) {
         const odin = evaluateScript<Odin>(state.odinModelResponse.model);
         commit(ModelMutation.SetOdin, odin);
+
+        const {parameters} = state.odinModelResponse.metadata;
+        commit(ModelMutation.SetParameters, parameters);
+
+        // Retain parameter values where they still exist in new model - for new params, use default values
+        const newValues: Dict<number> = {};
+        const oldValuesKeys = Object.keys(state.parameterValues);
+        parameters.forEach((param: OdinParameter) => {
+            const value = oldValuesKeys.includes(param.name) ? state.parameterValues[param.name] : param.default;
+            newValues[param.name] = value === null ? 0 : value;
+        });
+        commit(ModelMutation.SetParameterValues, newValues);
+
         if (state.requiredAction === RequiredModelAction.Compile) {
             commit(ModelMutation.SetRequiredAction, RequiredModelAction.Run);
         }
@@ -43,9 +57,10 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
 const runModel = async (context: ActionContext<ModelState, AppState>) => {
     const { state, commit } = context;
     if (state.odinRunner && state.odin) {
-        // TODO: these values will come from state when UI elements are implemented
         const parameters = {};
         const start = 0;
+
+        // TODO: these values will come from state when UI elements are implemented
         const end = 100;
         const control = {};
         const solution = state.odinRunner(dopri.Dopri, state.odin, parameters, start, end, control);

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -63,7 +63,7 @@ const runModel = async (context: ActionContext<ModelState, AppState>) => {
         // TODO: this value will come from state when UI elements are implemented
         const end = 100;
         const control = {};
-        const solution = state.odinRunner(dopri.Dopri, state.odin, parameters, start, end, control);
+        const solution = state.odinRunner(dopri, state.odin, parameters, start, end, control);
         commit(ModelMutation.SetOdinSolution, solution);
 
         if (state.requiredAction === RequiredModelAction.Run) {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -5,9 +5,9 @@ import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
 import { AppState } from "../AppState";
 import { ErrorsMutation } from "../errors/mutations";
-import {Odin, OdinModelResponse, OdinParameter} from "../../types/responseTypes";
+import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
-import {Dict} from "../../types/utilTypes";
+import { Dict } from "../../types/utilTypes";
 
 export enum ModelAction {
     FetchOdinRunner = "FetchOdinRunner",
@@ -36,7 +36,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
         const odin = evaluateScript<Odin>(state.odinModelResponse.model);
         commit(ModelMutation.SetOdin, odin);
 
-        const {parameters} = state.odinModelResponse.metadata;
+        const { parameters } = state.odinModelResponse.metadata;
 
         // Retain parameter values where they still exist in new model - for new params, use default values
         const newValues: Dict<number> = {};

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -37,7 +37,6 @@ const compileModel = async (context: ActionContext<ModelState, AppState>) => {
         commit(ModelMutation.SetOdin, odin);
 
         const {parameters} = state.odinModelResponse.metadata;
-        commit(ModelMutation.SetParameters, parameters);
 
         // Retain parameter values where they still exist in new model - for new params, use default values
         const newValues: Dict<number> = {};

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -38,11 +38,10 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         const { parameters } = state.odinModelResponse.metadata;
 
-        // Retain parameter values where they still exist in new model - for new params, use default values
+        // Overwrite any existing parameter values in the model
         const newValues: Dict<number> = {};
-        const oldValuesKeys = Object.keys(state.parameterValues);
         parameters.forEach((param: OdinParameter) => {
-            const value = oldValuesKeys.includes(param.name) ? state.parameterValues[param.name] : param.default;
+            const value = param.default;
             newValues[param.name] = value === null ? 0 : value;
         });
         commit(ModelMutation.SetParameterValues, newValues);

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -3,7 +3,8 @@ import { actions } from "./actions";
 import { mutations } from "./mutations";
 
 export const defaultState: ModelState = {
-    requiredAction: null,
+    requiredCodeAction: null,
+    requiredParamsAction: null,
     odinRunner: null,
     odinModelResponse: null,
     odin: null,

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -7,7 +7,9 @@ export const defaultState: ModelState = {
     odinRunner: null,
     odinModelResponse: null,
     odin: null,
-    odinSolution: null
+    odinSolution: null,
+    parameters: [],
+    parameterValues: {}
 };
 
 export const model = {

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -8,7 +8,6 @@ export const defaultState: ModelState = {
     odinModelResponse: null,
     odin: null,
     odinSolution: null,
-    parameters: [],
     parameterValues: {}
 };
 

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -3,8 +3,7 @@ import { actions } from "./actions";
 import { mutations } from "./mutations";
 
 export const defaultState: ModelState = {
-    requiredCodeAction: null,
-    requiredParamsAction: null,
+    requiredAction: null,
     odinRunner: null,
     odinModelResponse: null,
     odin: null,

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -10,7 +10,6 @@ export enum ModelMutation {
     SetOdin = "SetOdin",
     SetOdinSolution = "SetOdinSolution",
     SetRequiredAction = "SetRequiredCAction",
-    SetParameters = "SetParameters",
     SetParameterValues = "SetParameterValues",
     UpdateParameterValues = "UpdateParameterValues"
 }
@@ -34,10 +33,6 @@ export const mutations: MutationTree<ModelState> = {
 
     [ModelMutation.SetRequiredAction](state: ModelState, payload: RequiredModelAction | null) {
         state.requiredAction = payload;
-    },
-
-    [ModelMutation.SetParameters](state: ModelState, payload: OdinParameter[]) {
-        state.parameters = payload;
     },
 
     [ModelMutation.SetParameterValues](state: ModelState, payload: Dict<number>) {

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -1,9 +1,7 @@
-import { MutationTree } from "vuex";
-import { ModelState, RequiredModelAction } from "./state";
-import {
-    Odin, OdinModelResponse, OdinParameter, OdinRunner, OdinSolution
-} from "../../types/responseTypes";
-import { evaluateScript } from "../../utils";
+import {MutationTree} from "vuex";
+import {ModelState, RequiredModelAction} from "./state";
+import {Odin, OdinModelResponse, OdinParameter, OdinRunner, OdinSolution} from "../../types/responseTypes";
+import {evaluateScript} from "../../utils";
 import {Dict} from "../../types/utilTypes";
 
 export enum ModelMutation {
@@ -11,9 +9,11 @@ export enum ModelMutation {
     SetOdinResponse = "SetOdinResponse",
     SetOdin = "SetOdin",
     SetOdinSolution = "SetOdinSolution",
-    SetRequiredAction = "SetRequiredAction",
+    SetRequiredCodeAction = "SetRequiredCodeAction",
+    SetRequiredParamsAction = "SetRequiredParamsAction",
     SetParameters = "SetParameters",
-    SetParameterValues = "SetParameterValues"
+    SetParameterValues = "SetParameterValues",
+    UpdateParameterValues = "UpdateParameterValues"
 }
 
 export const mutations: MutationTree<ModelState> = {
@@ -33,8 +33,12 @@ export const mutations: MutationTree<ModelState> = {
         state.odinSolution = payload;
     },
 
-    [ModelMutation.SetRequiredAction](state: ModelState, payload: RequiredModelAction | null) {
-        state.requiredAction = payload;
+    [ModelMutation.SetRequiredCodeAction](state: ModelState, payload: RequiredModelAction | null) {
+        state.requiredCodeAction = payload;
+    },
+
+    [ModelMutation.SetRequiredParamsAction](state: ModelState, payload: RequiredModelAction | null) {
+        state.requiredParamsAction = payload;
     },
 
     [ModelMutation.SetParameters](state: ModelState, payload: OdinParameter[]) {
@@ -42,6 +46,16 @@ export const mutations: MutationTree<ModelState> = {
     },
 
     [ModelMutation.SetParameterValues](state: ModelState, payload: Dict<number>) {
+        // initialise values
         state.parameterValues = payload;
+    },
+
+    [ModelMutation.UpdateParameterValues](state: ModelState, payload: Dict<number>) {
+        // update values (incomplete or complete set) and set required action as run will be needed using new values
+        state.parameterValues = {
+            ...state.parameterValues,
+            ...payload
+        };
+        state.requiredParamsAction = RequiredModelAction.Run;
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -1,6 +1,6 @@
 import {MutationTree} from "vuex";
 import {ModelState, RequiredModelAction} from "./state";
-import {Odin, OdinModelResponse, OdinParameter, OdinRunner, OdinSolution} from "../../types/responseTypes";
+import {Odin, OdinModelResponse, OdinRunner, OdinSolution} from "../../types/responseTypes";
 import {evaluateScript} from "../../utils";
 import {Dict} from "../../types/utilTypes";
 
@@ -9,7 +9,7 @@ export enum ModelMutation {
     SetOdinResponse = "SetOdinResponse",
     SetOdin = "SetOdin",
     SetOdinSolution = "SetOdinSolution",
-    SetRequiredAction = "SetRequiredCAction",
+    SetRequiredAction = "SetRequiredAction",
     SetParameterValues = "SetParameterValues",
     UpdateParameterValues = "UpdateParameterValues"
 }

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -1,16 +1,19 @@
 import { MutationTree } from "vuex";
 import { ModelState, RequiredModelAction } from "./state";
 import {
-    Odin, OdinModelResponse, OdinRunner, OdinSolution
+    Odin, OdinModelResponse, OdinParameter, OdinRunner, OdinSolution
 } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
+import {Dict} from "../../types/utilTypes";
 
 export enum ModelMutation {
     SetOdinRunner = "SetOdinRunner",
     SetOdinResponse = "SetOdinResponse",
     SetOdin = "SetOdin",
     SetOdinSolution = "SetOdinSolution",
-    SetRequiredAction = "SetRequiredAction"
+    SetRequiredAction = "SetRequiredAction",
+    SetParameters = "SetParameters",
+    SetParameterValues = "SetParameterValues"
 }
 
 export const mutations: MutationTree<ModelState> = {
@@ -32,5 +35,13 @@ export const mutations: MutationTree<ModelState> = {
 
     [ModelMutation.SetRequiredAction](state: ModelState, payload: RequiredModelAction | null) {
         state.requiredAction = payload;
+    },
+
+    [ModelMutation.SetParameters](state: ModelState, payload: OdinParameter[]) {
+        state.parameters = payload;
+    },
+
+    [ModelMutation.SetParameterValues](state: ModelState, payload: Dict<number>) {
+        state.parameterValues = payload;
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -1,8 +1,10 @@
-import {MutationTree} from "vuex";
-import {ModelState, RequiredModelAction} from "./state";
-import {Odin, OdinModelResponse, OdinRunner, OdinSolution} from "../../types/responseTypes";
-import {evaluateScript} from "../../utils";
-import {Dict} from "../../types/utilTypes";
+import { MutationTree } from "vuex";
+import { ModelState, RequiredModelAction } from "./state";
+import {
+    Odin, OdinModelResponse, OdinRunner, OdinSolution
+} from "../../types/responseTypes";
+import { evaluateScript } from "../../utils";
+import { Dict } from "../../types/utilTypes";
 
 export enum ModelMutation {
     SetOdinRunner = "SetOdinRunner",

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -9,8 +9,7 @@ export enum ModelMutation {
     SetOdinResponse = "SetOdinResponse",
     SetOdin = "SetOdin",
     SetOdinSolution = "SetOdinSolution",
-    SetRequiredCodeAction = "SetRequiredCodeAction",
-    SetRequiredParamsAction = "SetRequiredParamsAction",
+    SetRequiredAction = "SetRequiredCAction",
     SetParameters = "SetParameters",
     SetParameterValues = "SetParameterValues",
     UpdateParameterValues = "UpdateParameterValues"
@@ -33,12 +32,8 @@ export const mutations: MutationTree<ModelState> = {
         state.odinSolution = payload;
     },
 
-    [ModelMutation.SetRequiredCodeAction](state: ModelState, payload: RequiredModelAction | null) {
-        state.requiredCodeAction = payload;
-    },
-
-    [ModelMutation.SetRequiredParamsAction](state: ModelState, payload: RequiredModelAction | null) {
-        state.requiredParamsAction = payload;
+    [ModelMutation.SetRequiredAction](state: ModelState, payload: RequiredModelAction | null) {
+        state.requiredAction = payload;
     },
 
     [ModelMutation.SetParameters](state: ModelState, payload: OdinParameter[]) {
@@ -56,6 +51,8 @@ export const mutations: MutationTree<ModelState> = {
             ...state.parameterValues,
             ...payload
         };
-        state.requiredParamsAction = RequiredModelAction.Run;
+        if (state.requiredAction !== RequiredModelAction.Compile) {
+            state.requiredAction = RequiredModelAction.Run;
+        }
     }
 };

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,7 +1,7 @@
 import {
     Odin, OdinModelResponse, OdinSolution, OdinRunner
 } from "../../types/responseTypes";
-import {Dict} from "../../types/utilTypes";
+import { Dict } from "../../types/utilTypes";
 
 export enum RequiredModelAction {
     Compile,

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,5 +1,5 @@
 import {
-    Odin, OdinModelResponse, OdinSolution, OdinRunner, OdinParameter
+    Odin, OdinModelResponse, OdinSolution, OdinRunner
 } from "../../types/responseTypes";
 import {Dict} from "../../types/utilTypes";
 
@@ -14,7 +14,5 @@ export interface ModelState {
     odinModelResponse: null | OdinModelResponse // This contains all validation messages etc
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model
     odinSolution: null | OdinSolution
-
-    parameters: OdinParameter[] // Param metadata, pulled from ModelResponse on compile (retained if code changes without recompile)
     parameterValues: Dict<number>
 }

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -9,7 +9,8 @@ export enum RequiredModelAction {
 }
 
 export interface ModelState {
-    requiredAction: null | RequiredModelAction
+    requiredCodeAction: null | RequiredModelAction
+    requiredParamsAction: null | RequiredModelAction
     odinRunner: null | OdinRunner
     odinModelResponse: null | OdinModelResponse // This contains all validation messages etc
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -9,8 +9,7 @@ export enum RequiredModelAction {
 }
 
 export interface ModelState {
-    requiredCodeAction: null | RequiredModelAction
-    requiredParamsAction: null | RequiredModelAction
+    requiredAction: null | RequiredModelAction
     odinRunner: null | OdinRunner
     odinModelResponse: null | OdinModelResponse // This contains all validation messages etc
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,6 +1,7 @@
 import {
-    Odin, OdinModelResponse, OdinSolution, OdinRunner
+    Odin, OdinModelResponse, OdinSolution, OdinRunner, OdinParameter
 } from "../../types/responseTypes";
+import {Dict} from "../../types/utilTypes";
 
 export enum RequiredModelAction {
     Compile,
@@ -13,4 +14,7 @@ export interface ModelState {
     odinModelResponse: null | OdinModelResponse // This contains all validation messages etc
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model
     odinSolution: null | OdinSolution
+
+    parameters: OdinParameter[] // Param metadata, pulled from ModelResponse on compile (retained if code changes without recompile)
+    parameterValues: Dict<number>
 }

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -36,11 +36,21 @@ export interface Odin {
     new(...args : unknown[]): unknown
 }
 
+export interface OdinParameter {
+    name: string,
+    default: null | number,
+    min: null | number,
+    max: null | number,
+    // eslint-disable-next-line camelcase
+    is_integer: boolean,
+    rank: number
+}
+
 export interface OdinModelResponse{
     valid: boolean,
     metadata: {
         variables: string[],
-        parameters: string[],
+        parameters: OdinParameter[],
         messages: string[]
     },
     model: string

--- a/app/static/src/app/types/utilTypes.ts
+++ b/app/static/src/app/types/utilTypes.ts
@@ -1,0 +1,1 @@
+export type Dict<V> = { [k: string]: V }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -5,6 +5,6 @@ export default {
     },
     run: {
         compileRequired: "Code has been updated. Compile code and Run Model to view graph for latest code.",
-        runRequired: "Code has been recompiled. Run Model to view graph for latest code."
+        runRequired: "Code has been recompiled or parameter. Run Model to view graph for latest code."
     }
 };

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -4,7 +4,7 @@ export default {
         isNotValid: "Code is not valid"
     },
     run: {
-        compileRequired: "Code has been updated. Compile code and Run Model to view graph for latest code.",
-        runRequired: "Code has been recompiled or parameter. Run Model to view graph for latest code."
+        compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",
+        runRequired: "Model code has been recompiled or parameters have been updated. Run Model to view updated graph."
     }
 };

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -1,6 +1,22 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
 
+export const newValidCode = `## Derivatives
+deriv(y1) <- sigma * (y2 - y1)
+deriv(y2) <- R * y1 - y2 - y1 * y3
+deriv(y3) <- -b * y3 + y1 * y2
+
+## Initial conditions
+initial(y1) <- 10.0
+initial(y2) <- 1.0
+initial(y3) <- 1.0
+
+## parameters
+sigma <- user(10.0)
+R     <- user(28.0)
+b     <-  user(3.0)
+`;
+
 test.describe("Code Tab tests", () => {
     const { timeout } = PlaywrightConfig;
 
@@ -13,21 +29,6 @@ test.describe("Code Tab tests", () => {
         return plot.evaluate((el) => window.getComputedStyle(el).getPropertyValue("opacity"));
     };
 
-    const newValidCode = `## Derivatives
-deriv(y1) <- sigma * (y2 - y1)
-deriv(y2) <- R * y1 - y2 - y1 * y3
-deriv(y3) <- -b * y3 + y1 * y2
-
-## Initial conditions
-initial(y1) <- 10.0
-initial(y2) <- 1.0
-initial(y3) <- 1.0
-
-## parameters
-sigma <- 10.0
-R     <- 28.0
-b     <-  8.0 / 3.0
-`;
     test("can update code, compile and run model", async ({ page }, done) => {
         // Update code - see update message and graph fade.
         // We seem to have to delete the old code here with key presses - 'fill' just prepends. I guess this relates to
@@ -36,34 +37,34 @@ b     <-  8.0 / 3.0
         await page.press(".monaco-editor textarea", "Delete");
         await page.fill(".monaco-editor textarea", newValidCode);
 
-        await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
             "Model code has been updated. Compile code and Run Model to view updated graph.", {
                 timeout
             }
         );
-        expect(await getRunPlotOpacity(page)).toBe("0.5");
-        expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
+        await expect(await getRunPlotOpacity(page)).toBe("0.5");
+        await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
         const compileBtn = await page.locator("#compile-btn");
         expect(await compileBtn.isDisabled()).toBe(false);
 
         // Compile code - see new update message
         await page.click("#compile-btn");
-        await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
             "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
                 timeout
             }
         );
-        expect(await getRunPlotOpacity(page)).toBe("0.5");
-        expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
+        await expect(await getRunPlotOpacity(page)).toBe("0.5");
+        await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
 
         // Run code - should no longer need update, and traces should have changed
         await page.click("#run-btn");
-        await expect(page.locator(".run-tab .run-update-msg")).toHaveText("", { timeout });
-        expect(await getRunPlotOpacity(page)).toBe("1");
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText("", { timeout });
+        await expect(await getRunPlotOpacity(page)).toBe("1");
         const legendTextSelector = ".js-plotly-plot .legendtext";
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 1)`)).toBe("y1");
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 2)`)).toBe("y2");
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 3)`)).toBe("y3");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 1)`)).toBe("y1");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 2)`)).toBe("y2");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 3)`)).toBe("y3");
     });
 
     test("can see code not valid msg when update code with syntax error", async ({ page }) => {
@@ -72,12 +73,12 @@ b     <-  8.0 / 3.0
         await page.press(".monaco-editor textarea", "Delete");
         await page.fill(".monaco-editor textarea", invalidCode);
 
-        await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
             "Model code has been updated. Compile code and Run Model to view updated graph.", {
                 timeout
             }
         );
-        expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
+        await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
         const compileBtn = await page.locator("#compile-btn");
         expect(await compileBtn.isDisabled()).toBe(true);
     });

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -1,7 +1,7 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
 
-test.describe("Wodin Tabs tests", () => {
+test.describe("Code Tab tests", () => {
     const { timeout } = PlaywrightConfig;
 
     test.beforeEach(async ({ page }) => {
@@ -37,7 +37,7 @@ b     <-  8.0 / 3.0
         await page.fill(".monaco-editor textarea", newValidCode);
 
         await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Code has been updated. Compile code and Run Model to view graph for latest code.", {
+            "Model code has been updated. Compile code and Run Model to view updated graph.", {
                 timeout
             }
         );
@@ -49,7 +49,7 @@ b     <-  8.0 / 3.0
         // Compile code - see new update message
         await page.click("#compile-btn");
         await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Code has been recompiled. Run Model to view graph for latest code.", {
+            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
                 timeout
             }
         );
@@ -73,7 +73,7 @@ b     <-  8.0 / 3.0
         await page.fill(".monaco-editor textarea", invalidCode);
 
         await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Code has been updated. Compile code and Run Model to view graph for latest code.", {
+            "Model code has been updated. Compile code and Run Model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -17,33 +17,33 @@ test.describe("Index tests", () => {
 
     test("renders heading", async ({ page }) => {
         await page.goto("/");
-        expect(await page.innerText("h1")).toBe("Example WODIN configuration");
+        await expect(await page.innerText("h1")).toBe("Example WODIN configuration");
     });
 
     test("day1 link goes to Basic app", async ({ page }) => {
         await page.goto("/");
         await page.click("a[href='apps/day1']");
 
-        expect(await page.innerText("h1")).toBe("Day 1 - Basic Model");
-        expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
+        await expect(await page.innerText("h1")).toBe("Day 1 - Basic Model");
+        await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
     });
 
     test("day2 link goes to Fit app", async ({ page }) => {
         await page.goto("/");
         await page.click("a[href='apps/day2']");
 
-        expect(await page.innerText("h1")).toBe("Day 2 - Model Fit");
-        expect(await page.innerText("#app-type")).toBe("App Type: fit");
-        expect(await page.innerText("#fit-prop")).toBe("Fit Prop: day2 fit value");
+        await expect(await page.innerText("h1")).toBe("Day 2 - Model Fit");
+        await expect(await page.innerText("#app-type")).toBe("App Type: fit");
+        await expect(await page.innerText("#fit-prop")).toBe("Fit Prop: day2 fit value");
     });
 
     test("day3 link goes to Stochastic app", async ({ page }) => {
         await page.goto("/");
         await page.click("a[href='apps/day3']");
 
-        expect(await page.innerText("h1")).toBe("Day 3 - Stochastic Model");
-        expect(await page.innerText("#app-type")).toBe("App Type: stochastic");
-        expect(await page.innerText("#stochastic-prop")).toBe("Stochastic Prop: day3 stochastic value");
+        await expect(await page.innerText("h1")).toBe("Day 3 - Stochastic Model");
+        await expect(await page.innerText("#app-type")).toBe("App Type: stochastic");
+        await expect(await page.innerText("#stochastic-prop")).toBe("Stochastic Prop: day3 stochastic value");
     });
 
     const testDownloadFile = async (href: string, localFileName: string, expectedContent: string, page: Page) => {
@@ -56,7 +56,7 @@ test.describe("Index tests", () => {
         const downloadPath = `${tmpPath}/${localFileName}`;
         await download.saveAs(downloadPath);
         const downloadContent = fs.readFileSync(downloadPath, { encoding: "utf-8" });
-        expect(downloadContent).toBe(expectedContent);
+        await expect(downloadContent).toBe(expectedContent);
     };
 
     test("can download day 2 sample files", async ({ page }) => {

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -33,7 +33,7 @@ test.describe("Options Tab tests", () => {
 
         // expand
         await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-upp");
         await expect(await page.locator("#model-params")).not.toBeHidden();
     });
 
@@ -92,5 +92,16 @@ test.describe("Options Tab tests", () => {
         await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("28");
         await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("sigma");
         await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("10");
+    });
+
+    test("cleared parameter input resets on model run", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", "");
+        await page.click("#run-btn");
+
+        await expect(await page.locator(":nth-match(#model-params input, 1)")).toHaveValue(
+            "4", {
+                timeout
+            }
+        );
     });
 });

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -33,7 +33,7 @@ test.describe("Options Tab tests", () => {
 
         // expand
         await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-upp");
+        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
     });
 

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -12,7 +12,7 @@ test.describe("Options Tab tests", () => {
 
     test("can see default parameters", async ({ page }) => {
         await expect(await page.innerText(".collapse-title")).toContain("Model Parameters");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.getAttribute(".collapse-title i", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
 
         await expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("beta");
@@ -27,13 +27,13 @@ test.describe("Options Tab tests", () => {
 
     test("can collapse and expand parameters panel", async ({ page }) => {
         // collapse
-        await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-down");
+        await page.click(".collapse-title");
+        await expect(await page.getAttribute(".collapse-title i", "data-name")).toBe("chevron-down");
         await expect(await page.locator("#model-params")).toBeHidden();
 
         // expand
-        await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await page.click(".collapse-title");
+        await expect(await page.getAttribute(".collapse-title i", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
     });
 

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -1,35 +1,97 @@
 import { expect, test, Page } from "@playwright/test";
+import PlaywrightConfig from "../../playwright.config";
+import { newValidCode } from "./code.etest";
 
 test.describe("Options Tab tests", () => {
+    const { timeout } = PlaywrightConfig;
+
     test.beforeEach(async ({ page }) => {
         await page.goto("/apps/day1");
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
     });
 
     test("can see default parameters", async ({ page }) => {
-        expect(await page.innerText(".collapse-title")).toContain("Model Parameters");
-        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.innerText(".collapse-title")).toContain("Model Parameters");
+        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
 
-        expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("beta");
-        expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
-        expect(await page.innerText(":nth-match(#model-params label, 2)")).toBe("I0");
-        expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
-        expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("N");
-        expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1000000");
-        expect(await page.innerText(":nth-match(#model-params label, 4)")).toBe("sigma");
-        expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
+        await expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("beta");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
+        await expect(await page.innerText(":nth-match(#model-params label, 2)")).toBe("I0");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
+        await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("N");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1000000");
+        await expect(await page.innerText(":nth-match(#model-params label, 4)")).toBe("sigma");
+        await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
     });
 
     test("can collapse and expand parameters panel", async ({ page }) => {
         // collapse
         await page.click(".collapse-title a");
-        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-down");
+        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-down");
         await expect(await page.locator("#model-params")).toBeHidden();
 
         // expand
         await page.click(".collapse-title a");
-        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
+    });
+
+    test("can update parameter value", async ({ page }) => {
+        // Check that we can see the graph paths change when a parameter changes and model is re-run
+        const graphPathSelector = ":nth-match(.plotly svg .scatterlayer .scatter g.lines path, 1)";
+        const previousPath = await page.getAttribute(graphPathSelector, "d");
+        expect(previousPath!.startsWith("M0")).toBe(true);
+
+        await page.fill(":nth-match(#model-params input, 1)", "3");
+
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
+                timeout
+            }
+        );
+
+        // Re-run model
+        await page.click("#run-btn");
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText("");
+
+        const newPath = await page.getAttribute(graphPathSelector, "d");
+        expect(newPath!.startsWith("M0")).toBe(true);
+        expect(newPath).not.toEqual(previousPath);
+    });
+
+    test("parameters update when compile with new code", async ({page}) => {
+        // Navigate to code tab
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+
+        // Provide new code
+        await page.press(".monaco-editor textarea", "Control+A");
+        await page.press(".monaco-editor textarea", "Delete");
+        await page.fill(".monaco-editor textarea", newValidCode);
+
+        await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+                timeout
+            }
+        );
+
+        // Compile code
+        await page.click("#compile-btn");
+        await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
+                timeout
+            }
+        );
+
+        // Navigate to options tab
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+
+        await expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("b");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("3");
+        await expect(await page.innerText(":nth-match(#model-params label, 2)")).toBe("R");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("28");
+        await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("sigma");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("10");
+
     });
 });

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -60,7 +60,7 @@ test.describe("Options Tab tests", () => {
         expect(newPath).not.toEqual(previousPath);
     });
 
-    test("parameters update when compile with new code", async ({page}) => {
+    test("parameters update when compile with new code", async ({ page }) => {
         // Navigate to code tab
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
 
@@ -92,6 +92,5 @@ test.describe("Options Tab tests", () => {
         await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("28");
         await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("sigma");
         await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("10");
-
     });
 });

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -1,0 +1,35 @@
+import { expect, test, Page } from "@playwright/test";
+
+test.describe("Options Tab tests", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/apps/day1");
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+    });
+
+    test("can see default parameters", async ({ page }) => {
+        expect(await page.innerText(".collapse-title")).toContain("Model Parameters");
+        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.locator("#model-params")).not.toBeHidden();
+
+        expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("beta");
+        expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
+        expect(await page.innerText(":nth-match(#model-params label, 2)")).toBe("I0");
+        expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
+        expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("N");
+        expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1000000");
+        expect(await page.innerText(":nth-match(#model-params label, 4)")).toBe("sigma");
+        expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
+    });
+
+    test("can collapse and expand parameters panel", async ({ page }) => {
+        // collapse
+        await page.click(".collapse-title a");
+        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-down");
+        await expect(await page.locator("#model-params")).toBeHidden();
+
+        // expand
+        await page.click(".collapse-title a");
+        expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        await expect(await page.locator("#model-params")).not.toBeHidden();
+    });
+});

--- a/app/static/tests/e2e/panels.etest.ts
+++ b/app/static/tests/e2e/panels.etest.ts
@@ -6,31 +6,31 @@ test.describe("Wodin App panels tests", () => {
     });
 
     const expectBothMode = async (page: Page) => {
-        expect(await page.innerText(".wodin-mode-both .wodin-left .wodin-content .nav-tabs .active"))
+        await expect(await page.innerText(".wodin-mode-both .wodin-left .wodin-content .nav-tabs .active"))
             .toBe("Code");
-        expect(await page.locator(".wodin-mode-both .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
-        expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
-        expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
-        expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-mode-both .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        await expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
     };
 
     const expectRightMode = async (page: Page) => {
-        expect(await page.locator(".wodin-mode-right .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
-        expect(await page.locator(".wodin-mode-right .wodin-left .wodin-content").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-collapse-controls #collapse-left").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
-        expect(await page.locator(".wodin-left .view-left")).toBeVisible();
-        expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-mode-right .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
+        await expect(await page.locator(".wodin-mode-right .wodin-left .wodin-content").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-collapse-controls #collapse-left").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        await expect(await page.locator(".wodin-left .view-left")).toBeVisible();
+        await expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
     };
 
     const expectLeftMode = async (page: Page) => {
-        expect(await page.locator(".wodin-mode-left .wodin-right .wodin-content").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-mode-left .wodin-left .wodin-content")).toBeVisible();
-        expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
-        expect(await page.locator(".wodin-collapse-controls #collapse-right").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
-        expect(await page.locator(".wodin-right .view-right")).toBeVisible();
+        await expect(await page.locator(".wodin-mode-left .wodin-right .wodin-content").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-mode-left .wodin-left .wodin-content")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #collapse-right").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-right .view-right")).toBeVisible();
     };
 
     test("can collapse and expand left panel", async ({ page }) => {
@@ -56,7 +56,7 @@ test.describe("Wodin App panels tests", () => {
     test("'View Options' shows both panels", async ({ page }) => {
         await page.click("#collapse-left");
 
-        expect(await page.innerText(".view-left")).toBe("View Options");
+        await expect(await page.innerText(".view-left")).toBe("View Options");
         await page.click(".view-left");
         await expectBothMode(page);
     });
@@ -64,7 +64,7 @@ test.describe("Wodin App panels tests", () => {
     test("'View Charts' shows both panels", async ({ page }) => {
         await page.click("#collapse-right");
 
-        expect(await page.innerText(".view-right")).toBe("View Charts");
+        await expect(await page.innerText(".view-right")).toBe("View Charts");
         await page.click(".view-right");
         await expectBothMode(page);
     });

--- a/app/static/tests/e2e/tabs.etest.ts
+++ b/app/static/tests/e2e/tabs.etest.ts
@@ -6,20 +6,20 @@ test.describe("Wodin App tabs tests", () => {
     });
 
     test("renders Code tab", async ({ page }) => {
-        expect(await page.innerText(".wodin-left .wodin-content .nav-tabs .active")).toBe("Code");
-        expect(await page.inputValue(".monaco-editor textarea")).toContain("# variables");
-        expect(await page.innerText(".wodin-left .wodin-content button")).toBe("Compile");
-        expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
+        await expect(await page.innerText(".wodin-left .wodin-content .nav-tabs .active")).toBe("Code");
+        await expect(await page.inputValue(".monaco-editor textarea")).toContain("# variables");
+        await expect(await page.innerText(".wodin-left .wodin-content button")).toBe("Compile");
+        await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is valid");
     });
 
     test("can change to Options tab and back", async ({ page }) => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
-        expect(await page.innerText(".wodin-left .wodin-content .nav-tabs .active")).toBe("Options");
-        expect(await page.innerText(".wodin-left .wodin-content div.mt-4")).toContain("Model Parameters");
+        await expect(await page.innerText(".wodin-left .wodin-content .nav-tabs .active")).toBe("Options");
+        await expect(await page.innerText(".wodin-left .wodin-content div.mt-4")).toContain("Model Parameters");
     });
 
     test("renders plot in Run tab", async ({ page }) => {
-        expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Run");
+        await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Run");
 
         const plotSelector = ".wodin-right .wodin-content div.mt-4 .js-plotly-plot";
 
@@ -31,17 +31,17 @@ test.describe("Wodin App tabs tests", () => {
 
         // Test traces appear on legend
         const legendTextSelector = `${plotSelector} .legendtext`;
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 1)`)).toBe("S");
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 2)`)).toBe("I");
-        expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 3)`)).toBe("R");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 1)`)).toBe("S");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 2)`)).toBe("I");
+        await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 3)`)).toBe("R");
 
         // Test modebar menu is present
-        expect(await page.isVisible(`${plotSelector} .modebar`)).toBe(true);
+        await expect(await page.isVisible(`${plotSelector} .modebar`)).toBe(true);
     });
 
     test("can change to Sensitivity tab and back", async ({ page }) => {
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
-        expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Sensitivity");
-        expect(await page.innerText(".wodin-right .wodin-content div.mt-4")).toBe("Coming soon: Sensitivity plot");
+        await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Sensitivity");
+        await expect(await page.innerText(".wodin-right .wodin-content div.mt-4")).toBe("Coming soon: Sensitivity plot");
     });
 });

--- a/app/static/tests/e2e/tabs.etest.ts
+++ b/app/static/tests/e2e/tabs.etest.ts
@@ -42,6 +42,7 @@ test.describe("Wodin App tabs tests", () => {
     test("can change to Sensitivity tab and back", async ({ page }) => {
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
         await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Sensitivity");
-        await expect(await page.innerText(".wodin-right .wodin-content div.mt-4")).toBe("Coming soon: Sensitivity plot");
+        await expect(await page.innerText(".wodin-right .wodin-content div.mt-4"))
+            .toBe("Coming soon: Sensitivity plot");
     });
 });

--- a/app/static/tests/e2e/tabs.etest.ts
+++ b/app/static/tests/e2e/tabs.etest.ts
@@ -15,7 +15,7 @@ test.describe("Wodin App tabs tests", () => {
     test("can change to Options tab and back", async ({ page }) => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
         expect(await page.innerText(".wodin-left .wodin-content .nav-tabs .active")).toBe("Options");
-        expect(await page.innerText(".wodin-left .wodin-content div.mt-4")).toBe("Coming soon: Options editor.");
+        expect(await page.innerText(".wodin-left .wodin-content div.mt-4")).toContain("Model Parameters");
     });
 
     test("renders plot in Run tab", async ({ page }) => {

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -41,7 +41,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         odin: null,
         odinSolution: null,
         odinModelResponse: null,
-        requiredCodeAction: null,
+        requiredAction: null,
         ...state
     };
 };

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -42,6 +42,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         odinSolution: null,
         odinModelResponse: null,
         requiredAction: null,
+        parameterValues: {},
         ...state
     };
 };

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -41,7 +41,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         odin: null,
         odinSolution: null,
         odinModelResponse: null,
-        requiredAction: null,
+        requiredCodeAction: null,
         ...state
     };
 };

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -10,6 +10,7 @@ import { mockBasicState, mockModelState } from "../../../mocks";
 import { BasicAction } from "../../../../src/app/store/basic/actions";
 import { ModelAction } from "../../../../src/app/store/model/actions";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
+import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
 
 describe("BasicApp", () => {
     const getWrapper = (mockFetchConfig = jest.fn(), shallow = true, includeConfig = true) => {
@@ -92,7 +93,7 @@ describe("BasicApp", () => {
 
         // Change to Options tab
         await leftTabs.findAll("li a").at(1)!.trigger("click");
-        expect(leftTabs.find("div.mt-4").text()).toBe("Coming soon: Options editor.");
+        expect(leftTabs.find("div.mt-4").findComponent(OptionsTab).exists()).toBe(true);
     });
 
     it("renders Sensitivity as expected", async () => {

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -3,7 +3,7 @@ import Vuex from "vuex";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
 import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vue";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
-import {BasicState} from "../../../../src/app/store/basic/state";
+import { BasicState } from "../../../../src/app/store/basic/state";
 
 describe("OptionsTab", () => {
     it("renders as expected", () => {
@@ -14,7 +14,7 @@ describe("OptionsTab", () => {
                 }
             } as any
         });
-        const wrapper = mount(OptionsTab, {global: { plugins: [store] }});
+        const wrapper = mount(OptionsTab, { global: { plugins: [store] } });
         const collapse = wrapper.findComponent(VerticalCollapse);
         expect(collapse.props("title")).toBe("Model Parameters");
         expect(collapse.props("collapseId")).toBe("model-params");

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -1,9 +1,23 @@
-import { shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import Vuex from "vuex";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
+import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vue";
+import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
+import {BasicState} from "../../../../src/app/store/basic/state";
 
 describe("OptionsTab", () => {
     it("renders as expected", () => {
-        const wrapper = shallowMount(OptionsTab);
-        expect(wrapper.text()).toBe("Coming soon: Options editor.");
+        const store = new Vuex.Store<BasicState>({
+            state: {
+                model: {
+                    parameterValues: {}
+                }
+            } as any
+        });
+        const wrapper = mount(OptionsTab, {global: { plugins: [store] }});
+        const collapse = wrapper.findComponent(VerticalCollapse);
+        expect(collapse.props("title")).toBe("Model Parameters");
+        expect(collapse.props("collapseId")).toBe("model-params");
+        expect(wrapper.findComponent(ParameterValues).exists()).toBe(true);
     });
 });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -4,6 +4,7 @@ import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
 import mock = jest.mock;
 import { mockBasicState, mockModelState } from "../../../mocks";
+import {mutations} from "../../../../src/app/store/fit/mutations";
 
 describe("ParameterValues", () => {
     const getWrapper = (mockUpdateParameterValues = jest.fn()) => {

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -1,9 +1,9 @@
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
-import {BasicState} from "../../../../src/app/store/basic/state";
+import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
 import mock = jest.mock;
-import {mockBasicState, mockModelState} from "../../../mocks";
+import { mockBasicState, mockModelState } from "../../../mocks";
 
 describe("ParameterValues", () => {
     const getWrapper = (mockUpdateParameterValues = jest.fn()) => {
@@ -55,6 +55,6 @@ describe("ParameterValues", () => {
         const input2 = wrapper.findAll("input").at(1)!;
         await input2.setValue("3.3");
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
-        expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({param2: 3.3});
+        expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({ param2: 3.3 });
     });
 });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -2,18 +2,27 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import {BasicState} from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
+import mock = jest.mock;
+import {mockBasicState, mockModelState} from "../../../mocks";
 
 describe("ParameterValues", () => {
-    const getWrapper = () => {
+    const getWrapper = (mockUpdateParameterValues = jest.fn()) => {
         const store = new Vuex.Store<BasicState>({
-            state: {
+            state: {} as any,
+            modules: {
                 model: {
-                    parameterValues: {
-                        param1: 1,
-                        param2: 2.2
+                    namespaced: true,
+                    state: mockModelState({
+                        parameterValues: {
+                            param1: 1,
+                            param2: 2.2
+                        }
+                    }),
+                    mutations: {
+                        UpdateParameterValues: mockUpdateParameterValues
                     }
                 }
-            } as any
+            }
         });
 
         return shallowMount(ParameterValues, {
@@ -38,13 +47,14 @@ describe("ParameterValues", () => {
         const input2 = p2.find("input")!;
         expect(input2.attributes("type")).toBe("number");
         expect((input2.element as HTMLInputElement).value).toBe("2.2");
-
     });
 
     it("commits parameter value change", async () => {
-        const wrapper = getWrapper();
-        const input2 = wrapper.findAll("input").at(2)!;
+        const mockUpdateParameterValues = jest.fn();
+        const wrapper = getWrapper(mockUpdateParameterValues);
+        const input2 = wrapper.findAll("input").at(1)!;
         await input2.setValue("3.3");
-        // TODO: check commits mock mutation
+        expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
+        expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({param2: 3.3});
     });
 });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -1,0 +1,50 @@
+import Vuex from "vuex";
+import { shallowMount } from "@vue/test-utils";
+import {BasicState} from "../../../../src/app/store/basic/state";
+import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
+
+describe("ParameterValues", () => {
+    const getWrapper = () => {
+        const store = new Vuex.Store<BasicState>({
+            state: {
+                model: {
+                    parameterValues: {
+                        param1: 1,
+                        param2: 2.2
+                    }
+                }
+            } as any
+        });
+
+        return shallowMount(ParameterValues, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        const rows = wrapper.findAll("div.row");
+
+        const p1 = rows.at(0)!;
+        expect(p1.find("label").text()).toBe("param1");
+        const input1 = p1.find("input")!;
+        expect(input1.attributes("type")).toBe("number");
+        expect((input1.element as HTMLInputElement).value).toBe("1");
+
+        const p2 = rows.at(1)!;
+        expect(p2.find("label").text()).toBe("param2");
+        const input2 = p2.find("input")!;
+        expect(input2.attributes("type")).toBe("number");
+        expect((input2.element as HTMLInputElement).value).toBe("2.2");
+
+    });
+
+    it("commits parameter value change", async () => {
+        const wrapper = getWrapper();
+        const input2 = wrapper.findAll("input").at(2)!;
+        await input2.setValue("3.3");
+        // TODO: check commits mock mutation
+    });
+});

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -1,11 +1,18 @@
-import Vuex from "vuex";
+import Vuex, { Store } from "vuex";
+import { nextTick } from "vue";
 import { shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
 import { mockModelState } from "../../../mocks";
+import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
+import Mock = jest.Mock;
 
 describe("ParameterValues", () => {
-    const getWrapper = (mockUpdateParameterValues = jest.fn()) => {
+    const getStore = (mockUpdateParameterValues: Mock<any, any> | null = null) => {
+        // Use mock or real mutations
+        const storeMutations = mockUpdateParameterValues
+            ? { UpdateParameterValues: mockUpdateParameterValues } : mutations;
+
         const store = new Vuex.Store<BasicState>({
             state: {} as any,
             modules: {
@@ -17,13 +24,14 @@ describe("ParameterValues", () => {
                             param2: 2.2
                         }
                     }),
-                    mutations: {
-                        UpdateParameterValues: mockUpdateParameterValues
-                    }
+                    mutations: storeMutations
                 }
             }
         });
+        return store;
+    };
 
+    const getWrapper = (store: Store<BasicState>) => {
         return shallowMount(ParameterValues, {
             global: {
                 plugins: [store]
@@ -32,7 +40,7 @@ describe("ParameterValues", () => {
     };
 
     it("renders as expected", () => {
-        const wrapper = getWrapper();
+        const wrapper = getWrapper(getStore());
         const rows = wrapper.findAll("div.row");
 
         const p1 = rows.at(0)!;
@@ -50,10 +58,28 @@ describe("ParameterValues", () => {
 
     it("commits parameter value change", async () => {
         const mockUpdateParameterValues = jest.fn();
-        const wrapper = getWrapper(mockUpdateParameterValues);
+        const wrapper = getWrapper(getStore(mockUpdateParameterValues));
         const input2 = wrapper.findAll("input").at(1)!;
         await input2.setValue("3.3");
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
         expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({ param2: 3.3 });
+    });
+
+    it("does not commit parameter value change to empty string", async () => {
+        const mockUpdateParameterValues = jest.fn();
+        const wrapper = getWrapper(getStore(mockUpdateParameterValues));
+        const input2 = wrapper.findAll("input").at(1)!;
+        await input2.setValue("");
+        expect(mockUpdateParameterValues).not.toHaveBeenCalled();
+    });
+
+    it("refreshes cleared input when odinSolution changes", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        wrapper.findAll("input").at(1)!.setValue("");
+
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, {});
+        await nextTick();
+        expect((wrapper.findAll("input").at(1)!.element as HTMLInputElement).value).toBe("2.2");
     });
 });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -2,9 +2,7 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
-import mock = jest.mock;
-import { mockBasicState, mockModelState } from "../../../mocks";
-import {mutations} from "../../../../src/app/store/fit/mutations";
+import { mockModelState } from "../../../mocks";
 
 describe("ParameterValues", () => {
     const getWrapper = (mockUpdateParameterValues = jest.fn()) => {

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -64,7 +64,7 @@ describe("RunTab", () => {
     it("fades plot and shows message when compile required", () => {
         const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Compile);
         expect(wrapper.find(".run-update-msg").text()).toBe(
-            "Code has been updated. Compile code and Run Model to view graph for latest code."
+            "Model code has been updated. Compile code and Run Model to view updated graph."
         );
         expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(true);
     });
@@ -72,7 +72,7 @@ describe("RunTab", () => {
     it("fades plot and shows message when model run required", () => {
         const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Run);
         expect(wrapper.find(".run-update-msg").text()).toBe(
-            "Code has been recompiled. Run Model to view graph for latest code."
+            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph."
         );
         expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(true);
     });

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -3,10 +3,10 @@ jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
 import Vuex from "vuex";
-import { shallowMount } from "@vue/test-utils";
-import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockModelState } from "../../../mocks";
-import { RequiredModelAction } from "../../../../src/app/store/model/state";
+import {shallowMount} from "@vue/test-utils";
+import {BasicState} from "../../../../src/app/store/basic/state";
+import {mockBasicState, mockModelState} from "../../../mocks";
+import {RequiredModelAction} from "../../../../src/app/store/model/state";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
 import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
 
@@ -51,10 +51,16 @@ describe("RunTab", () => {
         expect(wrapper.find("button").element.disabled).toBe(true);
     });
 
-    it("disabled run button when state has no odin model", () => {
+    it("disables run button when state has no odin model", () => {
         const wrapper = getWrapper({} as any, null);
         expect(wrapper.find("button").element.disabled).toBe(true);
     });
+
+    it("disabled run button when compile is required", () => {
+        const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Compile);
+        expect(wrapper.find("button").element.disabled).toBe(true);
+    });
+
     it("fades plot and shows message when compile required", () => {
         const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Compile);
         expect(wrapper.find(".run-update-msg").text()).toBe(

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -23,7 +23,7 @@ describe("RunTab", () => {
                     state: mockModelState({
                         odinRunner,
                         odin,
-                        requiredCodeAction: requiredAction
+                        requiredAction: requiredAction
                     }),
                     actions: {
                         RunModel: mockRunModel

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -3,10 +3,10 @@ jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
 import Vuex from "vuex";
-import {shallowMount} from "@vue/test-utils";
-import {BasicState} from "../../../../src/app/store/basic/state";
-import {mockBasicState, mockModelState} from "../../../mocks";
-import {RequiredModelAction} from "../../../../src/app/store/model/state";
+import { shallowMount } from "@vue/test-utils";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import { mockBasicState, mockModelState } from "../../../mocks";
+import { RequiredModelAction } from "../../../../src/app/store/model/state";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
 import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
 

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -23,7 +23,7 @@ describe("RunTab", () => {
                     state: mockModelState({
                         odinRunner,
                         odin,
-                        requiredAction: requiredAction
+                        requiredAction
                     }),
                     actions: {
                         RunModel: mockRunModel

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -23,7 +23,7 @@ describe("RunTab", () => {
                     state: mockModelState({
                         odinRunner,
                         odin,
-                        requiredAction
+                        requiredCodeAction: requiredAction
                     }),
                     actions: {
                         RunModel: mockRunModel

--- a/app/static/tests/unit/components/verticalCollapse.test.ts
+++ b/app/static/tests/unit/components/verticalCollapse.test.ts
@@ -1,0 +1,38 @@
+import { shallowMount } from "@vue/test-utils";
+import VueFeather from "vue-feather";
+import VerticalCollapse from "../../../src/app/components/VerticalCollapse.vue";
+
+describe("VerticalCollapse", () => {
+    const getWrapper = () => {
+        return shallowMount(VerticalCollapse, {
+            slots: {
+                default: "<h1>TEST SLOT CONTENT</h1>"
+            },
+            props: {
+                title: "Test Title",
+                collapseId: "test-collapse-id"
+            }
+        });
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find(".collapse-title").text()).toBe("Test Title");
+        const collapse = wrapper.find(".collapse-title a");
+        expect(collapse.attributes("data-bs-toggle")).toBe("collapse");
+        expect(collapse.attributes("href")).toBe("#test-collapse-id");
+        expect(collapse.attributes("role")).toBe("button");
+        expect(collapse.attributes("aria-expanded")).toBe("true");
+        expect(collapse.attributes("aria-controls")).toBe("test-collapse-id");
+        expect(collapse.findComponent(VueFeather).props("type")).toBe("chevron-up");
+    });
+
+    it("toggles icon on collapse/expand", async () => {
+        const wrapper = getWrapper();
+        const collapse = wrapper.find(".collapse-title a");
+        await collapse.trigger("click");
+        expect(collapse.findComponent(VueFeather).props("type")).toBe("chevron-down");
+        await collapse.trigger("click");
+        expect(collapse.findComponent(VueFeather).props("type")).toBe("chevron-up");
+    });
+});

--- a/app/static/tests/unit/components/verticalCollapse.test.ts
+++ b/app/static/tests/unit/components/verticalCollapse.test.ts
@@ -18,7 +18,7 @@ describe("VerticalCollapse", () => {
     it("renders as expected", () => {
         const wrapper = getWrapper();
         expect(wrapper.find(".collapse-title").text()).toBe("Test Title");
-        const collapse = wrapper.find(".collapse-title a");
+        const collapse = wrapper.find("a");
         expect(collapse.attributes("data-bs-toggle")).toBe("collapse");
         expect(collapse.attributes("href")).toBe("#test-collapse-id");
         expect(collapse.attributes("role")).toBe("button");
@@ -29,7 +29,7 @@ describe("VerticalCollapse", () => {
 
     it("toggles icon on collapse/expand", async () => {
         const wrapper = getWrapper();
-        const collapse = wrapper.find(".collapse-title a");
+        const collapse = wrapper.find("a");
         await collapse.trigger("click");
         expect(collapse.findComponent(VueFeather).props("type")).toBe("chevron-down");
         await collapse.trigger("click");

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -93,7 +93,7 @@ describe("Model actions", () => {
             odinModelResponse: {
                 model: "1+2"
             } as any,
-            requiredCodeAction: RequiredModelAction.Run
+            requiredAction: RequiredModelAction.Run
         });
         const commit = jest.fn();
         (actions[ModelAction.CompileModel] as any)({ commit, state });
@@ -116,7 +116,7 @@ describe("Model actions", () => {
         const state = mockModelState({
             odinRunner: mockRunner,
             odin: mockOdin,
-            requiredCodeAction: RequiredModelAction.Run
+            requiredAction: RequiredModelAction.Run
         });
         const commit = jest.fn();
 
@@ -143,7 +143,7 @@ describe("Model actions", () => {
         const state = mockModelState({
             odinRunner: mockRunner,
             odin: mockOdin,
-            requiredCodeAction: RequiredModelAction.Compile
+            requiredAction: RequiredModelAction.Compile
         });
         const commit = jest.fn();
 

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -72,20 +72,35 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][1].detail).toBe("server error");
     });
 
-    it("compiles model and updates required action", () => {
+    it("compiles model, sets parameter values and updates required action", () => {
         const state = {
             odinModelResponse: {
-                model: "1+2"
+                model: "1+2",
+                metadata: {
+                    parameters: [
+                        {name: "p2", default: 20},
+                        {name: "p3", default: 30},
+                        {name: "p4", default: 40}
+                    ]
+                }
             },
-            requiredAction: RequiredModelAction.Compile
+            requiredAction: RequiredModelAction.Compile,
+            parameterValues: {
+                p1: 1,
+                p2: 2,
+                p3: 3
+            }
         };
         const commit = jest.fn();
         (actions[ModelAction.CompileModel] as any)({ commit, state });
-        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls.length).toBe(3);
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[0][1]).toBe(3);
-        expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetRequiredAction);
-        expect(commit.mock.calls[1][1]).toBe(RequiredModelAction.Run);
+        expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);
+        // Expect pre-existing parameter values to be retained,
+        expect(commit.mock.calls[1][1]).toStrictEqual({p2: 2, p3: 3, p4: 40});
+        expect(commit.mock.calls[2][0]).toBe(ModelMutation.SetRequiredAction);
+        expect(commit.mock.calls[2][1]).toBe(RequiredModelAction.Run);
     });
 
     it("compile model does not update required action if required action was not Compile", () => {
@@ -116,15 +131,16 @@ describe("Model actions", () => {
         const state = mockModelState({
             odinRunner: mockRunner,
             odin: mockOdin,
-            requiredAction: RequiredModelAction.Run
+            requiredAction: RequiredModelAction.Run,
+            parameterValues: {p1: 1, p2: 2}
         });
         const commit = jest.fn();
 
         (actions[ModelAction.RunModel] as any)({ commit, state });
 
-        expect(mockRunner.mock.calls[0][0]).toBe(dopri.Dopri);
+        expect(mockRunner.mock.calls[0][0]).toBe(dopri);
         expect(mockRunner.mock.calls[0][1]).toBe(mockOdin);
-        expect(mockRunner.mock.calls[0][2]).toStrictEqual({ });
+        expect(mockRunner.mock.calls[0][2]).toStrictEqual({ p1: 1, p2: 2 });
         expect(mockRunner.mock.calls[0][3]).toBe(0); // start
         expect(mockRunner.mock.calls[0][4]).toBe(100); // end
         expect(mockRunner.mock.calls[0][5]).toStrictEqual({}); // control

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -78,9 +78,9 @@ describe("Model actions", () => {
                 model: "1+2",
                 metadata: {
                     parameters: [
-                        {name: "p2", default: 20},
-                        {name: "p3", default: 30},
-                        {name: "p4", default: 40}
+                        { name: "p2", default: 20 },
+                        { name: "p3", default: 30 },
+                        { name: "p4", default: 40 }
                     ]
                 }
             },
@@ -98,7 +98,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);
         // Expect pre-existing parameter values to be retained,
-        expect(commit.mock.calls[1][1]).toStrictEqual({p2: 2, p3: 3, p4: 40});
+        expect(commit.mock.calls[1][1]).toStrictEqual({ p2: 2, p3: 3, p4: 40 });
         expect(commit.mock.calls[2][0]).toBe(ModelMutation.SetRequiredAction);
         expect(commit.mock.calls[2][1]).toBe(RequiredModelAction.Run);
     });
@@ -132,7 +132,7 @@ describe("Model actions", () => {
             odinRunner: mockRunner,
             odin: mockOdin,
             requiredAction: RequiredModelAction.Run,
-            parameterValues: {p1: 1, p2: 2}
+            parameterValues: { p1: 1, p2: 2 }
         });
         const commit = jest.fn();
 

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -98,7 +98,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);
         // Expect pre-existing parameter values to be retained,
-        expect(commit.mock.calls[1][1]).toStrictEqual({ p2: 2, p3: 3, p4: 40 });
+        expect(commit.mock.calls[1][1]).toStrictEqual({ p2: 20, p3: 30, p4: 40 });
         expect(commit.mock.calls[2][0]).toBe(ModelMutation.SetRequiredAction);
         expect(commit.mock.calls[2][1]).toBe(RequiredModelAction.Run);
     });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -93,7 +93,7 @@ describe("Model actions", () => {
             odinModelResponse: {
                 model: "1+2"
             } as any,
-            requiredAction: RequiredModelAction.Run
+            requiredCodeAction: RequiredModelAction.Run
         });
         const commit = jest.fn();
         (actions[ModelAction.CompileModel] as any)({ commit, state });
@@ -116,7 +116,7 @@ describe("Model actions", () => {
         const state = mockModelState({
             odinRunner: mockRunner,
             odin: mockOdin,
-            requiredAction: RequiredModelAction.Run
+            requiredCodeAction: RequiredModelAction.Run
         });
         const commit = jest.fn();
 
@@ -143,7 +143,7 @@ describe("Model actions", () => {
         const state = mockModelState({
             odinRunner: mockRunner,
             odin: mockOdin,
-            requiredAction: RequiredModelAction.Compile
+            requiredCodeAction: RequiredModelAction.Compile
         });
         const commit = jest.fn();
 

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -45,15 +45,15 @@ describe("Model mutations", () => {
 
     it("sets parameter values", () => {
         const state = mockModelState();
-        const parameters = {p1: 1, p2: 2};
+        const parameters = { p1: 1, p2: 2 };
         mutations.SetParameterValues(state, parameters);
         expect(state.parameterValues).toBe(parameters);
     });
 
     it("updates parameter values and sets requiredAction to Run", () => {
-        const state = mockModelState({parameterValues: {p1: 1, p2: 2}});
-        mutations.UpdateParameterValues(state, {p1: 10, p3: 30});
-        expect(state.parameterValues).toStrictEqual({p1: 10, p2: 2, p3: 30});
+        const state = mockModelState({ parameterValues: { p1: 1, p2: 2 } });
+        mutations.UpdateParameterValues(state, { p1: 10, p3: 30 });
+        expect(state.parameterValues).toStrictEqual({ p1: 10, p2: 2, p3: 30 });
         expect(state.requiredAction).toBe(RequiredModelAction.Run);
     });
 });

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -40,6 +40,6 @@ describe("Model mutations", () => {
     it("sets required action", () => {
         const state = mockModelState();
         mutations.SetRequiredAction(state, RequiredModelAction.Compile);
-        expect(state.requiredCodeAction).toBe(RequiredModelAction.Compile);
+        expect(state.requiredAction).toBe(RequiredModelAction.Compile);
     });
 });

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -40,6 +40,6 @@ describe("Model mutations", () => {
     it("sets required action", () => {
         const state = mockModelState();
         mutations.SetRequiredAction(state, RequiredModelAction.Compile);
-        expect(state.requiredAction).toBe(RequiredModelAction.Compile);
+        expect(state.requiredCodeAction).toBe(RequiredModelAction.Compile);
     });
 });

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -42,4 +42,18 @@ describe("Model mutations", () => {
         mutations.SetRequiredAction(state, RequiredModelAction.Compile);
         expect(state.requiredAction).toBe(RequiredModelAction.Compile);
     });
+
+    it("sets parameter values", () => {
+        const state = mockModelState();
+        const parameters = {p1: 1, p2: 2};
+        mutations.SetParameterValues(state, parameters);
+        expect(state.parameterValues).toBe(parameters);
+    });
+
+    it("updates parameter values and sets requiredAction to Run", () => {
+        const state = mockModelState({parameterValues: {p1: 1, p2: 2}});
+        mutations.UpdateParameterValues(state, {p1: 10, p3: 30});
+        expect(state.parameterValues).toStrictEqual({p1: 10, p2: 2, p3: 30});
+        expect(state.requiredAction).toBe(RequiredModelAction.Run);
+    });
 });

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=main
+ODIN_API_BRANCH=mrc-3293
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=mrc-3183
+ODIN_API_BRANCH=main
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH


### PR DESCRIPTION
Adds UI and store support for updating parameter values, implemented on the Options tab. When the user edits a parameter value, the model's `requiredAction` becomes 'Run' since the model needs to be re-run to reflect the new parameter value. 

When the model is recompiled, we do not retain the current set of parameter values, but overwrite them with defaults from the new code. 

Parameter metadata includes min, max, is_integer and rank values - on discussion with Rich it emerged that he would prefer not to enforce or indicate these in the UI, but allow the model to fail when run if parameter is outside bounds or wrong format. (There is an outstanding ticket to put in error handling.)

Includes a VerticalCollapse panel to allow ModelParameters to be collapsed by user - this will also be used elsewhere on the Options tab. 

Inputs currently just support integers, decimals and other formatting to be supported in a separate ticket. 

Also:
- disabled the Run Model button when code compilation is required. This simplifies the logic around required actions in that, without it, user could still update params and run previous model without compiling newest so code, so both "run" and "compile" could be considered to be required. 
- updated the message displayed when `requiredAction` is Run, to include indication that parameters may have been updated. 
- Added some missing `await`s in the e2e tests - in Playwright you need to wait both for the locator, and for Playwright's `expect` (don't need it on `expect` when just doing things like checking strings). 

To test: run dependencies and app with `./scripts/run-dev-dependencies.sh` and `./scripts/build-and-run.sh`. Go to options tab to see parameters. Try updating one of the param values and re-running (e.g. change beta from 4 to 3). Should see the prompt to re-run, and when you re-run the model you should see the graph changes.  Try changing the code to have new parameter defaults, or new parameters e.g. add the line `sigma2 <- user(9)`. When you then recompile the model you should see that the new parameter, sigma2, has been added, with value 9, and any values you changed have been reverted to current code defaults.  