### PR TITLE
mrc-3663 Use latest odin api

### DIFF
--- a/app/static/package.json
+++ b/app/static/package.json
@@ -25,7 +25,6 @@
     "@popperjs/core": "^2.11.5",
     "axios": "^0.26.0",
     "bootstrap": "^5.1.3",
-    "dopri": "^0.0.8",
     "monaco-editor": "^0.30.1",
     "plotly.js": "^2.11.1",
     "vue": "^3.2.29",

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -7,7 +7,7 @@
       <div class="col-6">
         <input class="form-control parameter-input"
                type="number"
-               :value="paramValues[paramName]"
+               :value="paramValues.get(paramName)"
                @input="updateValue($event, paramName)"/>
       </div>
     </div>
@@ -26,7 +26,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const paramValues = computed(() => store.state.model.parameterValues);
-        const paramNames = computed(() => Object.keys(paramValues.value));
+        const paramNames = computed(() => Array.from(paramValues.value.keys()) as string[]);
 
         const timestampParamNames = () => paramNames.value.map((name: string) => name + Date.now());
 

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const paramValues = computed(() => store.state.model.parameterValues);
-        const paramNames = computed(() => Array.from(paramValues.value.keys()) as string[]);
+        const paramNames = computed(() => (paramValues.value ? Array.from(paramValues.value.keys()) as string[] : []));
 
         const timestampParamNames = () => paramNames.value.map((name: string) => name + Date.now());
 

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -8,7 +8,7 @@ export const defaultState: ModelState = {
     odinModelResponse: null,
     odin: null,
     odinSolution: null,
-    parameterValues: {},
+    parameterValues: null,
     endTime: 100
 };
 

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -44,18 +44,19 @@ export const mutations: MutationTree<ModelState> = {
         state.requiredAction = payload;
     },
 
-    [ModelMutation.SetParameterValues](state: ModelState, payload: Dict<number>) {
+    [ModelMutation.SetParameterValues](state: ModelState, payload: Map<string, number>) {
         // initialise values
         state.parameterValues = payload;
     },
 
     [ModelMutation.UpdateParameterValues](state: ModelState, payload: Dict<number>) {
-        // update values (incomplete or complete set) and set required action as run will be needed using new values
-        state.parameterValues = {
-            ...state.parameterValues,
-            ...payload
-        };
-        runRequired(state);
+        if (state.parameterValues) {
+            Object.keys(payload).forEach((key) => {
+                state.parameterValues!.set(key, payload[key]);
+            });
+
+            runRequired(state);
+        }
     },
 
     [ModelMutation.SetEndTime](state: ModelState, payload: number) {

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,7 +1,6 @@
 import {
     Odin, OdinModelResponse, OdinSolution, OdinRunner
 } from "../../types/responseTypes";
-import { Dict } from "../../types/utilTypes";
 
 export enum RequiredModelAction {
     Compile,

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -14,6 +14,6 @@ export interface ModelState {
     odinModelResponse: null | OdinModelResponse // This contains all validation messages etc
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model
     odinSolution: null | OdinSolution
-    parameterValues: Dict<number>
+    parameterValues: null | Map<string, number>
     endTime: number
 }

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -58,9 +58,9 @@ export interface OdinModelResponse{
 
 export type OdinSolution = (t0: number, t1: number, nPoints: number) => {x: number, y: number}[];
 
-export type OdinRunner = (dopri: unknown,
-                          odin: Odin,
-                          pars: Record<string, number>,
-                          tStart: number,
-                          tEnd: number,
-                          control: unknown) => OdinSolution;
+export interface OdinRunner {
+    wodinRun: (odin: Odin,
+               pars: Map<string, number>,
+               tStart: number,
+               tEnd: number) => OdinSolution;
+}

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -6,7 +6,6 @@ import { StochasticState } from "../src/app/store/stochastic/state";
 import { ResponseSuccess, ResponseFailure, APIError } from "../src/app/types/responseTypes";
 import { ModelState } from "../src/app/store/model/state";
 import { CodeState } from "../src/app/store/code/state";
-import mock = jest.mock;
 
 export const mockAxios = new MockAdapter(axios);
 
@@ -42,7 +41,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         odinSolution: null,
         odinModelResponse: null,
         requiredAction: null,
-        parameterValues: {},
+        parameterValues: null,
         endTime: 100,
         ...state
     };

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -11,7 +11,7 @@ describe("OptionsTab", () => {
         const store = new Vuex.Store<BasicState>({
             state: {
                 model: {
-                    parameterValues: {}
+                    parameterValues: null
                 }
             } as any
         });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -19,10 +19,7 @@ describe("ParameterValues", () => {
                 model: {
                     namespaced: true,
                     state: mockModelState({
-                        parameterValues: {
-                            param1: 1,
-                            param2: 2.2
-                        }
+                        parameterValues: new Map([["param1", 1], ["param2", 2.2]])
                     }),
                     mutations: storeMutations
                 }

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -1,4 +1,3 @@
-import * as dopri from "dopri";
 import Vuex from "vuex";
 import {
     mockAxios, mockBasicState, mockCodeState, mockFailure, mockModelState, mockSuccess
@@ -17,6 +16,12 @@ describe("Model actions", () => {
         code: {
             currentCode: ["line1", "line2"]
         }
+    };
+
+    const mockRunner = () => {
+        return {
+            wodinRun: jest.fn((odin, pars, start, end) => "test solution" as any)
+        };
     };
 
     it("fetches odin runner", async () => {
@@ -85,11 +90,11 @@ describe("Model actions", () => {
                 }
             },
             requiredAction: RequiredModelAction.Compile,
-            parameterValues: {
-                p1: 1,
-                p2: 2,
-                p3: 3
-            }
+            parameterValues: new Map([
+                ["p1", 1],
+                ["p2", 2],
+                ["p3", 3]
+            ])
         };
         const commit = jest.fn();
         (actions[ModelAction.CompileModel] as any)({ commit, state });
@@ -97,8 +102,8 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);
-        // Expect pre-existing parameter values to be retained,
-        expect(commit.mock.calls[1][1]).toStrictEqual({ p2: 20, p3: 30, p4: 40 });
+        const expectedParams = new Map([["p2", 20], ["p3", 30], ["p4", 40]]);
+        expect(commit.mock.calls[1][1]).toStrictEqual(expectedParams);
         expect(commit.mock.calls[2][0]).toBe(ModelMutation.SetRequiredAction);
         expect(commit.mock.calls[2][1]).toBe(RequiredModelAction.Run);
     });
@@ -119,7 +124,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);
-        expect(commit.mock.calls[1][1]).toStrictEqual({});
+        expect(commit.mock.calls[1][1]).toStrictEqual(new Map());
     });
 
     it("compile model does nothing if no odin response", () => {
@@ -130,26 +135,26 @@ describe("Model actions", () => {
     });
 
     it("runs model and updates required action", () => {
-        const mockRunner = jest.fn((dop, odin, pars, start, end, control) => "test solution" as any);
         const mockOdin = {} as any;
 
+        const parameterValues = new Map([["p1", 1], ["p2", 2]]);
+        const runner = mockRunner();
         const state = mockModelState({
-            odinRunner: mockRunner,
+            odinRunner: runner,
             odin: mockOdin,
             requiredAction: RequiredModelAction.Run,
-            parameterValues: { p1: 1, p2: 2 },
+            parameterValues,
             endTime: 99
         });
         const commit = jest.fn();
 
         (actions[ModelAction.RunModel] as any)({ commit, state });
 
-        expect(mockRunner.mock.calls[0][0]).toBe(dopri);
-        expect(mockRunner.mock.calls[0][1]).toBe(mockOdin);
-        expect(mockRunner.mock.calls[0][2]).toStrictEqual({ p1: 1, p2: 2 });
-        expect(mockRunner.mock.calls[0][3]).toBe(0); // start
-        expect(mockRunner.mock.calls[0][4]).toBe(99); // end time from state
-        expect(mockRunner.mock.calls[0][5]).toStrictEqual({}); // control
+        const run = runner.wodinRun;
+        expect(run.mock.calls[0][0]).toBe(mockOdin);
+        expect(run.mock.calls[0][1]).toStrictEqual(parameterValues);
+        expect(run.mock.calls[0][2]).toBe(0); // start
+        expect(run.mock.calls[0][3]).toBe(99); // end time from state
 
         expect(commit.mock.calls.length).toBe(2);
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdinSolution);
@@ -159,13 +164,13 @@ describe("Model actions", () => {
     });
 
     it("run model does not update required action if required action was not run", () => {
-        const mockRunner = jest.fn();
         const mockOdin = {} as any;
 
         const state = mockModelState({
-            odinRunner: mockRunner,
+            odinRunner: mockRunner(),
             odin: mockOdin,
-            requiredAction: RequiredModelAction.Compile
+            requiredAction: RequiredModelAction.Compile,
+            parameterValues: new Map()
         });
         const commit = jest.fn();
 
@@ -189,10 +194,9 @@ describe("Model actions", () => {
     });
 
     it("run model does nothing if odin is not set", () => {
-        const mockRunner = jest.fn();
-
+        const runner = mockRunner();
         const state = mockModelState({
-            odinRunner: mockRunner,
+            odinRunner: runner,
             odin: null
         });
         const commit = jest.fn();
@@ -200,12 +204,12 @@ describe("Model actions", () => {
         (actions[ModelAction.RunModel] as any)({ commit, state });
 
         expect(commit).not.toHaveBeenCalled();
-        expect(mockRunner).not.toHaveBeenCalled();
+        expect(runner.wodinRun).not.toHaveBeenCalled();
     });
 
     it("DefaultModel fetches, compiles and runs default model synchronously", async () => {
         // Use real store so can trace the flow of updates through the state
-        const mockRunner = jest.fn((dop, odin, pars, start, end, control) => "test solution" as any);
+        const runner = mockRunner();
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState(),
             modules: {
@@ -218,7 +222,7 @@ describe("Model actions", () => {
                 model: {
                     namespaced: true,
                     state: mockModelState({
-                        odinRunner: mockRunner,
+                        odinRunner: runner,
                         endTime: 99
                     }),
                     mutations,
@@ -254,17 +258,16 @@ describe("Model actions", () => {
         expect(commit.mock.calls[2][0]).toBe(`model/${ModelMutation.SetOdin}`);
         expect(commit.mock.calls[2][1]).toBe(3); // evaluated value of test model
         expect(commit.mock.calls[3][0]).toBe(`model/${ModelMutation.SetParameterValues}`);
-        expect(commit.mock.calls[3][1]).toStrictEqual({ p1: 1 });
+        expect(commit.mock.calls[3][1]).toStrictEqual(new Map([["p1", 1]]));
         expect(commit.mock.calls[4][0]).toBe(`model/${ModelMutation.SetRequiredAction}`);
         expect(commit.mock.calls[4][1]).toBe(RequiredModelAction.Run);
 
-        // run
-        expect(mockRunner.mock.calls[0][0]).toBe(dopri);
-        expect(mockRunner.mock.calls[0][1]).toBe(3);
-        expect(mockRunner.mock.calls[0][2]).toStrictEqual({ p1: 1 });
-        expect(mockRunner.mock.calls[0][3]).toBe(0); // start
-        expect(mockRunner.mock.calls[0][4]).toBe(99); // end
-        expect(mockRunner.mock.calls[0][5]).toStrictEqual({}); // control
+        // runs
+        const run = runner.wodinRun;
+        expect(run.mock.calls[0][0]).toBe(3);
+        expect(run.mock.calls[0][1]).toStrictEqual(new Map([["p1", 1]]));
+        expect(run.mock.calls[0][2]).toBe(0); // start
+        expect(run.mock.calls[0][3]).toBe(99); // end
 
         expect(commit.mock.calls[5][0]).toBe(`model/${ModelMutation.SetOdinSolution}`);
         expect(commit.mock.calls[5][1]).toBe("test solution");

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -51,16 +51,19 @@ describe("Model mutations", () => {
     });
 
     it("updates parameter values and sets requiredAction to Run", () => {
-        const state = mockModelState({ parameterValues: { p1: 1, p2: 2 } });
+        const state = mockModelState({ parameterValues: new Map([["p1", 1], ["p2", 2]]) });
         mutations.UpdateParameterValues(state, { p1: 10, p3: 30 });
-        expect(state.parameterValues).toStrictEqual({ p1: 10, p2: 2, p3: 30 });
+        expect(state.parameterValues).toStrictEqual(new Map([["p1", 10], ["p2", 2], ["p3", 30]]));
         expect(state.requiredAction).toBe(RequiredModelAction.Run);
     });
 
     it("UpdateParameterValues does not set requiredAction to Run if it is currently Compile", () => {
-        const state = mockModelState({ parameterValues: { p1: 1 }, requiredAction: RequiredModelAction.Compile });
+        const state = mockModelState({
+            parameterValues: new Map([["p1", 1]]),
+            requiredAction: RequiredModelAction.Compile
+        });
         mutations.UpdateParameterValues(state, { p2: 2 });
-        expect(state.parameterValues).toStrictEqual({ p1: 1, p2: 2 });
+        expect(state.parameterValues).toStrictEqual(new Map([["p1", 1], ["p2", 2]]));
         expect(state.requiredAction).toBe(RequiredModelAction.Compile);
     });
 

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=main
+ODIN_API_BRANCH=mrc-3356
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH


### PR DESCRIPTION
The model run interface is changing in the js runner returned by odin.api. This branch updates for these changes as follows:

- dopri and control are no longer required as parameters to the run method (dopri is now bundled up with the response, and we weren't using control anyway). 
- the runner returned from the endpoint is now an object rather than just a function. We call the method `wodinRun` on the object - and other methods will eventually be added around fit and sensitivity, 
- the parameters need to be passed as a Map rather than an ordinary object, so I've changed parameters to be Map in the state too. 