### PR TITLE
mrc-3318 Link data to model variables

### DIFF
--- a/app/static/package.json
+++ b/app/static/package.json
@@ -28,10 +28,6 @@
     "axios": "^0.26.0",
     "bootstrap": "^5.1.3",
     "csv-parse": "^5.2.1",
-<<<<<<< HEAD
-=======
-    "dopri": "^0.0.8",
->>>>>>> main
     "monaco-editor": "^0.30.1",
     "plotly.js": "^2.11.1",
     "vue": "^3.2.29",

--- a/app/static/src/app/components/data/DataTab.vue
+++ b/app/static/src/app/components/data/DataTab.vue
@@ -26,7 +26,6 @@ import { useStore } from "vuex";
 import VueFeather from "vue-feather";
 import { FitDataAction } from "../../store/fitData/actions";
 import ErrorInfo from "../ErrorInfo.vue";
-import { FitDataMutation } from "../../store/fitData/mutations";
 
 export default defineComponent({
     name: "DataTab",
@@ -43,7 +42,7 @@ export default defineComponent({
 
         const updateTimeVariable = (event: Event) => {
             const { value } = event.target as HTMLSelectElement;
-            store.commit(`fitData/${FitDataMutation.SetTimeVariable}`, value);
+            store.dispatch(`fitData/${FitDataAction.UpdateTimeVariable}`, value);
         };
 
         const error = computed(() => store.state.fitData.error);

--- a/app/static/src/app/components/data/DataTab.vue
+++ b/app/static/src/app/components/data/DataTab.vue
@@ -1,7 +1,12 @@
 <template>
   <h3>Upload data</h3>
   <div>
-    <input type="file" id="fitDataUpload" accept=".csv,.txt" @change="upload" class="form-control">
+    <input type="file"
+           id="fitDataUpload"
+           accept=".csv,.txt"
+           @change="upload"
+           @click="clearCurrentFile"
+           class="form-control">
   </div>
   <div v-if="success" class="mt-2" id="data-upload-success">
     <vue-feather class="inline-icon text-success" type="check"></vue-feather>
@@ -40,6 +45,11 @@ export default defineComponent({
             store.dispatch(`fitData/${FitDataAction.Upload}`, file);
         };
 
+        const clearCurrentFile = (event: InputEvent) => {
+            const target = event.target! as HTMLInputElement;
+            target.value = ""; // Allow file re-upload
+        };
+
         const updateTimeVariable = (event: Event) => {
             const { value } = event.target as HTMLSelectElement;
             store.dispatch(`fitData/${FitDataAction.UpdateTimeVariable}`, value);
@@ -53,6 +63,7 @@ export default defineComponent({
         const timeVariable = computed(() => store.state.fitData.timeVariable);
 
         return {
+            clearCurrentFile,
             upload,
             updateTimeVariable,
             error,

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -16,7 +16,7 @@
     </template>
     <template v-else>
       <div class="row my-2">
-        {{ linkPrerequisitesMsg }}
+        {{ linkPrerequisitesMessage }}
       </div>
     </template>
   </div>
@@ -38,6 +38,20 @@ export default defineComponent({
         const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
         const modelVariables = computed(() => store.state.model.odinModelResponse?.metadata.variables);
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
+        const linkPrerequisitesMessage = computed(() => {
+            const messages = [];
+            const { prefix, data, model } = userMessages.fitData.linkPrerequisites;
+            if (!dataColumns.value) {
+                messages.push(data);
+            }
+            if (!modelSuccess.value) {
+                messages.push(model);
+            }
+            if (messages.length) {
+                return `${prefix} ${messages.join(", ")}`;
+            }
+            return null;
+        });
 
         const updateLinkedVariable = (dataColumn: string, event: Event) => {
             const selectValue = (event.target as HTMLSelectElement).value;
@@ -45,15 +59,13 @@ export default defineComponent({
             store.commit(`${namespace}/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
         };
 
-        const linkPrerequisitesMsg = userMessages.fitData.linkPrerequisites;
-
         return {
             dataColumns,
             modelSuccess,
             modelVariables,
             linkedVariables,
             updateLinkedVariable,
-            linkPrerequisitesMsg
+            linkPrerequisitesMessage
         };
     }
 });

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -6,7 +6,7 @@
           <label class="col-form-label">{{ dataColumn }}</label>
         </div>
         <div class="col-6">
-            <select class="form-select">
+            <select class="form-select" @change="updateLinkedVariable(dataColumn, $event)" v-model="linkedVariables[dataColumn]">
               <option :value="null">-- no link --</option>
               <option v-for="modelVar in modelVariables" :value="modelVar" :key="modelVar">{{modelVar}}</option>
             </select>
@@ -20,24 +20,34 @@
 </template>
 
 <script lang="ts">
-import {defineComponent, computed} from "vue";
-import {useStore} from "vuex";
+import { defineComponent, computed } from "vue";
+import { useStore } from "vuex";
+import { FitDataMutation } from "../../store/fitData/mutations";
 
 export default defineComponent({
-  name: "LinkData",
-  setup() {
-    const store = useStore();
-    const dataColumns = computed(() => store.getters["fitData/nonTimeColumns"]); //TODO: use an enum for this
-    const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
-    const modelVariables = computed(() => store.state.model.odinModelResponse?.metadata.variables);
-    return {
-      dataColumns,
-      modelSuccess,
-      modelVariables
-    };
+    name: "LinkData",
+    setup() {
+        const store = useStore();
+        const dataColumns = computed(() => store.getters["fitData/nonTimeColumns"]); // TODO: use an enum for this
+        const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
+        const modelVariables = computed(() => store.state.model.odinModelResponse?.metadata.variables);
+        const linkedVariables = computed(() => store.state.fitData.linkedVariables);
+
+        const updateLinkedVariable = (dataColumn: string, event: Event) => {
+            const { value } = event.target as HTMLSelectElement;
+            store.commit(`fitData/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
+        };
+
+        return {
+            dataColumns,
+            modelSuccess,
+            modelVariables,
+            linkedVariables,
+            updateLinkedVariable
+        };
     // TODO: enforce must have at least 2 columns in data
     // TODO: Make a nice message for missing prerequisites
-  }
+    // TODO: Make an enum for app type
+    }
 });
 </script>
-

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="container">
     <template v-if="dataColumns && modelSuccess">
-      <div v-for="dataColumn in dataColumns" class="row my-2">
+      <div v-for="dataColumn in dataColumns" :key="dataColumn" class="row my-2">
         <div class="col-6">
           <label class="col-form-label">{{ dataColumn }}</label>
         </div>
         <div class="col-6">
-            <select class="form-select" @change="updateLinkedVariable(dataColumn, $event)" :value="linkedVariables[dataColumn] || ''">
+            <select class="form-select"
+                    @change="updateLinkedVariable(dataColumn, $event)" :value="linkedVariables[dataColumn] || ''">
               <option value="">-- no link --</option>
               <option v-for="modelVar in modelVariables" :value="modelVar" :key="modelVar">{{modelVar}}</option>
             </select>

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="container">
+    <template v-if="dataColumns && modelSuccess">
+      <div v-for="dataColumn in dataColumns" class="row my-2">
+        <div class="col-6">
+          <label class="col-form-label">{{ dataColumn }}</label>
+        </div>
+        <div class="col-6">
+            <select class="form-select">
+              <option :value="null">-- no link --</option>
+              <option v-for="modelVar in modelVariables" :value="modelVar" :key="modelVar">{{modelVar}}</option>
+            </select>
+        </div>
+      </div>
+    </template>
+    <template v-else>
+      no model fit data or no model
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent, computed} from "vue";
+import {useStore} from "vuex";
+
+export default defineComponent({
+  name: "LinkData",
+  setup() {
+    const store = useStore();
+    const dataColumns = computed(() => store.getters["fitData/nonTimeColumns"]); //TODO: use an enum for this
+    const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
+    const modelVariables = computed(() => store.state.model.odinModelResponse?.metadata.variables);
+    return {
+      dataColumns,
+      modelSuccess,
+      modelVariables
+    };
+    // TODO: enforce must have at least 2 columns in data
+    // TODO: Make a nice message for missing prerequisites
+  }
+});
+</script>
+

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -6,8 +6,8 @@
           <label class="col-form-label">{{ dataColumn }}</label>
         </div>
         <div class="col-6">
-            <select class="form-select" @change="updateLinkedVariable(dataColumn, $event)" v-model="linkedVariables[dataColumn]">
-              <option :value="null">-- no link --</option>
+            <select class="form-select" @change="updateLinkedVariable(dataColumn, $event)" :value="linkedVariables[dataColumn] || ''">
+              <option value="">-- no link --</option>
               <option v-for="modelVar in modelVariables" :value="modelVar" :key="modelVar">{{modelVar}}</option>
             </select>
         </div>
@@ -37,7 +37,8 @@ export default defineComponent({
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
 
         const updateLinkedVariable = (dataColumn: string, event: Event) => {
-            const { value } = event.target as HTMLSelectElement;
+            const selectValue = (event.target as HTMLSelectElement).value;
+            const value = selectValue === "" ? null : selectValue;
             store.commit(`${namespace}/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
         };
 

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -7,7 +7,8 @@
         </div>
         <div class="col-6">
             <select class="form-select"
-                    @change="updateLinkedVariable(dataColumn, $event)" :value="linkedVariables[dataColumn] || ''">
+                    @change="updateLinkedVariable(dataColumn, $event)"
+                    :value="linkedVariables[dataColumn] || ''">
               <option value="">-- no link --</option>
               <option v-for="modelVar in modelVariables" :value="modelVar" :key="modelVar">{{modelVar}}</option>
             </select>
@@ -40,6 +41,7 @@ export default defineComponent({
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
         const linkPrerequisitesMessage = computed(() => {
             const messages = [];
+            let result = null;
             const { prefix, data, model } = userMessages.fitData.linkPrerequisites;
             if (!dataColumns.value) {
                 messages.push(data);
@@ -48,15 +50,15 @@ export default defineComponent({
                 messages.push(model);
             }
             if (messages.length) {
-                return `${prefix} ${messages.join(", ")}`;
+                result = `${prefix} ${messages.join(", ")}`;
             }
-            return null;
+            return result;
         });
 
         const updateLinkedVariable = (dataColumn: string, event: Event) => {
             const selectValue = (event.target as HTMLSelectElement).value;
-            const value = selectValue === "" ? null : selectValue;
-            store.commit(`${namespace}/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
+            store.commit(`${namespace}/${FitDataMutation.SetLinkedVariable}`,
+                { column: dataColumn, variable: selectValue || null });
         };
 
         return {

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -14,7 +14,9 @@
       </div>
     </template>
     <template v-else>
-      {{ linkPrerequisitesMsg }}
+      <div class="row my-2">
+        {{ linkPrerequisitesMsg }}
+      </div>
     </template>
   </div>
 </template>
@@ -52,7 +54,6 @@ export default defineComponent({
             updateLinkedVariable,
             linkPrerequisitesMsg
         };
-    // TODO: show a warning/error if user selects same same variable to fit for multiple columns
     }
 });
 </script>

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -14,7 +14,7 @@
       </div>
     </template>
     <template v-else>
-      no model fit data or no model
+      {{ linkPrerequisitesMsg }}
     </template>
   </div>
 </template>
@@ -23,31 +23,35 @@
 import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { FitDataMutation } from "../../store/fitData/mutations";
+import { FitDataGetter } from "../../store/fitData/getters";
+import userMessages from "../../userMessages";
 
 export default defineComponent({
     name: "LinkData",
     setup() {
+        const namespace = "fitData";
         const store = useStore();
-        const dataColumns = computed(() => store.getters["fitData/nonTimeColumns"]); // TODO: use an enum for this
+        const dataColumns = computed(() => store.getters[`${namespace}/${FitDataGetter.nonTimeColumns}`]);
         const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
         const modelVariables = computed(() => store.state.model.odinModelResponse?.metadata.variables);
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
 
         const updateLinkedVariable = (dataColumn: string, event: Event) => {
             const { value } = event.target as HTMLSelectElement;
-            store.commit(`fitData/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
+            store.commit(`${namespace}/${FitDataMutation.SetLinkedVariable}`, { column: dataColumn, variable: value });
         };
+
+        const linkPrerequisitesMsg = userMessages.fitData.linkPrerequisites;
 
         return {
             dataColumns,
             modelSuccess,
             modelVariables,
             linkedVariables,
-            updateLinkedVariable
+            updateLinkedVariable,
+            linkPrerequisitesMsg
         };
-    // TODO: enforce must have at least 2 columns in data
-    // TODO: Make a nice message for missing prerequisites
-    // TODO: Make an enum for app type
+    // TODO: show a warning/error if user selects same same variable to fit for multiple columns
     }
 });
 </script>

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -19,6 +19,7 @@ import VerticalCollapse from "../VerticalCollapse.vue";
 import ParameterValues from "./ParameterValues.vue";
 import RunOptions from "./RunOptions.vue";
 import LinkData from "./LinkData.vue";
+import {AppType} from "../../store/appState/state";
 
 export default {
     name: "OptionsTab",
@@ -30,7 +31,7 @@ export default {
     },
     setup() {
         const store = useStore();
-        const isFit = computed(() => store.state.appType === "fit");
+        const isFit = computed(() => store.state.appType === AppType.Fit);
 
         return {
             isFit

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -1,5 +1,8 @@
 <template>
     <div>
+        <vertical-collapse v-if="isFit" title="Link" collapse-id="link-data">
+          <link-data></link-data>
+        </vertical-collapse>
         <vertical-collapse title="Model Parameters" collapse-id="model-params">
           <parameter-values></parameter-values>
         </vertical-collapse>
@@ -10,16 +13,29 @@
 </template>
 
 <script lang="ts">
+import { computed, onMounted } from "vue";
+import { useStore } from "vuex";
 import VerticalCollapse from "../VerticalCollapse.vue";
 import ParameterValues from "./ParameterValues.vue";
 import RunOptions from "./RunOptions.vue";
+import LinkData from "./LinkData.vue";
 
 export default {
     name: "OptionsTab",
     components: {
+        LinkData,
         ParameterValues,
         RunOptions,
         VerticalCollapse
+    },
+    setup() {
+        const store = useStore();
+        const isFit = computed(() => store.state.appType === "fit");
+
+        return {
+            isFit
+        };
+
     }
 };
 </script>

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -13,13 +13,13 @@
 </template>
 
 <script lang="ts">
-import { computed, onMounted } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import VerticalCollapse from "../VerticalCollapse.vue";
 import ParameterValues from "./ParameterValues.vue";
 import RunOptions from "./RunOptions.vue";
 import LinkData from "./LinkData.vue";
-import {AppType} from "../../store/appState/state";
+import { AppType } from "../../store/appState/state";
 
 export default {
     name: "OptionsTab",
@@ -36,7 +36,6 @@ export default {
         return {
             isFit
         };
-
     }
 };
 </script>

--- a/app/static/src/app/csvUpload.ts
+++ b/app/static/src/app/csvUpload.ts
@@ -8,6 +8,8 @@ import { SetDataPayload } from "./store/fitData/mutations";
 
 type OnError = (error: Error) => void;
 type OnSuccess = (success: SetDataPayload) => void;
+type PostSuccess = () => void;
+
 interface ParseError {
     message: string
 }
@@ -18,6 +20,8 @@ export class CSVUpload<S extends string, E extends string> {
     private _onError: OnError | null = null;
 
     private _onSuccess: OnSuccess | null = null;
+
+    private _postSuccess: PostSuccess | null = null;
 
     constructor(context: AppCtx) {
         this._commit = context.commit;
@@ -34,6 +38,11 @@ export class CSVUpload<S extends string, E extends string> {
         this._onSuccess = (success: SetDataPayload) => {
             this._commit(type, success);
         };
+        return this;
+    };
+
+    then = (postSuccess: PostSuccess) => {
+        this._postSuccess = postSuccess;
         return this;
     };
 
@@ -67,6 +76,9 @@ export class CSVUpload<S extends string, E extends string> {
                         if (!dataError && processResult?.data) {
                             if (this._onSuccess) {
                                 this._onSuccess(processResult);
+                            }
+                            if (this._postSuccess) {
+                                this._postSuccess();
                             }
                         } else if (this._onError) {
                             this._onError(dataError!);

--- a/app/static/src/app/settings.ts
+++ b/app/static/src/app/settings.ts
@@ -1,4 +1,5 @@
 export default {
     minFitDataRows: 5,
+    minFitDataColumns: 2,
     displayFitDataNonNumericValues: 3
 };

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -2,10 +2,16 @@ import { CodeState } from "../code/state";
 import { ModelState } from "../model/state";
 import { AppConfig } from "../../types/responseTypes";
 
+export enum AppType {
+    Basic = "basic",
+    Fit = "fit",
+    Stochastic = "stochastic"
+}
+
 export interface AppState {
     config: null | AppConfig,
     appName: null | string,
-    appType: string
+    appType: AppType
     code: CodeState
     model: ModelState
 }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -6,7 +6,7 @@ import { BasicState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
 import { logMutations } from "../plugins";
-import {AppType} from "../appState/state";
+import { AppType } from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -6,11 +6,12 @@ import { BasicState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
 import { logMutations } from "../plugins";
+import {AppType} from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        appType: "basic",
+        appType: AppType.Basic,
         appName: null,
         config: null
     };

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -7,6 +7,7 @@ import { model } from "../model/model";
 import { code } from "../code/code";
 import { fitData } from "../fitData/fitData";
 import { AppType } from "../appState/state";
+import { logMutations } from "../plugins";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
@@ -26,5 +27,8 @@ export const storeOptions: StoreOptions<FitState> = {
         code,
         model,
         fitData
-    }
+    },
+    plugins: [
+        logMutations
+    ]
 };

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -6,11 +6,12 @@ import { FitState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
 import { fitData } from "../fitData/fitData";
+import {AppType} from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        appType: "fit",
+        appType: AppType.Fit,
         appName: null,
         config: null
     };

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -6,7 +6,7 @@ import { FitState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
 import { fitData } from "../fitData/fitData";
-import {AppType} from "../appState/state";
+import { AppType } from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -17,6 +17,7 @@ export enum FitDataAction {
 const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) => {
     // This is called whenever new data is uploaded, or selected time variable changes, or the model changes, which
     // may partially or fully invalidate any existing links. We retain any we can from previous selection.
+    // Empty string means no link
     const {commit, state, rootState, getters} = context;
     const modelResponse = rootState.model.odinModelResponse;
     const modelVariables = modelResponse?.valid ? modelResponse.metadata.variables : [];

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -1,12 +1,12 @@
 import { parse } from "csv-parse";
-import {ActionTree, ActionContext} from "vuex";
+import { ActionTree, ActionContext } from "vuex";
 import { FitDataState } from "./state";
 import { Error } from "../../types/responseTypes";
 import { FitDataMutation } from "./mutations";
 import { processFitData, ProcessFitDataResult } from "../../utils";
 import userMessages from "../../userMessages";
-import {FitState} from "../fit/state";
-import {Dict} from "../../types/utilTypes";
+import { FitState } from "../fit/state";
+import { Dict } from "../../types/utilTypes";
 
 export enum FitDataAction {
     Upload = "Upload",
@@ -18,7 +18,9 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     // This is called whenever new data is uploaded, or selected time variable changes, or the model changes, which
     // may partially or fully invalidate any existing links. We retain any we can from previous selection.
     // Empty string means no link
-    const {commit, state, rootState, getters} = context;
+    const {
+        commit, state, rootState, getters
+    } = context;
     const modelResponse = rootState.model.odinModelResponse;
     const modelVariables = modelResponse?.valid ? modelResponse.metadata.variables : [];
     const dataColumns = getters.nonTimeColumns;
@@ -27,7 +29,7 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
         newLinks = dataColumns.reduce((links: Dict<string | null>, column: string) => {
             const existingLink = state.linkedVariables[column];
             const value = (existingLink && modelVariables.includes(existingLink)) ? existingLink : null;
-            return {...links, [column]: value};
+            return { ...links, [column]: value };
         }, {});
     }
     commit(FitDataMutation.SetLinkedVariables, newLinks);

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -1,18 +1,39 @@
 import { parse } from "csv-parse";
-import { ActionTree } from "vuex";
-import { AppState } from "../appState/state";
+import {ActionTree, ActionContext} from "vuex";
 import { FitDataState } from "./state";
 import { Error } from "../../types/responseTypes";
 import { FitDataMutation } from "./mutations";
 import { processFitData, ProcessFitDataResult } from "../../utils";
 import userMessages from "../../userMessages";
+import {FitState} from "../fit/state";
+import {Dict} from "../../types/utilTypes";
 
 export enum FitDataAction {
-    Upload = "Upload"
+    Upload = "Upload",
+    UpdateTimeVariable = "UpdateTimeVariable",
+    UpdateLinkedVariables = "UpdateLinkedVariables"
 }
 
-export const actions: ActionTree<FitDataState, AppState> = {
-    Upload(context, file) {
+const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) => {
+    // This is called whenever new data is uploaded, or selected time variable changes, or the model changes, which
+    // may partially or fully invalidate any existing links. We retain any we can from previous selection.
+    const {commit, state, rootState, getters} = context;
+    const modelResponse = rootState.model.odinModelResponse;
+    const modelVariables = modelResponse?.valid ? modelResponse.metadata.variables : [];
+    const dataColumns = getters.nonTimeColumns;
+    let newLinks = {};
+    if (dataColumns) {
+        newLinks = dataColumns.reduce((links: Dict<string | null>, column: string) => {
+            const existingLink = state.linkedVariables[column];
+            const value = (existingLink && modelVariables.includes(existingLink)) ? existingLink : null;
+            return {...links, [column]: value};
+        }, {});
+    }
+    commit(FitDataMutation.SetLinkedVariables, newLinks);
+};
+
+export const actions: ActionTree<FitDataState, FitState> = {
+    [FitDataAction.Upload](context, file) {
         const { commit } = context;
         if (file) {
             const reader = new FileReader();
@@ -35,6 +56,7 @@ export const actions: ActionTree<FitDataState, AppState> = {
                                 columns,
                                 timeVariableCandidates: processResult.timeVariableCandidates
                             });
+                            updateLinkedVariables(context);
                         } else {
                             commit(FitDataMutation.SetError, dataError);
                         }
@@ -49,5 +71,15 @@ export const actions: ActionTree<FitDataState, AppState> = {
 
             reader.readAsText(file, "UTF-8");
         }
+    },
+
+    [FitDataAction.UpdateTimeVariable](context, timeVariable) {
+        const { commit } = context;
+        commit(FitDataMutation.SetTimeVariable, timeVariable);
+        updateLinkedVariables(context);
+    },
+
+    [FitDataAction.UpdateLinkedVariables](context) {
+        updateLinkedVariables(context);
     }
 };

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -37,6 +37,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
         csvUpload(context)
             .withSuccess(FitDataMutation.SetData)
             .withError(FitDataMutation.SetError)
+            .then(() => updateLinkedVariables(context))
             .upload(file);
     },
 

--- a/app/static/src/app/store/fitData/fitData.ts
+++ b/app/static/src/app/store/fitData/fitData.ts
@@ -1,21 +1,15 @@
-import { GetterTree } from "vuex";
 import { FitDataState } from "./state";
 import { actions } from "./actions";
 import { mutations } from "./mutations";
-import {AppState} from "../appState/state";
+import { getters } from "./getters";
 
 export const defaultState: FitDataState = {
     data: null,
     columns: null,
     timeVariableCandidates: null,
     timeVariable: null,
+    linkedVariables: {},
     error: null
-};
-
-export const getters: GetterTree<FitDataState, AppState> = {
-    nonTimeColumns: (state: FitDataState) => {
-        return state.columns?.filter((column) => column !== state.timeVariable);
-    }
 };
 
 export const fitData = {

--- a/app/static/src/app/store/fitData/fitData.ts
+++ b/app/static/src/app/store/fitData/fitData.ts
@@ -1,6 +1,8 @@
+import { GetterTree } from "vuex";
 import { FitDataState } from "./state";
 import { actions } from "./actions";
 import { mutations } from "./mutations";
+import {AppState} from "../appState/state";
 
 export const defaultState: FitDataState = {
     data: null,
@@ -10,9 +12,16 @@ export const defaultState: FitDataState = {
     error: null
 };
 
+export const getters: GetterTree<FitDataState, AppState> = {
+    nonTimeColumns: (state: FitDataState) => {
+        return state.columns?.filter((column) => column !== state.timeVariable);
+    }
+};
+
 export const fitData = {
     namespaced: true,
     state: defaultState,
     actions,
-    mutations
+    mutations,
+    getters
 };

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -1,0 +1,13 @@
+import {GetterTree, Getter} from "vuex";
+import {FitDataState} from "./state";
+import {FitState} from "../fit/state";
+
+export interface FitDataGetters {
+    nonTimeColumns: Getter<FitDataState, FitState>
+}
+
+export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
+    nonTimeColumns: (state: FitDataState) => {
+        return state.columns?.filter((column) => column !== state.timeVariable);
+    }
+};

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -1,13 +1,17 @@
-import {GetterTree, Getter} from "vuex";
-import {FitDataState} from "./state";
-import {FitState} from "../fit/state";
+import { GetterTree, Getter } from "vuex";
+import { FitDataState } from "./state";
+import { FitState } from "../fit/state";
+
+export enum FitDataGetter {
+    nonTimeColumns ="nonTimeColumns"
+}
 
 export interface FitDataGetters {
-    nonTimeColumns: Getter<FitDataState, FitState>
+    [FitDataGetter.nonTimeColumns]: Getter<FitDataState, FitState>
 }
 
 export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
-    nonTimeColumns: (state: FitDataState) => {
+    [FitDataGetter.nonTimeColumns]: (state: FitDataState) => {
         return state.columns?.filter((column) => column !== state.timeVariable);
     }
 };

--- a/app/static/src/app/store/fitData/mutations.ts
+++ b/app/static/src/app/store/fitData/mutations.ts
@@ -43,7 +43,6 @@ export const mutations: MutationTree<FitDataState> = {
     },
 
     [FitDataMutation.SetLinkedVariables](state: FitDataState, payload: Dict<string | null>) {
-        console.log("Setting Linked Variables to: " + JSON.stringify(payload))
         state.linkedVariables = payload;
     },
 

--- a/app/static/src/app/store/fitData/mutations.ts
+++ b/app/static/src/app/store/fitData/mutations.ts
@@ -6,13 +6,20 @@ import { Error } from "../../types/responseTypes";
 export enum FitDataMutation {
     SetData = "SetData",
     SetError = "SetError",
-    SetTimeVariable = "SetTimeVariable"
+    SetTimeVariable = "SetTimeVariable",
+    SetLinkedVariables = "SetLinkedVariables",
+    SetLinkedVariable = "SetLinkedVariable"
 }
 
 export interface SetDataPayload {
     data: Dict<number>[] | null,
     columns: string[] | null,
     timeVariableCandidates: string[] | null
+}
+
+export interface SetLinkedVariablePayload {
+    column: string,
+    variable: string | null
 }
 
 export const mutations: MutationTree<FitDataState> = {
@@ -33,5 +40,14 @@ export const mutations: MutationTree<FitDataState> = {
 
     [FitDataMutation.SetTimeVariable](state: FitDataState, payload: string | null) {
         state.timeVariable = payload;
+    },
+
+    [FitDataMutation.SetLinkedVariables](state: FitDataState, payload: Dict<string | null>) {
+        console.log("Setting Linked Variables to: " + JSON.stringify(payload))
+        state.linkedVariables = payload;
+    },
+
+    [FitDataMutation.SetLinkedVariable](state: FitDataState, payload: SetLinkedVariablePayload) {
+        state.linkedVariables[payload.column] = payload.variable;
     }
 };

--- a/app/static/src/app/store/fitData/state.ts
+++ b/app/static/src/app/store/fitData/state.ts
@@ -6,6 +6,6 @@ export interface FitDataState {
     columns: string[] | null,
     timeVariableCandidates: string[] | null,
     timeVariable: string | null
-    linkedVariables: Dict<string| null> // Dict of data column names (keys) to linked model variables (values)
+    linkedVariables: Dict<string | null> // Dict of data column names (keys) to linked model variables (values)
     error: Error | null
 }

--- a/app/static/src/app/store/fitData/state.ts
+++ b/app/static/src/app/store/fitData/state.ts
@@ -6,5 +6,6 @@ export interface FitDataState {
     columns: string[] | null,
     timeVariableCandidates: string[] | null,
     timeVariable: string | null
+    linkedVariables: Dict<string| null> // Dict of data column names (keys) to linked model variables (values)
     error: Error | null
 }

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -2,11 +2,11 @@ import { ActionContext, ActionTree } from "vuex";
 import { ModelState, RequiredModelAction } from "./state";
 import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
-import {AppState, AppType} from "../appState/state";
+import { AppState, AppType } from "../appState/state";
 import { ErrorsMutation } from "../errors/mutations";
 import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
-import {FitDataAction} from "../fitData/actions";
+import { FitDataAction } from "../fitData/actions";
 
 export enum ModelAction {
     FetchOdinRunner = "FetchOdinRunner",
@@ -30,7 +30,9 @@ const fetchOdin = async (context: ActionContext<ModelState, AppState>) => {
 };
 
 const compileModel = (context: ActionContext<ModelState, AppState>) => {
-    const { commit, state, rootState, dispatch } = context;
+    const {
+        commit, state, rootState, dispatch
+    } = context;
     if (state.odinModelResponse) {
         const odin = evaluateScript<Odin>(state.odinModelResponse.model);
         commit(ModelMutation.SetOdin, odin);
@@ -51,7 +53,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         if (rootState.appType === AppType.Fit) {
             // initialise data links
-            dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, {root: true});
+            dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, { root: true });
         }
     }
 };

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -8,6 +8,7 @@ import { ErrorsMutation } from "../errors/mutations";
 import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
 import { Dict } from "../../types/utilTypes";
+import {FitDataAction} from "../fitData/actions";
 
 export enum ModelAction {
     FetchOdinRunner = "FetchOdinRunner",
@@ -31,7 +32,7 @@ const fetchOdin = async (context: ActionContext<ModelState, AppState>) => {
 };
 
 const compileModel = (context: ActionContext<ModelState, AppState>) => {
-    const { commit, state } = context;
+    const { commit, state, rootState, dispatch } = context;
     if (state.odinModelResponse) {
         const odin = evaluateScript<Odin>(state.odinModelResponse.model);
         commit(ModelMutation.SetOdin, odin);
@@ -48,6 +49,11 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         if (state.requiredAction === RequiredModelAction.Compile) {
             commit(ModelMutation.SetRequiredAction, RequiredModelAction.Run);
+        }
+
+        if (rootState.appType === "fit") {
+            // initialise data links
+            dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, {root: true});
         }
     }
 };

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -3,7 +3,7 @@ import { ActionContext, ActionTree } from "vuex";
 import { ModelState, RequiredModelAction } from "./state";
 import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
-import { AppState } from "../appState/state";
+import {AppState, AppType} from "../appState/state";
 import { ErrorsMutation } from "../errors/mutations";
 import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
@@ -51,7 +51,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
             commit(ModelMutation.SetRequiredAction, RequiredModelAction.Run);
         }
 
-        if (rootState.appType === "fit") {
+        if (rootState.appType === AppType.Fit) {
             // initialise data links
             dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, {root: true});
         }

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -5,11 +5,12 @@ import { errors } from "../errors/errors";
 import { StochasticState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
+import {AppType} from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        appType: "stochastic",
+        appType: AppType.Stochastic,
         appName: null,
         config: null
     };

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -5,7 +5,7 @@ import { errors } from "../errors/errors";
 import { StochasticState } from "./state";
 import { model } from "../model/model";
 import { code } from "../code/code";
-import {AppType} from "../appState/state";
+import { AppType } from "../appState/state";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -9,8 +9,10 @@ export default {
         errorLoadingData: "An error occurred when loading data",
         errorReadingFile: "An error occurred when reading data file",
         tooFewRows: `File must contain at least ${settings.minFitDataRows} data rows.`,
+        tooFewColumns: `File must contain at least ${settings.minFitDataColumns} columns`,
         nonNumericValues: "Data contains non-numeric values",
-        noTimeVariables: "Data contains no suitable time variable. A time variable must strictly increase per row."
+        noTimeVariables: "Data contains no suitable time variable. A time variable must strictly increase per row.",
+        linkPrerequisites: "Please upload data and compile model in order to select links."
     },
     run: {
         compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -12,7 +12,11 @@ export default {
         tooFewColumns: `File must contain at least ${settings.minFitDataColumns} columns.`,
         nonNumericValues: "Data contains non-numeric values",
         noTimeVariables: "Data contains no suitable time variable. A time variable must strictly increase per row.",
-        linkPrerequisites: "Please upload data and compile model in order to select links."
+        linkPrerequisites: {
+            prefix: "Please complete the following in order to select links:",
+            data: "Upload valid data",
+            model: "Compile model"
+        }
     },
     run: {
         compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -9,7 +9,7 @@ export default {
         errorLoadingData: "An error occurred when loading data",
         errorReadingFile: "An error occurred when reading data file",
         tooFewRows: `File must contain at least ${settings.minFitDataRows} data rows.`,
-        tooFewColumns: `File must contain at least ${settings.minFitDataColumns} columns`,
+        tooFewColumns: `File must contain at least ${settings.minFitDataColumns} columns.`,
         nonNumericValues: "Data contains non-numeric values",
         noTimeVariables: "Data contains no suitable time variable. A time variable must strictly increase per row.",
         linkPrerequisites: "Please upload data and compile model in order to select links."

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -37,6 +37,9 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
     if (data.length < settings.minFitDataRows) {
         return { ...emptyResult, error: { error: errorMsg, detail: userMessages.fitData.tooFewRows } };
     }
+    if (Object.keys(data[0]).length < settings.minFitDataColumns) {
+        return { ...emptyResult, error: {error: errorMsg, detail: userMessages.fitData.tooFewColumns} }
+    }
     const nonNumValues: string[] = [];
 
     const processedData = data.map((row) => {

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -38,7 +38,7 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
         return { ...emptyResult, error: { error: errorMsg, detail: userMessages.fitData.tooFewRows } };
     }
     if (Object.keys(data[0]).length < settings.minFitDataColumns) {
-        return { ...emptyResult, error: {error: errorMsg, detail: userMessages.fitData.tooFewColumns} }
+        return { ...emptyResult, error: { error: errorMsg, detail: userMessages.fitData.tooFewColumns } };
     }
     const nonNumValues: string[] = [];
 

--- a/app/static/tests/e2e/data.etest.ts
+++ b/app/static/tests/e2e/data.etest.ts
@@ -1,6 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
-import {uploadCSVData} from "./utils";
+import { uploadCSVData } from "./utils";
 
 test.describe("Data tab tests", () => {
     const { timeout } = PlaywrightConfig;

--- a/app/static/tests/e2e/data.etest.ts
+++ b/app/static/tests/e2e/data.etest.ts
@@ -1,5 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
+import {uploadCSVData} from "./utils";
 
 test.describe("Data tab tests", () => {
     const { timeout } = PlaywrightConfig;
@@ -7,15 +8,6 @@ test.describe("Data tab tests", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/apps/day2");
     });
-
-    const uploadCSVData = async (page: Page, data: string) => {
-        const file = {
-            name: "file.csv",
-            mimeType: "text/plain",
-            buffer: Buffer.from(data)
-        };
-        await page.setInputFiles("#fitDataUpload", file);
-    };
 
     test("can upload valid csv file", async ({ page }) => {
         await uploadCSVData(page, "a,b\n1,2\n3,4\n5,6\n7,8\n9,10");

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -1,7 +1,7 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
-import {uploadCSVData} from "./utils";
-import {newValidCode} from "./code.etest";
+import { uploadCSVData } from "./utils";
+import { newValidCode } from "./code.etest";
 
 export const newVariableCode = `# variables
 deriv(S) <-  - beta * S * J / N
@@ -19,9 +19,9 @@ sigma <- user(2)
 `;
 
 test.describe("Link Variables tests", () => {
-    const {timeout} = PlaywrightConfig;
+    const { timeout } = PlaywrightConfig;
 
-    test.beforeEach(async ({page}) => {
+    test.beforeEach(async ({ page }) => {
         await page.goto("/apps/day2");
         uploadCSVData(page, "Day,Cases,Admissions\n1,2,1\n3,4,2\n5,6,3\n7,8,4\n9,10,5");
     });
@@ -35,7 +35,7 @@ test.describe("Link Variables tests", () => {
         await select2.selectOption("R");
     };
 
-    test("displays expected link interface after data upload", async ({page}) => {
+    test("displays expected link interface after data upload", async ({ page }) => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
         await expect(await page.innerText(":nth-match(.collapse-title, 1)")).toBe("Link");
         const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
@@ -57,7 +57,7 @@ test.describe("Link Variables tests", () => {
         await expect(await options2.allInnerTexts()).toStrictEqual(expectedVariableOptions);
     });
 
-    test("can change link variables selections, which are retained on tab change", async ({page}) => {
+    test("can change link variables selections, which are retained on tab change", async ({ page }) => {
         await makeInitialLinkSelections(page);
 
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
@@ -68,7 +68,7 @@ test.describe("Link Variables tests", () => {
         await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
     });
 
-    test("link variables selections are retained on upload new data where possible", async ({page}) => {
+    test("link variables selections are retained on upload new data where possible", async ({ page }) => {
         await makeInitialLinkSelections(page);
 
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
@@ -81,7 +81,7 @@ test.describe("Link Variables tests", () => {
         await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("");
     });
 
-    test("link variables selections are retained on select new time variable where possible", async ({page}) => {
+    test("link variables selections are retained on select new time variable where possible", async ({ page }) => {
         await makeInitialLinkSelections(page);
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
         await page.selectOption("#select-time-variable", "Cases");
@@ -93,7 +93,7 @@ test.describe("Link Variables tests", () => {
         await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
     });
 
-    test("link variables selections are retained on recompile code where possible", async ({page}) => {
+    test("link variables selections are retained on recompile code where possible", async ({ page }) => {
         await makeInitialLinkSelections(page);
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
 

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -1,7 +1,22 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
 import {uploadCSVData} from "./utils";
+import {newValidCode} from "./code.etest";
 
+export const newVariableCode = `# variables
+deriv(S) <-  - beta * S * J / N
+deriv(J) <- beta * S * J / N - sigma * J
+deriv(R) <- sigma * J
+# initial conditions
+initial(S) <- N - I0
+initial(J) <- I0
+initial(R) <- 0
+# parameters
+N <- user(1e6)
+I0 <- user(1)
+beta <- user(4)
+sigma <- user(2)
+`;
 
 test.describe("Link Variables tests", () => {
     const {timeout} = PlaywrightConfig;
@@ -10,6 +25,15 @@ test.describe("Link Variables tests", () => {
         await page.goto("/apps/day2");
         uploadCSVData(page, "Day,Cases,Admissions\n1,2,1\n3,4,2\n5,6,3\n7,8,4\n9,10,5");
     });
+
+    const makeInitialLinkSelections = async (page: Page) => {
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+        const select1 = await linkContainer.locator(":nth-match(select, 1)");
+        await select1.selectOption("I");
+        const select2 = await linkContainer.locator(":nth-match(select, 2)");
+        await select2.selectOption("R");
+    };
 
     test("displays expected link interface after data upload", async ({page}) => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
@@ -34,12 +58,7 @@ test.describe("Link Variables tests", () => {
     });
 
     test("can change link variables selections, which are retained on tab change", async ({page}) => {
-        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
-        const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
-        const select1 = await linkContainer.locator(":nth-match(select, 1)");
-        await select1.selectOption("I");
-        const select2 = await linkContainer.locator(":nth-match(select, 2)");
-        await select2.selectOption("R");
+        await makeInitialLinkSelections(page);
 
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
         await expect(await page.innerText("h3")).toBe("Upload data");
@@ -47,5 +66,69 @@ test.describe("Link Variables tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
         await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("I");
         await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
+    });
+
+    test("link variables selections are retained on upload new data where possible", async ({page}) => {
+        await makeInitialLinkSelections(page);
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+        uploadCSVData(page, "Day,Cases,AdmissionsNew\n1,2,1\n3,4,2\n5,6,3\n7,8,4\n9,10,5");
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await expect(await page.innerText(":nth-match(.collapse label, 1)")).toBe("Cases");
+        await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("I");
+        await expect(await page.innerText(":nth-match(.collapse label, 2)")).toBe("AdmissionsNew");
+        await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("");
+    });
+
+    test("link variables selections are retained on select new time variable where possible", async ({page}) => {
+        await makeInitialLinkSelections(page);
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+        await page.selectOption("#select-time-variable", "Cases");
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await expect(await page.innerText(":nth-match(.collapse label, 1)")).toBe("Day");
+        await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("");
+        await expect(await page.innerText(":nth-match(.collapse label, 2)")).toBe("Admissions");
+        await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
+    });
+
+    test("link variables selections are retained on recompile code where possible", async ({page}) => {
+        await makeInitialLinkSelections(page);
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+
+        // new code replaces I variable with J
+        await page.press(".monaco-editor textarea", "Control+A");
+        await page.press(".monaco-editor textarea", "Delete");
+        await page.fill(".monaco-editor textarea", newVariableCode);
+
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+                timeout
+            }
+        );
+        await page.click("#compile-btn");
+        await expect(await page.locator(".run-tab .run-update-msg")).toHaveText(
+            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+                timeout
+            }
+        );
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await expect(await page.innerText(":nth-match(.collapse label, 1)")).toBe("Cases");
+        await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("");
+        await expect(await page.innerText(":nth-match(.collapse label, 2)")).toBe("Admissions");
+        await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
+
+        const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+        const select1 = await linkContainer.locator(":nth-match(select, 1)");
+        const options1 = await select1.locator("option");
+        const expectedVariableOptions = ["-- no link --", "S", "J", "R"];
+        await expect(options1).toHaveCount(4);
+        await expect(await options1.allInnerTexts()).toStrictEqual(expectedVariableOptions);
+        const select2 = await linkContainer.locator(":nth-match(select, 2)");
+        const options2 = await select2.locator("option");
+        await expect(options2).toHaveCount(4);
+        await expect(await options2.allInnerTexts()).toStrictEqual(expectedVariableOptions);
     });
 });

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -1,0 +1,18 @@
+import { expect, test, Page } from "@playwright/test";
+import PlaywrightConfig from "../../playwright.config";
+import {uploadCSVData} from "./utils";
+
+
+test.describe("Link Variables tests", () => {
+    const {timeout} = PlaywrightConfig;
+
+    test.beforeEach(async ({page}) => {
+        await page.goto("/apps/day2");
+        uploadCSVData(page, "Day,Cases,Admissions\n1,2,1\n3,4,2\n5,6,3\n7,8,4\n9,10,5");
+    });
+
+    test("displays expected link interface after data upload", async ({page}) => {
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+
+    });
+});

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -12,7 +12,40 @@ test.describe("Link Variables tests", () => {
     });
 
     test("displays expected link interface after data upload", async ({page}) => {
-        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await expect(await page.innerText(":nth-match(.collapse-title, 1)")).toBe("Link");
+        const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+        const rows = await linkContainer.locator(".row");
+        await expect(rows).toHaveCount(2);
+        await expect(await page.innerText(":nth-match(.collapse label, 1)")).toBe("Cases");
+        await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("");
+        const select1 = await linkContainer.locator(":nth-match(select, 1)");
+        const options1 = await select1.locator("option");
+        const expectedVariableOptions = ["-- no link --", "S", "I", "R"];
+        await expect(options1).toHaveCount(4);
+        await expect(await options1.allInnerTexts()).toStrictEqual(expectedVariableOptions);
 
+        await expect(await page.innerText(":nth-match(.collapse label, 2)")).toBe("Admissions");
+        await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("");
+        const select2 = await linkContainer.locator(":nth-match(select, 2)");
+        const options2 = await select2.locator("option");
+        await expect(options2).toHaveCount(4);
+        await expect(await options2.allInnerTexts()).toStrictEqual(expectedVariableOptions);
+    });
+
+    test("can change link variables selections, which are retained on tab change", async ({page}) => {
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+        const select1 = await linkContainer.locator(":nth-match(select, 1)");
+        await select1.selectOption("I");
+        const select2 = await linkContainer.locator(":nth-match(select, 2)");
+        await select2.selectOption("R");
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+        await expect(await page.innerText("h3")).toBe("Upload data");
+
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await expect(await page.inputValue(":nth-match(.collapse select, 1)")).toBe("I");
+        await expect(await page.inputValue(":nth-match(.collapse select, 2)")).toBe("R");
     });
 });

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -1,4 +1,4 @@
-import {Page} from "@playwright/test";
+import { Page } from "@playwright/test";
 
 export const uploadCSVData = async (page: Page, data: string) => {
     const file = {

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -1,0 +1,10 @@
+import {Page} from "@playwright/test";
+
+export const uploadCSVData = async (page: Page, data: string) => {
+    const file = {
+        name: "file.csv",
+        mimeType: "text/plain",
+        buffer: Buffer.from(data)
+    };
+    await page.setInputFiles("#fitDataUpload", file);
+};

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -7,7 +7,7 @@ import { ResponseSuccess, ResponseFailure, Error } from "../src/app/types/respon
 import { ModelState } from "../src/app/store/model/state";
 import { CodeState } from "../src/app/store/code/state";
 import { FitDataState } from "../src/app/store/fitData/state";
-import {AppType} from "../src/app/store/appState/state";
+import { AppType } from "../src/app/store/appState/state";
 
 export const mockAxios = new MockAdapter(axios);
 

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -6,8 +6,8 @@ import { StochasticState } from "../src/app/store/stochastic/state";
 import { ResponseSuccess, ResponseFailure, Error } from "../src/app/types/responseTypes";
 import { ModelState } from "../src/app/store/model/state";
 import { CodeState } from "../src/app/store/code/state";
-import mock = jest.mock;
 import { FitDataState } from "../src/app/store/fitData/state";
+import {AppType} from "../src/app/store/appState/state";
 
 export const mockAxios = new MockAdapter(axios);
 
@@ -63,13 +63,14 @@ export const mockFitDataState = (state:Partial<FitDataState> = {}): FitDataState
         error: null,
         timeVariableCandidates: null,
         timeVariable: null,
+        linkedVariables: {},
         ...state
     };
 };
 
 export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
     return {
-        appType: "basic",
+        appType: AppType.Basic,
         appName: "",
         config: {
             basicProp: "",
@@ -83,7 +84,7 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
 
 export const mockFitState = (state: Partial<FitState> = {}): FitState => {
     return {
-        appType: "fit",
+        appType: AppType.Fit,
         appName: "",
         config: {
             fitProp: "",
@@ -97,7 +98,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
 
 export const mockStochasticState = (state: Partial<StochasticState> = {}): StochasticState => {
     return {
-        appType: "stochastic",
+        appType: AppType.Stochastic,
         appName: "",
         config: {
             stochasticProp: "",

--- a/app/static/tests/unit/components/data/dataTab.test.ts
+++ b/app/static/tests/unit/components/data/dataTab.test.ts
@@ -102,4 +102,18 @@ describe("Data Tab", () => {
         expect(mockUpdateTimeVar).toHaveBeenCalledTimes(1);
         expect(mockUpdateTimeVar.mock.calls[0][1]).toBe("a");
     });
+
+    it("clears input value on click", async () => {
+        const wrapper = getWrapper();
+        const input = wrapper.find("input");
+        const el = (input.element as HTMLInputElement);
+        const mockSetValue = jest.fn();
+        Object.defineProperty(el, "value", {
+            get: jest.fn().mockReturnValue("testFile.csv"),
+            set: mockSetValue
+        });
+        await input.trigger("click");
+        expect(mockSetValue).toHaveBeenCalledTimes(1);
+        expect(mockSetValue.mock.calls[0][0]).toBe("");
+    });
 });

--- a/app/static/tests/unit/components/data/dataTab.test.ts
+++ b/app/static/tests/unit/components/data/dataTab.test.ts
@@ -11,7 +11,7 @@ describe("Data Tab", () => {
     const getWrapper = (
         state: Partial<FitDataState> = {},
         mockUpload = jest.fn(),
-        mockSetTimeVariable = jest.fn()
+        mockUpdateTimeVariable = jest.fn()
     ) => {
         const store = new Vuex.Store<FitState>({
             state: mockFitState(),
@@ -20,10 +20,8 @@ describe("Data Tab", () => {
                     namespaced: true,
                     state: mockFitDataState(state),
                     actions: {
-                        Upload: mockUpload
-                    },
-                    mutations: {
-                        SetTimeVariable: mockSetTimeVariable
+                        Upload: mockUpload,
+                        UpdateTimeVariable: mockUpdateTimeVariable
                     }
                 }
             }
@@ -87,21 +85,21 @@ describe("Data Tab", () => {
         expect(mockUpload.mock.calls[0][1]).toBe(mockFile);
     });
 
-    it("commits SetTimeVariable when select changes", async () => {
+    it("dispatches UpdateTimeVariable when select changes", async () => {
         const data = [{ a: 1, b: 2, c: 3 }, { a: 2, b: 3, c: -4 }];
         const columns = ["a", "b", "c"];
         const timeVariableCandidates = ["a", "b"];
         const timeVariable = "b";
-        const mockSetTimeVar = jest.fn();
+        const mockUpdateTimeVar = jest.fn();
         const wrapper = getWrapper({
             data, columns, timeVariableCandidates, timeVariable
-        }, jest.fn(), mockSetTimeVar);
+        }, jest.fn(), mockUpdateTimeVar);
 
         const select = wrapper.find("#time-variable select");
         (select.element as HTMLSelectElement).value = "a";
         await select.trigger("change");
 
-        expect(mockSetTimeVar).toHaveBeenCalledTimes(1);
-        expect(mockSetTimeVar.mock.calls[0][1]).toBe("a");
+        expect(mockUpdateTimeVar).toHaveBeenCalledTimes(1);
+        expect(mockUpdateTimeVar.mock.calls[0][1]).toBe("a");
     });
 });

--- a/app/static/tests/unit/components/options/linkData.test.ts
+++ b/app/static/tests/unit/components/options/linkData.test.ts
@@ -94,7 +94,7 @@ describe("LinkData", () => {
         (admissionsSelect.element as HTMLSelectElement).value = "R";
         await admissionsSelect.trigger("change");
         expect(mockSetLinkedVariable).toHaveBeenCalledTimes(1);
-        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({column: "Admissions", variable: "R"});
+        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({ column: "Admissions", variable: "R" });
     });
 
     it("updates linked variable on select no link", async () => {
@@ -104,7 +104,7 @@ describe("LinkData", () => {
         (casesSelect.element as HTMLSelectElement).value = "";
         await casesSelect.trigger("change");
         expect(mockSetLinkedVariable).toHaveBeenCalledTimes(1);
-        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({column: "Cases", variable: null});
+        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({ column: "Cases", variable: null });
     });
 
     it("renders as expected when data has not been uploaded", () => {

--- a/app/static/tests/unit/components/options/linkData.test.ts
+++ b/app/static/tests/unit/components/options/linkData.test.ts
@@ -59,10 +59,10 @@ describe("LinkData", () => {
         expect(options[3].value).toBe("R");
     };
 
-    const checkCannotLink = (wrapper: VueWrapper<any>) => {
+    const checkCannotLink = (wrapper: VueWrapper<any>, expectedMessage: string) => {
         const rows = wrapper.findAll(".row");
         expect(rows.length).toBe(1);
-        expect(rows.at(0)!.text()).toBe("Please upload data and compile model in order to select links.");
+        expect(rows.at(0)!.text()).toBe(expectedMessage);
         expect(wrapper.find("label").exists()).toBe(false);
         expect(wrapper.find("select").exists()).toBe(false);
     };
@@ -109,16 +109,19 @@ describe("LinkData", () => {
 
     it("renders as expected when data has not been uploaded", () => {
         const wrapper = getWrapper(false, true);
-        checkCannotLink(wrapper);
+        checkCannotLink(wrapper,
+            "Please complete the following in order to select links: Upload valid data");
     });
 
     it("renders as expected when model has not been compiled", () => {
         const wrapper = getWrapper(true, false);
-        checkCannotLink(wrapper);
+        checkCannotLink(wrapper,
+            "Please complete the following in order to select links: Compile model");
     });
 
     it("renders as expected without neither data nor compiled data", () => {
         const wrapper = getWrapper(false, false);
-        checkCannotLink(wrapper);
+        checkCannotLink(wrapper,
+            "Please complete the following in order to select links: Upload valid data, Compile model");
     });
 });

--- a/app/static/tests/unit/components/options/linkData.test.ts
+++ b/app/static/tests/unit/components/options/linkData.test.ts
@@ -1,0 +1,124 @@
+import { shallowMount, VueWrapper } from "@vue/test-utils";
+import Vuex from "vuex";
+import LinkData from "../../../../src/app/components/options/LinkData.vue";
+import { FitState } from "../../../../src/app/store/fit/state";
+import { getters } from "../../../../src/app/store/fitData/getters";
+import { FitDataMutation } from "../../../../src/app/store/fitData/mutations";
+import { mockFitDataState, mockFitState, mockModelState } from "../../../mocks";
+
+describe("LinkData", () => {
+    const getWrapper = (includeColumns = true, includeValidModel = true, mockSetLinkedVariable = jest.fn()) => {
+        const store = new Vuex.Store<FitState>({
+            state: mockFitState(),
+            modules: {
+                fitData: {
+                    namespaced: true,
+                    state: mockFitDataState({
+                        columns: includeColumns ? ["Day", "Cases", "Admissions"] : null,
+                        timeVariable: includeColumns ? "Day" : null,
+                        linkedVariables: includeColumns && includeColumns ? {
+                            Cases: "I",
+                            Admissions: null
+                        } : {}
+                    }),
+                    getters,
+                    mutations: {
+                        [FitDataMutation.SetLinkedVariable]: mockSetLinkedVariable
+                    }
+                },
+                model: {
+                    namespaced: true,
+                    state: mockModelState({
+                        odinModelResponse: {
+                            valid: includeValidModel,
+                            metadata: {
+                                variables: includeValidModel ? ["S", "I", "R"] : []
+                            }
+                        } as any
+                    })
+                }
+            }
+        });
+        return shallowMount(LinkData, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    const checkExpectedSelectOptions = (select: HTMLSelectElement) => {
+        const { options } = select;
+        expect(options.length).toBe(4);
+        expect(options[0].text).toBe("-- no link --");
+        expect(options[0].value).toBe("");
+        expect(options[1].text).toBe("S");
+        expect(options[1].value).toBe("S");
+        expect(options[2].text).toBe("I");
+        expect(options[2].value).toBe("I");
+        expect(options[3].text).toBe("R");
+        expect(options[3].value).toBe("R");
+    };
+
+    const checkCannotLink = (wrapper: VueWrapper<any>) => {
+        const rows = wrapper.findAll(".row");
+        expect(rows.length).toBe(1);
+        expect(rows.at(0)!.text()).toBe("Please upload data and compile model in order to select links.");
+        expect(wrapper.find("label").exists()).toBe(false);
+        expect(wrapper.find("select").exists()).toBe(false);
+    };
+
+    it("renders as expected when data can be linked", () => {
+        const wrapper = getWrapper();
+        const rows = wrapper.findAll(".row");
+        expect(rows.length).toBe(2);
+
+        expect(rows.at(0)!.find("label").text()).toBe("Cases");
+        const select1 = rows.at(0)!.find("select").element as HTMLSelectElement;
+        expect(select1.selectedOptions.length).toBe(1);
+        expect(select1.selectedOptions[0].text).toBe("I");
+        expect(select1.value).toBe("I");
+        checkExpectedSelectOptions(select1);
+
+        expect(rows.at(1)!.find("label").text()).toBe("Admissions");
+        const select2 = rows.at(1)!.find("select").element as HTMLSelectElement;
+        expect(select2.selectedOptions.length).toBe(1);
+        expect(select2.selectedOptions[0].text).toBe("-- no link --");
+        expect(select2.value).toBe("");
+        checkExpectedSelectOptions(select2);
+    });
+
+    it("updates linked variable on select variable", async () => {
+        const mockSetLinkedVariable = jest.fn();
+        const wrapper = getWrapper(true, true, mockSetLinkedVariable);
+        const admissionsSelect = wrapper.findAll("select").at(1)!;
+        (admissionsSelect.element as HTMLSelectElement).value = "R";
+        await admissionsSelect.trigger("change");
+        expect(mockSetLinkedVariable).toHaveBeenCalledTimes(1);
+        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({column: "Admissions", variable: "R"});
+    });
+
+    it("updates linked variable on select no link", async () => {
+        const mockSetLinkedVariable = jest.fn();
+        const wrapper = getWrapper(true, true, mockSetLinkedVariable);
+        const casesSelect = wrapper.findAll("select").at(0)!;
+        (casesSelect.element as HTMLSelectElement).value = "";
+        await casesSelect.trigger("change");
+        expect(mockSetLinkedVariable).toHaveBeenCalledTimes(1);
+        expect(mockSetLinkedVariable.mock.calls[0][1]).toStrictEqual({column: "Cases", variable: null});
+    });
+
+    it("renders as expected when data has not been uploaded", () => {
+        const wrapper = getWrapper(false, true);
+        checkCannotLink(wrapper);
+    });
+
+    it("renders as expected when model has not been compiled", () => {
+        const wrapper = getWrapper(true, false);
+        checkCannotLink(wrapper);
+    });
+
+    it("renders as expected without neither data nor compiled data", () => {
+        const wrapper = getWrapper(false, false);
+        checkCannotLink(wrapper);
+    });
+});

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -35,7 +35,7 @@ describe("OptionsTab", () => {
             state: {
                 appType: AppType.Fit,
                 model: {
-                    parameterValues: {}
+                    parameterValues: new Map<string, number>()
                 }
             } as any
         });

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -4,12 +4,16 @@ import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
 import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vue";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
 import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
+import LinkData from "../../../../src/app/components/options/LinkData.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
+import {FitState} from "../../../../src/app/store/fit/state";
+import {AppType} from "../../../../src/app/store/appState/state";
 
 describe("OptionsTab", () => {
-    it("renders as expected", () => {
+    it("renders as expected for Basic app", () => {
         const store = new Vuex.Store<BasicState>({
             state: {
+                appType: AppType.Basic,
                 model: {
                     parameterValues: {}
                 }
@@ -17,11 +21,35 @@ describe("OptionsTab", () => {
         });
         const wrapper = mount(OptionsTab, { global: { plugins: [store] } });
         const collapses = wrapper.findAllComponents(VerticalCollapse);
+        expect(collapses.length).toBe(2);
         expect(collapses.at(0)!.props("title")).toBe("Model Parameters");
         expect(collapses.at(0)!.props("collapseId")).toBe("model-params");
         expect(collapses.at(0)!.findComponent(ParameterValues).exists()).toBe(true);
         expect(collapses.at(1)!.props("title")).toBe("Run Options");
         expect(collapses.at(1)!.props("collapseId")).toBe("run-options");
         expect(collapses.at(1)!.findComponent(RunOptions).exists()).toBe(true);
+    });
+
+    it("renders as expected for Fit app", () => {
+        const store = new Vuex.Store<FitState>({
+            state: {
+                appType: AppType.Fit,
+                model: {
+                    parameterValues: {}
+                }
+            } as any
+        });
+        const wrapper = mount(OptionsTab, { global: { plugins: [store] } });
+        const collapses = wrapper.findAllComponents(VerticalCollapse);
+        expect(collapses.length).toBe(3);
+        expect(collapses.at(0)!.props("title")).toBe("Link");
+        expect(collapses.at(0)!.props("collapseId")).toBe("link-data");
+        expect(collapses.at(0)!.findComponent(LinkData).exists()).toBe(true);
+        expect(collapses.at(1)!.props("title")).toBe("Model Parameters");
+        expect(collapses.at(1)!.props("collapseId")).toBe("model-params");
+        expect(collapses.at(1)!.findComponent(ParameterValues).exists()).toBe(true);
+        expect(collapses.at(2)!.props("title")).toBe("Run Options");
+        expect(collapses.at(2)!.props("collapseId")).toBe("run-options");
+        expect(collapses.at(2)!.findComponent(RunOptions).exists()).toBe(true);
     });
 });

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -6,8 +6,8 @@ import ParameterValues from "../../../../src/app/components/options/ParameterVal
 import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
 import LinkData from "../../../../src/app/components/options/LinkData.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {FitState} from "../../../../src/app/store/fit/state";
-import {AppType} from "../../../../src/app/store/appState/state";
+import { FitState } from "../../../../src/app/store/fit/state";
+import { AppType } from "../../../../src/app/store/appState/state";
 
 describe("OptionsTab", () => {
     it("renders as expected for Basic app", () => {

--- a/app/static/tests/unit/csvUpload.test.ts
+++ b/app/static/tests/unit/csvUpload.test.ts
@@ -20,6 +20,8 @@ describe("CSVUpload", () => {
         return mockFileReader;
     };
 
+    const postSuccess = jest.fn();
+
     afterEach(() => {
         resetAllMocks();
     });
@@ -35,13 +37,14 @@ describe("CSVUpload", () => {
       Error = "Error"
     }
 
-    it("commits data on success", (done) => {
+    it("commits data and calls post success on success", (done) => {
         const mockFileReader = getMockFileReader("a,b\n1,2\n3,4\n5,6\n7,8\n9,10\n");
 
         const commit = jest.fn();
         csvUpload({ commit } as any)
             .withSuccess(TestMutation.Success)
             .withError(TestMutation.Error)
+            .then(postSuccess)
             .upload(file);
 
         expectFileRead(mockFileReader);
@@ -60,6 +63,28 @@ describe("CSVUpload", () => {
                 timeVariableCandidates: ["a", "b"]
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedSetDataPayload);
+
+            expect(postSuccess).toHaveBeenCalledTimes(1);
+
+            done();
+        }, fileTimeout);
+    });
+
+    it("succeeds if post success is not set", (done) => {
+        const mockFileReader = getMockFileReader("a,b\n1,2\n3,4\n5,6\n7,8\n9,10\n");
+
+        const commit = jest.fn();
+        csvUpload({ commit } as any)
+            .withSuccess(TestMutation.Success)
+            .withError(TestMutation.Error)
+            .upload(file);
+
+        expectFileRead(mockFileReader);
+        setTimeout(() => {
+            expect(commit).toHaveBeenCalledTimes(1);
+            expect(commit.mock.calls[0][0]).toBe(TestMutation.Success);
+            expect(postSuccess).not.toHaveBeenCalled();
+
             done();
         }, fileTimeout);
     });
@@ -71,6 +96,7 @@ describe("CSVUpload", () => {
         csvUpload({ commit } as any)
             .withSuccess(TestMutation.Success)
             .withError(TestMutation.Error)
+            .then(postSuccess)
             .upload(file);
 
         expectFileRead(mockFileReader);
@@ -82,6 +108,7 @@ describe("CSVUpload", () => {
                 detail: "Invalid Record Length: columns length is 2, got 3 on line 2"
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedError);
+            expect(postSuccess).not.toHaveBeenCalled();
             done();
         }, fileTimeout);
     });
@@ -93,6 +120,7 @@ describe("CSVUpload", () => {
         csvUpload({ commit } as any)
             .withSuccess(TestMutation.Success)
             .withError(TestMutation.Error)
+            .then(postSuccess)
             .upload(file);
         expectFileRead(mockFileReader);
         setTimeout(() => {
@@ -103,6 +131,7 @@ describe("CSVUpload", () => {
                 detail: "Data contains non-numeric values: 'hello'"
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedError);
+            expect(postSuccess).not.toHaveBeenCalled();
             done();
         }, fileTimeout);
     });
@@ -120,6 +149,7 @@ describe("CSVUpload", () => {
         csvUpload({ commit } as any)
             .withSuccess(TestMutation.Success)
             .withError(TestMutation.Error)
+            .then(postSuccess)
             .upload(file);
         expectFileRead(mockFileReader);
         setTimeout(() => {
@@ -130,6 +160,7 @@ describe("CSVUpload", () => {
                 detail: "File cannot be read"
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedError);
+            expect(postSuccess).not.toHaveBeenCalled();
             done();
         }, fileTimeout);
     });

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -32,7 +32,7 @@ describe("Fit Data actions", () => {
         expect(mockFileReader.readAsText.mock.calls[0][1]).toBe("UTF-8");
     };
 
-    it("Upload commits data and updates linke variables on success", (done) => {
+    it("Upload commits data and updates linked variables on success", (done) => {
         const mockFileReader = getMockFileReader("a,b\n1,2\n3,4\n5,6\n7,8\n9,10");
         const mockGetters = {
             nonTimeColumns: ["a"]

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -1,7 +1,7 @@
 import { actions, FitDataAction } from "../../../../src/app/store/fitData/actions";
 import { FitDataMutation } from "../../../../src/app/store/fitData/mutations";
 import resetAllMocks = jest.resetAllMocks;
-import {mockFitDataState} from "../../../mocks";
+import { mockFitDataState } from "../../../mocks";
 
 describe("Fit Data actions", () => {
     const file = { name: "testFile" } as any;
@@ -47,7 +47,7 @@ describe("Fit Data actions", () => {
             }
         };
         const mockState = {
-            linkedVariables: {a: "X", b: "Y"}
+            linkedVariables: { a: "X", b: "Y" }
         };
 
         const commit = jest.fn();
@@ -75,7 +75,7 @@ describe("Fit Data actions", () => {
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedSetDataPayload);
             expect(commit.mock.calls[1][0]).toBe(FitDataMutation.SetLinkedVariables);
-            expect(commit.mock.calls[1][1]).toStrictEqual({a: "X"});
+            expect(commit.mock.calls[1][1]).toStrictEqual({ a: "X" });
             done();
         });
     });
@@ -178,11 +178,13 @@ describe("Fit Data actions", () => {
 
         const commit = jest.fn();
 
-        (actions[FitDataAction.UpdateLinkedVariables] as any)({commit, state, rootState, getters});
+        (actions[FitDataAction.UpdateLinkedVariables] as any)({
+            commit, state, rootState, getters
+        });
 
         expect(commit).toHaveBeenCalledTimes(1);
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetLinkedVariables);
-        expect(commit.mock.calls[0][1]).toStrictEqual({old1: null, old3: "C", new: null});
+        expect(commit.mock.calls[0][1]).toStrictEqual({ old1: null, old3: "C", new: null });
     });
 
     it("update linked variables without retaining existing links when model is not valid", () => {
@@ -199,10 +201,12 @@ describe("Fit Data actions", () => {
 
         const commit = jest.fn();
 
-        (actions[FitDataAction.UpdateLinkedVariables] as any)({commit, state, rootState, getters});
+        (actions[FitDataAction.UpdateLinkedVariables] as any)({
+            commit, state, rootState, getters
+        });
 
         expect(commit).toHaveBeenCalledTimes(1);
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetLinkedVariables);
-        expect(commit.mock.calls[0][1]).toStrictEqual({old1: null, old3: null, new: null});
+        expect(commit.mock.calls[0][1]).toStrictEqual({ old1: null, old3: null, new: null });
     });
 });

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -210,4 +210,45 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetLinkedVariables);
         expect(commit.mock.calls[0][1]).toStrictEqual({ old1: null, old3: null, new: null });
     });
+
+    it("Update time variable commits new time variable and updates linked variables", () => {
+        const testState = {
+            timeVariable: "Day1",
+            columns: ["Day1", "Day2", "Cases"],
+            linkedVariables: {
+                Day2: "A",
+                Cases: "B"
+            }
+        };
+
+        const rootState = {
+            model: {
+                odinModelResponse: {
+                    valid: true,
+                    metadata: {
+                        variables: ["A", "B", "C"]
+                    }
+                }
+            }
+        };
+
+        // mock the getter result we should get after the mutation has been committed
+        const testGetters = {
+            nonTimeColumns: ["Day1", "Cases"]
+        };
+
+        const commit = jest.fn().mockImplementation((type: FitDataMutation, payload: string) => {
+            if (type === FitDataMutation.SetTimeVariable) {
+                state.timeVariable = payload;
+            }
+        });
+        (actions[FitDataAction.UpdateTimeVariable] as any)({
+            commit, state: testState, rootState, getters: testGetters
+        }, "Day2");
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetTimeVariable);
+        expect(commit.mock.calls[0][1]).toBe("Day2");
+        expect(commit.mock.calls[1][0]).toBe(FitDataMutation.SetLinkedVariables);
+        expect(commit.mock.calls[1][1]).toStrictEqual({ Day1: null, Cases: "B" });
+    });
 });

--- a/app/static/tests/unit/store/fitData/getters.test.ts
+++ b/app/static/tests/unit/store/fitData/getters.test.ts
@@ -1,0 +1,12 @@
+import {FitDataGetter, getters} from "../../../../src/app/store/fitData/getters";
+import {mockFitDataState} from "../../../mocks";
+
+describe("FitDataGetters", () => {
+    it("gets non-time columns", () => {
+        const state = mockFitDataState({
+            columns: ["Day", "Cases", "Admissions"],
+            timeVariable: "Day"
+        });
+        expect((getters[FitDataGetter.nonTimeColumns] as any)(state)).toStrictEqual(["Cases", "Admissions"]);
+    });
+});

--- a/app/static/tests/unit/store/fitData/getters.test.ts
+++ b/app/static/tests/unit/store/fitData/getters.test.ts
@@ -1,5 +1,5 @@
-import {FitDataGetter, getters} from "../../../../src/app/store/fitData/getters";
-import {mockFitDataState} from "../../../mocks";
+import { FitDataGetter, getters } from "../../../../src/app/store/fitData/getters";
+import { mockFitDataState } from "../../../mocks";
 
 describe("FitDataGetters", () => {
     it("gets non-time columns", () => {

--- a/app/static/tests/unit/store/fitData/mutations.test.ts
+++ b/app/static/tests/unit/store/fitData/mutations.test.ts
@@ -31,4 +31,19 @@ describe("FitData mutations", () => {
         mutations.SetTimeVariable(state, "b");
         expect(state.timeVariable).toBe("b");
     });
+
+    it("sets linked variables", () => {
+        const state = mockFitDataState();
+        const linkedVars = {a: "S", b: "I"};
+        mutations.SetLinkedVariables(state, linkedVars);
+        expect(state.linkedVariables).toBe(linkedVars);
+    });
+
+    it("sets linked variable", () => {
+        const state = mockFitDataState();
+        mutations.SetLinkedVariable(state, {column: "a", variable: "S"});
+        expect(state.linkedVariables).toStrictEqual({a: "S"});
+        mutations.SetLinkedVariable(state, {column: "b", variable: null});
+        expect(state.linkedVariables).toStrictEqual({a: "S", b: null});
+    });
 });

--- a/app/static/tests/unit/store/fitData/mutations.test.ts
+++ b/app/static/tests/unit/store/fitData/mutations.test.ts
@@ -34,16 +34,16 @@ describe("FitData mutations", () => {
 
     it("sets linked variables", () => {
         const state = mockFitDataState();
-        const linkedVars = {a: "S", b: "I"};
+        const linkedVars = { a: "S", b: "I" };
         mutations.SetLinkedVariables(state, linkedVars);
         expect(state.linkedVariables).toBe(linkedVars);
     });
 
     it("sets linked variable", () => {
         const state = mockFitDataState();
-        mutations.SetLinkedVariable(state, {column: "a", variable: "S"});
-        expect(state.linkedVariables).toStrictEqual({a: "S"});
-        mutations.SetLinkedVariable(state, {column: "b", variable: null});
-        expect(state.linkedVariables).toStrictEqual({a: "S", b: null});
+        mutations.SetLinkedVariable(state, { column: "a", variable: "S" });
+        expect(state.linkedVariables).toStrictEqual({ a: "S" });
+        mutations.SetLinkedVariable(state, { column: "b", variable: null });
+        expect(state.linkedVariables).toStrictEqual({ a: "S", b: null });
     });
 });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -6,8 +6,8 @@ import { actions, ModelAction } from "../../../../src/app/store/model/actions";
 import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
 import { RequiredModelAction } from "../../../../src/app/store/model/state";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {AppType} from "../../../../src/app/store/appState/state";
-import {FitDataAction} from "../../../../src/app/store/fitData/actions";
+import { AppType } from "../../../../src/app/store/appState/state";
+import { FitDataAction } from "../../../../src/app/store/fitData/actions";
 
 describe("Model actions", () => {
     beforeEach(() => {
@@ -126,10 +126,12 @@ describe("Model actions", () => {
             requiredAction: RequiredModelAction.Compile,
             parameterValues: {}
         };
-        const fitRootState = {appType: AppType.Fit};
+        const fitRootState = { appType: AppType.Fit };
         const commit = jest.fn();
         const dispatch = jest.fn();
-        (actions[ModelAction.CompileModel] as any)({ commit, dispatch, state, rootState: fitRootState });
+        (actions[ModelAction.CompileModel] as any)({
+            commit, dispatch, state, rootState: fitRootState
+        });
         expect(commit.mock.calls.length).toBe(3);
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[1][0]).toBe(ModelMutation.SetParameterValues);

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -74,6 +74,22 @@ describe("processFitData", () => {
         });
     });
 
+    it("returns error if less than 2 columns", () => {
+        const data = [
+            { a: "1" },
+            { a: "3.5" },
+            { a: "5" },
+            { a: "7" },
+            { a: "10" }
+        ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.data).toBe(null);
+        expect(result.error).toStrictEqual({
+            error: "Error occurred",
+            detail: "File must contain at least 2 columns."
+        });
+    });
+
     it("returns error with 3 or fewer non-numeric values", () => {
         const data = [
             { a: "one", b: "two" },

--- a/config/defaultCode/day2.R
+++ b/config/defaultCode/day2.R
@@ -1,0 +1,13 @@
+# variables
+deriv(S) <-  - beta * S * I / N
+deriv(I) <- beta * S * I / N - sigma * I
+deriv(R) <- sigma * I
+# initial conditions
+initial(S) <- N - I0
+initial(I) <- I0
+initial(R) <- 0
+# parameters
+N <- user(1e6)
+I0 <- user(1)
+beta <- user(4)
+sigma <- user(2)


### PR DESCRIPTION
This branch allows the user to link data columns to model variables. For Model Fit applications, after data has been uploaded and code compiled, when you go to the Options tab, you should see a new 'Link' section with a drop down list for each non-time column in the data, with all model variables available in the drop down lists. Selections from the drop down lists should perist across tab changes.  The user can, if they wish, select the same variabe to link to multiple columns, since only one link at a time will be used when the fit itself is executed.

The values selected will be updated when:
- new data is uploaded (since all columns may have changed)
- new time variable is selected in Data tab (since the old time variable should now be available to link, and the new time variable shouldn't)
- code is recompiled (since this could affect what model variables are available)

In all these cases, the app should retain any previous selections which can be retained e.g. on code change it will retain any selections of variables which still exist and remove any which do not.  

To test, run deps and app, browse to http://localhost:3000/apps/day2
Upload either of the attached data files (they have different columns so can be used for testing the case of uploading new data removing selections for old columns). 
Go to Options tab and test expected behaviour.  

To test the code change case, you can paste this code over the default code for the Day 2 app. This replaces the I variable with a J variable. Remember to compile the code before you'll see changes the linked variables.
```
# variables
deriv(S) <-  - beta * S * J / N
deriv(J) <- beta * S * J / N - sigma * J
deriv(R) <- sigma * J
# initial conditions
initial(S) <- N - I0
initial(J) <- I0
initial(R) <- 0
# parameters
N <- user(1e6)
I0 <- user(1)
beta <- user(4)
sigma <- user(2)
```

Other changes in this branch:
- file uploads are required to contain at least two columns (one time and one non-time)
- added an enum for app types

[influenza_data_MULTIPLE_TIME.csv](https://github.com/mrc-ide/wodin/files/9062649/influenza_data_MULTIPLE_TIME.csv)
[influenza_data_MULTIPLE_TIME_DIFFERENT.csv](https://github.com/mrc-ide/wodin/files/9062650/influenza_data_MULTIPLE_TIME_DIFFERENT.csv)

