### PR TITLE
mrc-3253 Add End Time to Options tab

### DIFF
--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -3,17 +3,22 @@
         <vertical-collapse title="Model Parameters" collapse-id="model-params">
           <parameter-values></parameter-values>
         </vertical-collapse>
+        <vertical-collapse title="Run Options" collapse-id="run-options">
+          <run-options></run-options>
+        </vertical-collapse>
     </div>
 </template>
 
 <script lang="ts">
 import VerticalCollapse from "../VerticalCollapse.vue";
 import ParameterValues from "./ParameterValues.vue";
+import RunOptions from "./RunOptions.vue";
 
 export default {
     name: "OptionsTab",
     components: {
         ParameterValues,
+        RunOptions,
         VerticalCollapse
     }
 };

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="container">
-    <div v-for="paramName in paramNames" class="row my-2" :key="paramName">
+    <div class="row my-2">
       <div class="col-6">
-        <label class="col-form-label">{{paramName}}</label>
+        <label class="col-form-label">End time</label>
       </div>
       <div class="col-6">
         <input class="form-control parameter-input"
                type="number"
-               :value="paramValues[paramName]"
-               @input="updateValue($event, paramName)"/>
+               min="1"
+               :value="endTime
+               @input="updateEndTime"/>
       </div>
     </div>
   </div>
@@ -17,23 +18,22 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
+import {ModelMutation} from "../../store/model/mutations";
 
 export default defineComponent({
   name: "RunOptions",
   setup() {
     const store = useStore();
-    const paramValues = computed(() => store.state.model.parameterValues);
-    const paramNames = computed(() => Object.keys(paramValues.value)); // TODO: use rank
+    const endTime = computed(() => store.state.model.endTime);
 
-    const updateValue = (e: Event, paramName: string) => {
+    const updateEndTime = (e: Event) => {
       const newValue = parseFloat((e.target as HTMLInputElement).value);
-      store.commit("model/UpdateParameterValues", { [paramName]: newValue });
+      store.commit(`model/${ModelMutation.SetEndTime}`, newValue);
     };
 
     return {
-      paramValues,
-      paramNames,
-      updateValue
+      endTime,
+      updateEndTime
     };
   }
 });

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="container">
+    <div v-for="paramName in paramNames" class="row my-2" :key="paramName">
+      <div class="col-6">
+        <label class="col-form-label">{{paramName}}</label>
+      </div>
+      <div class="col-6">
+        <input class="form-control parameter-input"
+               type="number"
+               :value="paramValues[paramName]"
+               @input="updateValue($event, paramName)"/>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import { useStore } from "vuex";
+
+export default defineComponent({
+  name: "RunOptions",
+  setup() {
+    const store = useStore();
+    const paramValues = computed(() => store.state.model.parameterValues);
+    const paramNames = computed(() => Object.keys(paramValues.value)); // TODO: use rank
+
+    const updateValue = (e: Event, paramName: string) => {
+      const newValue = parseFloat((e.target as HTMLInputElement).value);
+      store.commit("model/UpdateParameterValues", { [paramName]: newValue });
+    };
+
+    return {
+      paramValues,
+      paramNames,
+      updateValue
+    };
+  }
+});
+</script>

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -8,7 +8,7 @@
         <input class="form-control parameter-input"
                type="number"
                min="1"
-               :value="endTime
+               :value="endTime"
                @input="updateEndTime"/>
       </div>
     </div>
@@ -18,23 +18,23 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
-import {ModelMutation} from "../../store/model/mutations";
+import { ModelMutation } from "../../store/model/mutations";
 
 export default defineComponent({
-  name: "RunOptions",
-  setup() {
-    const store = useStore();
-    const endTime = computed(() => store.state.model.endTime);
+    name: "RunOptions",
+    setup() {
+        const store = useStore();
+        const endTime = computed(() => store.state.model.endTime);
 
-    const updateEndTime = (e: Event) => {
-      const newValue = parseFloat((e.target as HTMLInputElement).value);
-      store.commit(`model/${ModelMutation.SetEndTime}`, newValue);
-    };
+        const updateEndTime = (e: Event) => {
+            const newValue = parseFloat((e.target as HTMLInputElement).value);
+            store.commit(`model/${ModelMutation.SetEndTime}`, newValue);
+        };
 
-    return {
-      endTime,
-      updateEndTime
-    };
-  }
+        return {
+            endTime,
+            updateEndTime
+        };
+    }
 });
 </script>

--- a/app/static/src/app/components/run/RunModelPlot.vue
+++ b/app/static/src/app/components/run/RunModelPlot.vue
@@ -23,6 +23,7 @@ export default defineComponent({
 
         const plotStyle = computed(() => (props.fadePlot ? "opacity:0.5;" : ""));
         const solution = computed(() => store.state.model.odinSolution);
+        const endTime = computed(() => store.state.model.endTime);
 
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
         const baseData = ref(null);
@@ -63,8 +64,7 @@ export default defineComponent({
 
         const drawPlot = () => {
             if (solution.value) {
-                // TODO: default end time will eventually be configured in the app
-                baseData.value = solution.value(0, 100, nPoints);
+                baseData.value = solution.value(0, endTime.value, nPoints);
 
                 if (baseData.value) {
                     const el = plot.value as unknown;

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -57,9 +57,7 @@ const runModel = (context: ActionContext<ModelState, AppState>) => {
     if (state.odinRunner && state.odin) {
         const parameters = state.parameterValues;
         const start = 0;
-
-        // TODO: this value will come from state when UI elements are implemented
-        const end = 100;
+        const end = state.endTime;
         const control = {};
         const solution = state.odinRunner(dopri, state.odin, parameters, start, end, control);
         commit(ModelMutation.SetOdinSolution, solution);

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -8,7 +8,8 @@ export const defaultState: ModelState = {
     odinModelResponse: null,
     odin: null,
     odinSolution: null,
-    parameterValues: {}
+    parameterValues: {},
+    endTime: 100
 };
 
 export const model = {

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -17,6 +17,12 @@ export enum ModelMutation {
     SetEndTime = "SetEndTime"
 }
 
+const runRequired = (state: ModelState) => {
+    if (state.requiredAction !== RequiredModelAction.Compile) {
+        state.requiredAction = RequiredModelAction.Run;
+    }
+};
+
 export const mutations: MutationTree<ModelState> = {
     [ModelMutation.SetOdinRunner](state: ModelState, payload: string) {
         state.odinRunner = evaluateScript<OdinRunner>(payload);
@@ -49,15 +55,11 @@ export const mutations: MutationTree<ModelState> = {
             ...state.parameterValues,
             ...payload
         };
-        if (state.requiredAction !== RequiredModelAction.Compile) {
-            state.requiredAction = RequiredModelAction.Run;
-        }
+        runRequired(state);
     },
 
     [ModelMutation.SetEndTime](state: ModelState, payload: number) {
         state.endTime = payload;
-        if (state.requiredAction !== RequiredModelAction.Compile) {  // TODO: common method for this?
-            state.requiredAction = RequiredModelAction.Run;
-        }
+        runRequired(state);
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -13,7 +13,8 @@ export enum ModelMutation {
     SetOdinSolution = "SetOdinSolution",
     SetRequiredAction = "SetRequiredAction",
     SetParameterValues = "SetParameterValues",
-    UpdateParameterValues = "UpdateParameterValues"
+    UpdateParameterValues = "UpdateParameterValues",
+    SetEndTime = "SetEndTime"
 }
 
 export const mutations: MutationTree<ModelState> = {
@@ -51,5 +52,9 @@ export const mutations: MutationTree<ModelState> = {
         if (state.requiredAction !== RequiredModelAction.Compile) {
             state.requiredAction = RequiredModelAction.Run;
         }
+    },
+
+    [ModelMutation.SetEndTime](state: ModelState, payload: number) {
+        state.endTime = payload;
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -56,5 +56,8 @@ export const mutations: MutationTree<ModelState> = {
 
     [ModelMutation.SetEndTime](state: ModelState, payload: number) {
         state.endTime = payload;
+        if (state.requiredAction !== RequiredModelAction.Compile) {  // TODO: common method for this?
+            state.requiredAction = RequiredModelAction.Run;
+        }
     }
 };

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -15,4 +15,5 @@ export interface ModelState {
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model
     odinSolution: null | OdinSolution
     parameterValues: Dict<number>
+    endTime: number
 }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -5,6 +5,6 @@ export default {
     },
     run: {
         compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",
-        runRequired: "Model code has been recompiled or parameters have been updated. Run Model to view updated graph."
+        runRequired: "Model code has been recompiled or options have been updated. Run Model to view updated graph."
     }
 };

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -50,7 +50,7 @@ test.describe("Code Tab tests", () => {
         // Compile code - see new update message
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -46,7 +46,7 @@ test.describe("Options Tab tests", () => {
         await page.fill(":nth-match(#model-params input, 1)", "3");
 
         await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
                 timeout
             }
         );
@@ -78,7 +78,7 @@ test.describe("Options Tab tests", () => {
         // Compile code
         await page.click("#compile-btn");
         await expect(page.locator(".run-tab .run-update-msg")).toHaveText(
-            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph.", {
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -10,9 +10,9 @@ test.describe("Options Tab tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
     });
 
-    test("can see default parameters", async ({ page }) => {
-        await expect(await page.innerText(".collapse-title")).toContain("Model Parameters");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+    test("can see default options", async ({ page }) => {
+        await expect(await page.innerText(":nth-match(.collapse-title, 1)")).toContain("Model Parameters");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i, 1)", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
 
         await expect(await page.innerText(":nth-match(#model-params label, 1)")).toBe("beta");
@@ -23,18 +23,35 @@ test.describe("Options Tab tests", () => {
         await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1000000");
         await expect(await page.innerText(":nth-match(#model-params label, 4)")).toBe("sigma");
         await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
+
+        await expect(await page.innerText(":nth-match(.collapse-title, 2)")).toContain("Run Options");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i, 2)", "data-name")).toBe("chevron-up");
+        await expect(await page.locator("#run-options")).not.toBeHidden();
+
+        await expect(await page.innerText(":nth-match(#run-options label, 1)")).toBe("End time");
+        await expect(await page.inputValue(":nth-match(#run-options input, 1)")).toBe("100");
     });
 
-    test("can collapse and expand parameters panel", async ({ page }) => {
-        // collapse
-        await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-down");
+    test("can collapse and expand options panel", async ({ page }) => {
+        // parameters collapse
+        await page.click(":nth-match(.collapse-title a, 1)");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i, 1)", "data-name")).toBe("chevron-down");
         await expect(await page.locator("#model-params")).toBeHidden();
 
-        // expand
-        await page.click(".collapse-title a");
-        await expect(await page.getAttribute(".collapse-title a i", "data-name")).toBe("chevron-up");
+        // parameters expand
+        await page.click(":nth-match(.collapse-title a, 1)");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i ,1)", "data-name")).toBe("chevron-up");
         await expect(await page.locator("#model-params")).not.toBeHidden();
+
+        // run-options collapse
+        await page.click(":nth-match(.collapse-title a, 2)");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i, 2)", "data-name")).toBe("chevron-down");
+        await expect(await page.locator("#run-options")).toBeHidden();
+
+        // parameters expand
+        await page.click(":nth-match(.collapse-title a, 2)");
+        await expect(await page.getAttribute(":nth-match(.collapse-title a i, 2)", "data-name")).toBe("chevron-up");
+        await expect(await page.locator("#run-options")).not.toBeHidden();
     });
 
     test("can update parameter value", async ({ page }) => {
@@ -92,5 +109,26 @@ test.describe("Options Tab tests", () => {
         await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("28");
         await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("sigma");
         await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("10");
+    });
+
+    test("can update end time", async ({ page }) => {
+        // Expect run plot's x axis final tick to initially be 100
+        const xAxisTickSelector = ".plotly svg .xaxislayer-above .xtick text";
+        await expect(await page.locator(xAxisTickSelector).last().innerHTML()).toBe("100");
+
+        await page.fill("#run-options input", "200");
+
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+                timeout
+            }
+        );
+
+        // Re-run model
+        await page.click("#run-btn");
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText("");
+
+        // Expect run plot's x axis final tick to now be 200
+        await expect(await page.locator(xAxisTickSelector).last().innerHTML()).toBe("200");
     });
 });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -43,6 +43,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         odinModelResponse: null,
         requiredAction: null,
         parameterValues: {},
+        endTime: 100,
         ...state
     };
 };

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
 import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vue";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
+import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 
 describe("OptionsTab", () => {
@@ -15,9 +16,12 @@ describe("OptionsTab", () => {
             } as any
         });
         const wrapper = mount(OptionsTab, { global: { plugins: [store] } });
-        const collapse = wrapper.findComponent(VerticalCollapse);
-        expect(collapse.props("title")).toBe("Model Parameters");
-        expect(collapse.props("collapseId")).toBe("model-params");
-        expect(wrapper.findComponent(ParameterValues).exists()).toBe(true);
+        const collapses = wrapper.findAllComponents(VerticalCollapse);
+        expect(collapses.at(0)!.props("title")).toBe("Model Parameters");
+        expect(collapses.at(0)!.props("collapseId")).toBe("model-params");
+        expect(collapses.at(0)!.findComponent(ParameterValues).exists()).toBe(true);
+        expect(collapses.at(1)!.props("title")).toBe("Run Options");
+        expect(collapses.at(1)!.props("collapseId")).toBe("run-options");
+        expect(collapses.at(1)!.findComponent(RunOptions).exists()).toBe(true);
     });
 });

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -1,6 +1,6 @@
 import Vuex from "vuex";
-import {BasicState} from "../../../../src/app/store/basic/state";
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
+import { BasicState } from "../../../../src/app/store/basic/state";
 import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
 
 describe("RunOptions", () => {

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -1,0 +1,46 @@
+import Vuex from "vuex";
+import {BasicState} from "../../../../src/app/store/basic/state";
+import {shallowMount} from "@vue/test-utils";
+import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
+
+describe("RunOptions", () => {
+    const getWrapper = (mockSetEndTime = jest.fn()) => {
+        const store = new Vuex.Store<BasicState>({
+            state: {} as any,
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: {
+                        endTime: 99
+                    },
+                    mutations: {
+                        SetEndTime: mockSetEndTime
+                    }
+                }
+            }
+        });
+        return shallowMount(RunOptions, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("label").text()).toBe("End time");
+        const input = wrapper.find("input");
+        expect(input.attributes("type")).toBe("number");
+        expect(input.attributes("min")).toBe("1");
+        expect((input.element as HTMLInputElement).value).toBe("99");
+    });
+
+    it("commits end time change", () => {
+        const mockSetEndTime = jest.fn();
+        const wrapper = getWrapper(mockSetEndTime);
+        const input = wrapper.find("input");
+        input.setValue("101");
+        expect(mockSetEndTime).toHaveBeenCalledTimes(1);
+        expect(mockSetEndTime.mock.calls[0][1]).toBe(101);
+    });
+});

--- a/app/static/tests/unit/components/run/runModelPlot.test.ts
+++ b/app/static/tests/unit/components/run/runModelPlot.test.ts
@@ -159,7 +159,7 @@ describe("RunModelPlot", () => {
         await relayout(relayoutEvent);
 
         expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
-        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual([0, 100]);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual([0, 99]);
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
     });
 

--- a/app/static/tests/unit/components/run/runModelPlot.test.ts
+++ b/app/static/tests/unit/components/run/runModelPlot.test.ts
@@ -35,7 +35,9 @@ describe("RunModelPlot", () => {
             modules: {
                 model: {
                     namespaced: true,
-                    state: mockModelState(),
+                    state: mockModelState({
+                        endTime: 99
+                    }),
                     actions: {
                         RunModel: mockRunModel
                     },
@@ -90,7 +92,7 @@ describe("RunModelPlot", () => {
         store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
         await nextTick();
         expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div").element);
-        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual([0, 100]);
+        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual([0, 99]);
         expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 0 } });
 
         expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -72,7 +72,7 @@ describe("RunTab", () => {
     it("fades plot and shows message when model run required", () => {
         const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Run);
         expect(wrapper.find(".run-update-msg").text()).toBe(
-            "Model code has been recompiled or parameters have been updated. Run Model to view updated graph."
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph."
         );
         expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(true);
     });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -218,7 +218,8 @@ describe("Model actions", () => {
                 model: {
                     namespaced: true,
                     state: mockModelState({
-                        odinRunner: mockRunner
+                        odinRunner: mockRunner,
+                        endTime: 99
                     }),
                     mutations,
                     actions
@@ -262,7 +263,7 @@ describe("Model actions", () => {
         expect(mockRunner.mock.calls[0][1]).toBe(3);
         expect(mockRunner.mock.calls[0][2]).toStrictEqual({ p1: 1 });
         expect(mockRunner.mock.calls[0][3]).toBe(0); // start
-        expect(mockRunner.mock.calls[0][4]).toBe(100); // end
+        expect(mockRunner.mock.calls[0][4]).toBe(99); // end
         expect(mockRunner.mock.calls[0][5]).toStrictEqual({}); // control
 
         expect(commit.mock.calls[5][0]).toBe(`model/${ModelMutation.SetOdinSolution}`);

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -137,7 +137,8 @@ describe("Model actions", () => {
             odinRunner: mockRunner,
             odin: mockOdin,
             requiredAction: RequiredModelAction.Run,
-            parameterValues: { p1: 1, p2: 2 }
+            parameterValues: { p1: 1, p2: 2 },
+            endTime: 99
         });
         const commit = jest.fn();
 
@@ -147,7 +148,7 @@ describe("Model actions", () => {
         expect(mockRunner.mock.calls[0][1]).toBe(mockOdin);
         expect(mockRunner.mock.calls[0][2]).toStrictEqual({ p1: 1, p2: 2 });
         expect(mockRunner.mock.calls[0][3]).toBe(0); // start
-        expect(mockRunner.mock.calls[0][4]).toBe(100); // end
+        expect(mockRunner.mock.calls[0][4]).toBe(99); // end time from state
         expect(mockRunner.mock.calls[0][5]).toStrictEqual({}); // control
 
         expect(commit.mock.calls.length).toBe(2);

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -1,6 +1,6 @@
-import { mutations } from "../../../../src/app/store/model/mutations";
-import { mockModelState } from "../../../mocks";
-import { RequiredModelAction } from "../../../../src/app/store/model/state";
+import {mutations} from "../../../../src/app/store/model/mutations";
+import {mockModelState} from "../../../mocks";
+import {RequiredModelAction} from "../../../../src/app/store/model/state";
 
 describe("Model mutations", () => {
     it("evaluates and sets odin runner", () => {
@@ -55,5 +55,26 @@ describe("Model mutations", () => {
         mutations.UpdateParameterValues(state, { p1: 10, p3: 30 });
         expect(state.parameterValues).toStrictEqual({ p1: 10, p2: 2, p3: 30 });
         expect(state.requiredAction).toBe(RequiredModelAction.Run);
+    });
+
+    it("UpdateParameterValues does not set requiredAction to Run if it is currently Compile", () => {
+        const state = mockModelState({ parameterValues: { p1: 1 }, requiredAction: RequiredModelAction.Compile});
+        mutations.UpdateParameterValues(state, { p2: 2 });
+        expect(state.parameterValues).toStrictEqual({ p1: 1, p2: 2 });
+        expect(state.requiredAction).toBe(RequiredModelAction.Compile);
+    });
+
+    it("sets end time and sets requiredAction to Run", () => {
+        const state = mockModelState({endTime: 99})
+        mutations.SetEndTime(state, 101);
+        expect(state.endTime).toBe(101);
+        expect(state.requiredAction).toBe(RequiredModelAction.Run);
+    });
+
+    it("SetEndTime does not set requiredAction to Run if it is currently Compile", () => {
+        const state = mockModelState({endTime: 99, requiredAction: RequiredModelAction.Compile})
+        mutations.SetEndTime(state, 101);
+        expect(state.endTime).toBe(101);
+        expect(state.requiredAction).toBe(RequiredModelAction.Compile);
     });
 });

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -1,6 +1,6 @@
-import {mutations} from "../../../../src/app/store/model/mutations";
-import {mockModelState} from "../../../mocks";
-import {RequiredModelAction} from "../../../../src/app/store/model/state";
+import { mutations } from "../../../../src/app/store/model/mutations";
+import { mockModelState } from "../../../mocks";
+import { RequiredModelAction } from "../../../../src/app/store/model/state";
 
 describe("Model mutations", () => {
     it("evaluates and sets odin runner", () => {
@@ -58,21 +58,21 @@ describe("Model mutations", () => {
     });
 
     it("UpdateParameterValues does not set requiredAction to Run if it is currently Compile", () => {
-        const state = mockModelState({ parameterValues: { p1: 1 }, requiredAction: RequiredModelAction.Compile});
+        const state = mockModelState({ parameterValues: { p1: 1 }, requiredAction: RequiredModelAction.Compile });
         mutations.UpdateParameterValues(state, { p2: 2 });
         expect(state.parameterValues).toStrictEqual({ p1: 1, p2: 2 });
         expect(state.requiredAction).toBe(RequiredModelAction.Compile);
     });
 
     it("sets end time and sets requiredAction to Run", () => {
-        const state = mockModelState({endTime: 99})
+        const state = mockModelState({ endTime: 99 });
         mutations.SetEndTime(state, 101);
         expect(state.endTime).toBe(101);
         expect(state.requiredAction).toBe(RequiredModelAction.Run);
     });
 
     it("SetEndTime does not set requiredAction to Run if it is currently Compile", () => {
-        const state = mockModelState({endTime: 99, requiredAction: RequiredModelAction.Compile})
+        const state = mockModelState({ endTime: 99, requiredAction: RequiredModelAction.Compile });
         mutations.SetEndTime(state, 101);
         expect(state.endTime).toBe(101);
         expect(state.requiredAction).toBe(RequiredModelAction.Compile);


### PR DESCRIPTION
Adds End Time option, and uses it when running model. End Time defaults to 100 - a separate ticket will implement configuring default end time for applications. 

To test - run deps and app and browse to Day 1 app. Edit End time parameter - this should cause 're-run required' message to be displayed. When model is re-run, results on graph should be displayed up to the new end time. 