### PR TITLE
mrc-3442 Add build frontend script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ WODIN fetches compiled odin code from [odin.api](https://github.com/mrc-ide/odin
 
 For development, you can install dependencies, build and run the app locally in one step using `./scripts/build-and-run.sh`. The app will be available at http://localhost:3000 
 
-To build front end changes only for a given app type run, `./scripts/build-frontend.sh basic` (or provide `fit` or
+To build front end changes only for a given app type run, `./scripts/build-frontend.sh basic` (or replace `basic` with `fit` or
 `stochastic` as the script argument).
 
 WODIN is deployable via an npm package: https://www.npmjs.com/package/wodin

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ WODIN fetches compiled odin code from [odin.api](https://github.com/mrc-ide/odin
 
 For development, you can install dependencies, build and run the app locally in one step using `./scripts/build-and-run.sh`. The app will be available at http://localhost:3000 
 
+To build front end changes only for a given app type run, `./scripts/build-frontend.sh basic` (or provide `fit` or
+`stochastic` as the script argument).
+
 WODIN is deployable via an npm package: https://www.npmjs.com/package/wodin
 
 To run an instance of WODIN with custom configuration, install the package and use `npx wodin --config=/path/to/config`

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,0 +1,3 @@
+set -ex
+npm run build-$1 --prefix=app/static
+npm run copy-all --prefix=app/static

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,3 +1,3 @@
 set -ex
-npm run build-$1 --prefix=app/static
+npm run build-"$1" --prefix=app/static
 npm run copy-all --prefix=app/static


### PR DESCRIPTION
One of the reasons the WODIN build takes so long is because it builds js for each app type separately. Our build script (`./scripts/build-and-run.sh`) also rebuilds the backend too. However, typically in development, we make changes to the front end and want to quickly spin up a single app type to test changes.

This branch adds a helper build script which builds front end for a given app type only. It does not re-run the app as a running server will serve new js when page is re-loaded.

The script builds the front end for the requested app type then copies js etc to the server folder. For me, this reduced build time from ~2mins to ~1min. 

Run the script providing app type as an arg e.g. `./scripts/build-frontend.sh fit` or `./scripts/build-frontend.sh basic`

To test:
- spin up the app using the full build script `./scripts/build-and-run.sh` or just serve the latest build you have: `npm run serve --prefix=app/server`
- Make some changes to the front end code, e.g. change `userMessages.code.isValid` to a different text
- run `./scripts/build-frontend.sh basic`
- browse to http://localhost:3000/apps/day1
- You should see your code change has taken effect e.g. different code is valid message on Code tab