### PR TITLE
mrc-3290 Front end Error handling

### DIFF
--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -1,13 +1,14 @@
 <template>
-  <div class="run-tab">
-    <div>
-      <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
+    <div class="run-tab">
+        <div>
+            <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
+        </div>
+        <div class="run-update-msg text-danger text-center">
+            <span v-if="updateMsg" class="p-1">{{ updateMsg }}</span>
+        </div>
+        <run-model-plot :fade-plot="!!updateMsg"></run-model-plot>
     </div>
-    <div class="run-update-msg text-danger text-center">
-      <span v-if="updateMsg" class="p-1">{{updateMsg}}</span>
-    </div>
-    <run-model-plot :fade-plot="!!updateMsg"></run-model-plot>
-  </div>
+    <error-info :error="error"></error-info>
 </template>
 
 <script lang="ts">
@@ -17,16 +18,19 @@ import RunModelPlot from "./RunModelPlot.vue";
 import { ModelAction } from "../../store/model/actions";
 import { RequiredModelAction } from "../../store/model/state";
 import userMessages from "../../userMessages";
+import ErrorInfo from "../ErrorInfo.vue";
 
 export default defineComponent({
     name: "RunTab",
     components: {
-        RunModelPlot
+        RunModelPlot,
+        ErrorInfo
     },
     setup() {
         const store = useStore();
 
         const requiredAction = computed(() => store.state.model.requiredAction);
+        const error = computed(() => store.state.model.error);
 
         // Enable run button if model has initialised and compile is not required
         const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin
@@ -46,7 +50,8 @@ export default defineComponent({
         return {
             canRunModel,
             updateMsg,
-            runModel
+            runModel,
+            error
         };
     }
 });

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -21,7 +21,7 @@ const fetchOdin = async (context: ActionContext<ModelState, AppState>) => {
 
     await api(context)
         .withSuccess(ModelMutation.SetOdinResponse)
-        .withError(`errors/${ErrorsMutation.AddError}` as ErrorsMutation, true)
+        .withError(ModelMutation.SetError)
         .post<OdinModelResponse>("/odin/model", { model })
         .then(() => {
             commit(ModelMutation.SetRequiredAction, RequiredModelAction.Compile);
@@ -69,7 +69,7 @@ export const actions: ActionTree<ModelState, AppState> = {
     async FetchOdinRunner(context) {
         await api(context)
             .withSuccess(ModelMutation.SetOdinRunner)
-            .withError(`errors/${ErrorsMutation.AddError}` as ErrorsMutation, true)
+            .withError(ModelMutation.SetError)
             .get<string>("/odin/runner");
     },
 

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -3,7 +3,6 @@ import { ModelState, RequiredModelAction } from "./state";
 import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
 import { AppState } from "../appState/state";
-import { ErrorsMutation } from "../errors/mutations";
 import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
 

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -9,7 +9,8 @@ export const defaultState: ModelState = {
     odin: null,
     odinSolution: null,
     parameterValues: null,
-    endTime: 100
+    endTime: 100,
+    error: null
 };
 
 export const model = {

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -1,7 +1,11 @@
 import { MutationTree } from "vuex";
 import { ModelState, RequiredModelAction } from "./state";
 import {
-    Odin, OdinModelResponse, OdinRunner, OdinSolution
+    Odin,
+    OdinModelResponse,
+    OdinRunner,
+    OdinSolution,
+    Error
 } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
 import { Dict } from "../../types/utilTypes";
@@ -14,7 +18,8 @@ export enum ModelMutation {
     SetRequiredAction = "SetRequiredAction",
     SetParameterValues = "SetParameterValues",
     UpdateParameterValues = "UpdateParameterValues",
-    SetEndTime = "SetEndTime"
+    SetEndTime = "SetEndTime",
+    SetError = "SetError",
 }
 
 const runRequired = (state: ModelState) => {
@@ -62,5 +67,9 @@ export const mutations: MutationTree<ModelState> = {
     [ModelMutation.SetEndTime](state: ModelState, payload: number) {
         state.endTime = payload;
         runRequired(state);
+    },
+
+    [ModelMutation.SetError](state: ModelState, payload: Error) {
+        state.error = payload;
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -31,10 +31,12 @@ const runRequired = (state: ModelState) => {
 export const mutations: MutationTree<ModelState> = {
     [ModelMutation.SetOdinRunner](state: ModelState, payload: string) {
         state.odinRunner = evaluateScript<OdinRunner>(payload);
+        state.error = null;
     },
 
     [ModelMutation.SetOdinResponse](state: ModelState, payload: OdinModelResponse) {
         state.odinModelResponse = payload;
+        state.error = null;
     },
 
     [ModelMutation.SetOdin](state: ModelState, payload: Odin | null) {

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,5 +1,5 @@
 import {
-    Odin, OdinModelResponse, OdinSolution, OdinRunner
+    Odin, OdinModelResponse, OdinSolution, OdinRunner, Error
 } from "../../types/responseTypes";
 
 export enum RequiredModelAction {
@@ -14,5 +14,6 @@ export interface ModelState {
     odin: null | Odin // When we 'compile' we evaluate the response's 'model' string into a working model
     odinSolution: null | OdinSolution
     parameterValues: null | Map<string, number>
-    endTime: number
+    endTime: number,
+    error: Error | null
 }

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -44,6 +44,7 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
         requiredAction: null,
         parameterValues: null,
         endTime: 100,
+        error: null,
         ...state
     };
 };

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -6,25 +6,31 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { mockBasicState, mockModelState } from "../../../mocks";
-import { RequiredModelAction } from "../../../../src/app/store/model/state";
+import { ModelState, RequiredModelAction } from "../../../../src/app/store/model/state";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
 import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
+import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
 
 describe("RunTab", () => {
-    const getWrapper = (odinRunner = {} as any,
-        odin = {} as any,
-        requiredAction: RequiredModelAction | null = null,
-        mockRunModel = jest.fn()) => {
+    const defaultModelState = {
+        odinRunner: {} as any,
+        odin: {} as any,
+        requiredAction: null
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const mockRunModel = jest.fn();
+
+    const getWrapper = (modelState: Partial<ModelState> = defaultModelState) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState(),
             modules: {
                 model: {
                     namespaced: true,
-                    state: mockModelState({
-                        odinRunner,
-                        odin,
-                        requiredAction
-                    }),
+                    state: mockModelState(modelState),
                     actions: {
                         RunModel: mockRunModel
                     }
@@ -47,22 +53,22 @@ describe("RunTab", () => {
     });
 
     it("disables run button when state has no odinRunner", () => {
-        const wrapper = getWrapper(null);
+        const wrapper = getWrapper({ odinRunner: null });
         expect(wrapper.find("button").element.disabled).toBe(true);
     });
 
     it("disables run button when state has no odin model", () => {
-        const wrapper = getWrapper({} as any, null);
+        const wrapper = getWrapper({ odin: null });
         expect(wrapper.find("button").element.disabled).toBe(true);
     });
 
     it("disabled run button when compile is required", () => {
-        const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Compile);
+        const wrapper = getWrapper({ requiredAction: RequiredModelAction.Compile });
         expect(wrapper.find("button").element.disabled).toBe(true);
     });
 
     it("fades plot and shows message when compile required", () => {
-        const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Compile);
+        const wrapper = getWrapper({ requiredAction: RequiredModelAction.Compile });
         expect(wrapper.find(".run-update-msg").text()).toBe(
             "Model code has been updated. Compile code and Run Model to view updated graph."
         );
@@ -70,7 +76,7 @@ describe("RunTab", () => {
     });
 
     it("fades plot and shows message when model run required", () => {
-        const wrapper = getWrapper({} as any, {} as any, RequiredModelAction.Run);
+        const wrapper = getWrapper({ requiredAction: RequiredModelAction.Run });
         expect(wrapper.find(".run-update-msg").text()).toBe(
             "Model code has been recompiled or options have been updated. Run Model to view updated graph."
         );
@@ -78,9 +84,15 @@ describe("RunTab", () => {
     });
 
     it("invokes run model action when run button is clicked", () => {
-        const mockRunModel = jest.fn();
-        const wrapper = getWrapper({} as any, {} as any, null, mockRunModel);
+        const wrapper = getWrapper();
         wrapper.find("button").trigger("click");
         expect(mockRunModel).toHaveBeenCalled();
+    });
+
+    it("displays error info in run model", () => {
+        const error = { error: "model error", detail: "with details" };
+        const wrapper = getWrapper({ error });
+        expect(wrapper.findComponent(ErrorInfo).exists()).toBe(true);
+        expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(error);
     });
 });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -44,7 +44,7 @@ describe("Model actions", () => {
         const commit = jest.fn();
         await (actions[ModelAction.FetchOdinRunner] as any)({ commit });
 
-        expect(commit.mock.calls[0][0]).toBe("errors/AddError");
+        expect(commit.mock.calls[0][0]).toBe("SetError");
         expect(commit.mock.calls[0][1].detail).toBe("server error");
     });
 
@@ -73,7 +73,7 @@ describe("Model actions", () => {
         const commit = jest.fn();
         await (actions[ModelAction.FetchOdin] as any)({ commit, rootState });
 
-        expect(commit.mock.calls[0][0]).toBe("errors/AddError");
+        expect(commit.mock.calls[0][0]).toBe("SetError");
         expect(commit.mock.calls[0][1].detail).toBe("server error");
     });
 

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -30,7 +30,7 @@ describe("Model mutations", () => {
     });
 
     it("sets odin solution", () => {
-        const mockSolution = (t0: number, t1: number) => [{ x: 1, y: 2 }];
+        const mockSolution = () => [{ x: 1, y: 2 }];
         const state = mockModelState();
 
         mutations.SetOdinSolution(state, mockSolution);
@@ -79,5 +79,12 @@ describe("Model mutations", () => {
         mutations.SetEndTime(state, 101);
         expect(state.endTime).toBe(101);
         expect(state.requiredAction).toBe(RequiredModelAction.Compile);
+    });
+
+    it("sets model error", () => {
+        const error = { error: "model error", detail: "with details" };
+        const state = mockModelState();
+        mutations.SetError(state, error);
+        expect(state.error).toBe(error);
     });
 });

--- a/app/static/tests/unit/store/model/mutations.test.ts
+++ b/app/static/tests/unit/store/model/mutations.test.ts
@@ -1,14 +1,15 @@
 import { mutations } from "../../../../src/app/store/model/mutations";
-import { mockModelState } from "../../../mocks";
+import { mockError, mockModelState } from "../../../mocks";
 import { RequiredModelAction } from "../../../../src/app/store/model/state";
 
 describe("Model mutations", () => {
     it("evaluates and sets odin runner", () => {
         const mockRunner = "() => 'runner'";
-        const state = mockModelState();
+        const state = mockModelState({ error: mockError("error") });
 
         mutations.SetOdinRunner(state, mockRunner);
         expect((state.odinRunner as any)()).toBe("runner");
+        expect(state.error).toBe(null);
     });
 
     it("sets  odin response", () => {
@@ -17,10 +18,11 @@ describe("Model mutations", () => {
             metadata: {},
             model: "() => 'hello'"
         };
-        const state = mockModelState();
+        const state = mockModelState({ error: mockError("error") });
 
         mutations.SetOdinResponse(state, mockOdinModelResponse);
         expect(state.odinModelResponse).toBe(mockOdinModelResponse);
+        expect(state.error).toBe(null);
     });
 
     it("sets odin", () => {


### PR DESCRIPTION
This PR displays errors from model endpoints

To test:
* sabotage wodin api by stopping or restarting docker container
* `docker restart wodin.api`
* quickly type rubbish on code editor
* you should see an error displayed.