### PR TITLE
mrc-3296 Custom numeric input for parameter values

### DIFF
--- a/app/static/jest.config.js
+++ b/app/static/jest.config.js
@@ -9,5 +9,6 @@ module.exports = {
     ],
     coveragePathIgnorePatterns: [
         "./tests/mocks.ts"
-    ]
+    ],
+    transformIgnorePatterns: ["node_modules/(?!(d3-format))"]
 };

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -2766,6 +2766,11 @@
       "integrity": "sha512-VkWIQoZXLFdcBGe5pdBKJmTU3fmpXvo/KV6ixvTzOMl1yJ2hbTXpfvsziag0kcaerPDwas2T0vxojwQG3YwivQ==",
       "dev": true
     },
+    "@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg=="
+    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -10763,9 +10768,9 @@
       }
     },
     "d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-geo": {
       "version": "1.12.1",
@@ -20080,6 +20085,13 @@
         "topojson-client": "^3.1.0",
         "webgl-context": "^2.2.0",
         "world-calendars": "^1.0.3"
+      },
+      "dependencies": {
+        "d3-format": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+          "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+        }
       }
     },
     "pn": {

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -25,9 +25,11 @@
   "dependencies": {
     "@monaco-editor/loader": "^1.3.2",
     "@popperjs/core": "^2.11.5",
+    "@types/d3-format": "^3.0.1",
     "axios": "^0.26.0",
     "bootstrap": "^5.1.3",
     "csv-parse": "^5.2.1",
+    "d3-format": "^3.1.0",
     "monaco-editor": "^0.30.1",
     "plotly.js": "^2.11.1",
     "vue": "^3.2.29",

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -21,8 +21,6 @@ export default defineComponent({
         }
     },
     setup(props, { emit }) {
-      //pattern="^\d{1,3}(,?\d{3})*(\.\d+)?$"
-
         // We want to correct user's poor formatting e.g. insert comma separators, but bad UX to do
         // this on every keystroke, so update text value on blur, mounted, and external value change (a change
         // to a value which wasn't the last one changed to here e.g. caused by model fit)
@@ -30,24 +28,24 @@ export default defineComponent({
         const textValue = ref("");
 
         const formatTextValue = () => {
-            console.log("formatting");
             // display value with thousands format
             textValue.value = format(",")(props.value);
-            console.log(`Set textValue to ${textValue.value}`);
         };
 
         const updateValue = (event: Event) => {
+            // 1. Apply character mask - only allow numerics, decimal point and comma
             const element = event.target as HTMLInputElement;
-            const newVal = element.value;
+            const newVal = element.value.replace(/[^0-9,.]/g, "");
+
             textValue.value = newVal;
-            console.log("updatingValue");
-            // take out commas should be able to parse
+            // within the event handler we need to update the element directly to apply character mask as well as
+            // updating reactive value
+            element.value = newVal;
+
+            // 2. Remove commas and parse to number, and emit update to container
             const cleanedValue = newVal.replace(/,/g, "");
-            console.log(`cleanedValue: ${cleanedValue}`);
             const numeric = parseFloat(cleanedValue);
-            console.log(`numeric: ${numeric}`);
             if (!Number.isNaN(numeric)) {
-                console.log("emitting numeric");
                 lastNumericValueSet.value = numeric;
                 emit("update", numeric);
             }

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -1,0 +1,70 @@
+<template>
+  <input class="form-control parameter-input"
+         type="text"
+         :value="textValue"
+         @input="updateValue"
+         @blur="formatTextValue"/>
+</template>
+
+<script lang="ts">
+import { format } from "d3-format";
+import {
+    defineComponent, ref, onMounted, watch
+} from "vue";
+
+export default defineComponent({
+    name: "NumericInput",
+    props: {
+        value: {
+            type: Number,
+            required: true
+        }
+    },
+    setup(props, { emit }) {
+      //pattern="^\d{1,3}(,?\d{3})*(\.\d+)?$"
+
+        // We want to correct user's poor formatting e.g. insert comma separators, but bad UX to do
+        // this on every keystroke, so update text value on blur, mounted, and external value change (a change
+        // to a value which wasn't the last one changed to here e.g. caused by model fit)
+        const lastNumericValueSet = ref<null|number>(null);
+        const textValue = ref("");
+
+        const formatTextValue = () => {
+            console.log("formatting");
+            // display value with thousands format
+            textValue.value = format(",")(props.value);
+            console.log(`Set textValue to ${textValue.value}`);
+        };
+
+        const updateValue = (event: Event) => {
+            const element = event.target as HTMLInputElement;
+            const newVal = element.value;
+            textValue.value = newVal;
+            console.log("updatingValue");
+            // take out commas should be able to parse
+            const cleanedValue = newVal.replace(/,/g, "");
+            console.log(`cleanedValue: ${cleanedValue}`);
+            const numeric = parseFloat(cleanedValue);
+            console.log(`numeric: ${numeric}`);
+            if (!Number.isNaN(numeric)) {
+                console.log("emitting numeric");
+                lastNumericValueSet.value = numeric;
+                emit("update", numeric);
+            }
+        };
+
+        onMounted(formatTextValue);
+        watch(() => props.value, (newVal) => {
+            if (newVal !== lastNumericValueSet.value) {
+                formatTextValue();
+            }
+        });
+
+        return {
+            textValue,
+            updateValue,
+            formatTextValue
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -20,6 +20,7 @@ export default defineComponent({
             required: true
         }
     },
+    emits: ["update"],
     setup(props, { emit }) {
         // We want to correct user's poor formatting e.g. insert comma separators, but bad UX to do
         // this on every keystroke, so update text value on blur, mounted, and external value change (a change
@@ -37,9 +38,9 @@ export default defineComponent({
             const element = event.target as HTMLInputElement;
             const newVal = element.value.replace(/[^0-9,.]/g, "");
 
-            textValue.value = newVal;
             // within the event handler we need to update the element directly to apply character mask as well as
             // updating reactive value
+            textValue.value = newVal;
             element.value = newVal;
 
             // 2. Remove commas and parse to number, and emit update to container

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -29,14 +29,15 @@ export default defineComponent({
         const textValue = ref("");
 
         const formatTextValue = () => {
-            // display value with thousands format
+            // display value with thousands formats
             textValue.value = format(",")(props.value);
         };
 
         const updateValue = (event: Event) => {
-            // 1. Apply character mask - only allow numerics, decimal point and comma
+            // 1. Apply character mask - only allow numerics, decimal point, comma, and accept both hyphen and minus
+            // sign for negatives
             const element = event.target as HTMLInputElement;
-            const newVal = element.value.replace(/[^0-9,.]/g, "");
+            const newVal = element.value.replace(/[^0-9,.−-]/g, "");
 
             // within the event handler we need to update the element directly to apply character mask as well as
             // updating reactive value

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -36,10 +36,7 @@ export default defineComponent({
         const odinSolution = computed(() => store.state.model.odinSolution);
 
         const updateValue = (newValue: number, paramName: string) => {
-            console.log(`New value of ${JSON.stringify(newValue)} for paramName ${paramName}`)
-            if (!Number.isNaN(newValue)) {
-              store.commit(`model/${ModelMutation.UpdateParameterValues}`, {[paramName]: newValue});
-            }
+            store.commit(`model/${ModelMutation.UpdateParameterValues}`, { [paramName]: newValue });
         };
 
         watch(odinSolution, () => {

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -5,10 +5,8 @@
         <label class="col-form-label">{{paramName}}</label>
       </div>
       <div class="col-6">
-        <input class="form-control parameter-input"
-               type="number"
-               :value="paramValues.get(paramName)"
-               @input="updateValue($event, paramName)"/>
+        <numeric-input :value="paramValues.get(paramName)"
+                       @update="(n) => updateValue(n, paramName)"/>
       </div>
     </div>
   </div>
@@ -20,9 +18,13 @@ import {
 } from "vue";
 import { useStore } from "vuex";
 import { ModelMutation } from "../../store/model/mutations";
+import NumericInput from "./NumericInput.vue";
 
 export default defineComponent({
     name: "ParameterValues",
+    components: {
+        NumericInput
+    },
     setup() {
         const store = useStore();
         const paramValues = computed(() => store.state.model.parameterValues);
@@ -33,12 +35,10 @@ export default defineComponent({
         const paramKeys = ref(timestampParamNames());
         const odinSolution = computed(() => store.state.model.odinSolution);
 
-        const updateValue = (e: Event, paramName: string) => {
-            const input = e.target as HTMLInputElement;
-            const newValue = parseFloat(input.value);
-            // Do not send update if user has cleared the numeric input. Refresh inputs on next run
+        const updateValue = (newValue: number, paramName: string) => {
+            console.log(`New value of ${JSON.stringify(newValue)} for paramName ${paramName}`)
             if (!Number.isNaN(newValue)) {
-                store.commit(`model/${ModelMutation.UpdateParameterValues}`, { [paramName]: newValue });
+              store.commit(`model/${ModelMutation.UpdateParameterValues}`, {[paramName]: newValue});
             }
         };
 

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -20,7 +20,7 @@ test.describe("Options Tab tests", () => {
         await expect(await page.innerText(":nth-match(#model-params label, 2)")).toBe("I0");
         await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
         await expect(await page.innerText(":nth-match(#model-params label, 3)")).toBe("N");
-        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1000000");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1,000,000");
         await expect(await page.innerText(":nth-match(#model-params label, 4)")).toBe("sigma");
         await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
 
@@ -142,5 +142,22 @@ test.describe("Options Tab tests", () => {
                 timeout
             }
         );
+    });
+
+    test("cannot enter chars in parameter input which are not numeric, comma or decimal point", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", "12.3g");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("12.3");
+    });
+
+    test("Entered parameter values are formatted when blur input", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", "10000");
+        await page.click(":nth-match(#model-params input, 2)");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("10,000");
+    });
+
+    test("Non-numbers are reverted to previous value when blur input", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", ",.");
+        await page.click(":nth-match(#model-params input, 2)");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
     });
 });

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -153,6 +153,10 @@ test.describe("Options Tab tests", () => {
         await page.fill(":nth-match(#model-params input, 1)", "10000");
         await page.click(":nth-match(#model-params input, 2)");
         await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("10,000");
+
+        await page.fill(":nth-match(#model-params input, 1)", "-10000");
+        await page.click(":nth-match(#model-params input, 2)");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("−10,000");
     });
 
     test("Non-numbers are reverted to previous value when blur input", async ({ page }) => {

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -1,0 +1,90 @@
+import { mount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
+
+describe("NumericInput", () => {
+    const expectInputToHaveValue = (wrapper: VueWrapper<any>, expectedTextValue: string) => {
+        expect((wrapper.find("input").element as HTMLInputElement).value).toBe(expectedTextValue);
+    };
+
+    const expectInitialValueOnMount = async (value: number, expectedTextValue: string) => {
+        const wrapper = mount(NumericInput, { props: { value } });
+        await nextTick();
+        expectInputToHaveValue(wrapper, expectedTextValue);
+    };
+
+    it("renders as expected", async () => {
+        await expectInitialValueOnMount(12, "12");
+        await expectInitialValueOnMount(10000000, "10,000,000");
+        await expectInitialValueOnMount(0.25, "0.25");
+        await expectInitialValueOnMount(1234.5, "1,234.5");
+    });
+
+    it("Updates and formats input when prop updates to externally changed value", async () => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.setProps({ value: 9999 });
+        expectInputToHaveValue(wrapper, "9,999");
+    });
+
+    it("Does not reformat input when prop updates to last numeric value set in component", async () => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.find("input").setValue("9999");
+
+        await wrapper.setProps({ value: 9999 });
+
+        expectInputToHaveValue(wrapper, "9999");
+    });
+
+    const expectEmitOnInputChange = async (newInputValue: string, expectedEmitValue: number) => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.find("input").setValue(newInputValue);
+        expect(wrapper.emitted("update")!.length).toBe(1);
+        expect(wrapper.emitted("update")![0]).toStrictEqual([expectedEmitValue]);
+        expectInputToHaveValue(wrapper, newInputValue);
+    };
+
+    it("emits new value on input change, and does not reformat", async () => {
+        await expectEmitOnInputChange("9999", 9999);
+        await expectEmitOnInputChange("0.1", 0.1);
+        // expect commas to be ignored
+        await expectEmitOnInputChange("9,999", 9999);
+        await expectEmitOnInputChange("1,00,00", 10000);
+        await expectEmitOnInputChange(",10,.1", 10.1);
+    });
+
+    it("applies character mask", async () => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.find("input").setValue("100abc!");
+        expectInputToHaveValue(wrapper, "100");
+        expect(wrapper.emitted("update")![0]).toStrictEqual([100]);
+    });
+
+    it("does not emit update if value is not parseable as numeric", async () => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.find("input").setValue("..1.2.3");
+        expectInputToHaveValue(wrapper, "..1.2.3"); // only clears value on blur
+        expect(wrapper.emitted("update")).toBe(undefined);
+    });
+
+    it("formats input value on blur", async () => {
+        const wrapper = mount(NumericInput, { props: { value: 12 } });
+        await nextTick();
+
+        await wrapper.find("input").setValue("9999.9");
+        await wrapper.setProps({value: 9999.9});
+
+        await wrapper.find("input").trigger("blur");
+
+        expectInputToHaveValue(wrapper, "9,999.9");
+    });
+});

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -2,6 +2,7 @@ import { mount, VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
+//TODO: test input attribute values
 describe("NumericInput", () => {
     const expectInputToHaveValue = (wrapper: VueWrapper<any>, expectedTextValue: string) => {
         expect((wrapper.find("input").element as HTMLInputElement).value).toBe(expectedTextValue);

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -2,7 +2,6 @@ import { mount, VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
-//TODO: test input attribute values
 describe("NumericInput", () => {
     const expectInputToHaveValue = (wrapper: VueWrapper<any>, expectedTextValue: string) => {
         expect((wrapper.find("input").element as HTMLInputElement).value).toBe(expectedTextValue);
@@ -10,6 +9,7 @@ describe("NumericInput", () => {
 
     const expectInitialValueOnMount = async (value: number, expectedTextValue: string) => {
         const wrapper = mount(NumericInput, { props: { value } });
+        expect(wrapper.find("input").attributes("type")).toBe("text");
         await nextTick();
         expectInputToHaveValue(wrapper, expectedTextValue);
     };
@@ -82,7 +82,7 @@ describe("NumericInput", () => {
         await nextTick();
 
         await wrapper.find("input").setValue("9999.9");
-        await wrapper.setProps({value: 9999.9});
+        await wrapper.setProps({ value: 9999.9 });
 
         await wrapper.find("input").trigger("blur");
 

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -19,6 +19,8 @@ describe("NumericInput", () => {
         await expectInitialValueOnMount(10000000, "10,000,000");
         await expectInitialValueOnMount(0.25, "0.25");
         await expectInitialValueOnMount(1234.5, "1,234.5");
+        await expectInitialValueOnMount(-0.5, "−0.5");
+        await expectInitialValueOnMount(-9999.9, "−9,999.9");
     });
 
     it("Updates and formats input when prop updates to externally changed value", async () => {
@@ -53,6 +55,7 @@ describe("NumericInput", () => {
     it("emits new value on input change, and does not reformat", async () => {
         await expectEmitOnInputChange("9999", 9999);
         await expectEmitOnInputChange("0.1", 0.1);
+        await expectEmitOnInputChange("-10", -10);
         // expect commas to be ignored
         await expectEmitOnInputChange("9,999", 9999);
         await expectEmitOnInputChange("1,00,00", 10000);

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from "vuex";
 import { nextTick } from "vue";
-import {mount, shallowMount} from "@vue/test-utils";
+import { mount, shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -1,8 +1,9 @@
 import Vuex, { Store } from "vuex";
 import { nextTick } from "vue";
-import { shallowMount } from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import ParameterValues from "../../../../src/app/components/options/ParameterValues.vue";
+import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 import { mockModelState } from "../../../mocks";
 import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
 import Mock = jest.Mock;
@@ -42,41 +43,36 @@ describe("ParameterValues", () => {
 
         const p1 = rows.at(0)!;
         expect(p1.find("label").text()).toBe("param1");
-        const input1 = p1.find("input")!;
-        expect(input1.attributes("type")).toBe("number");
-        expect((input1.element as HTMLInputElement).value).toBe("1");
+        const input1 = p1.findComponent(NumericInput);
+        expect(input1.props("value")).toBe(1);
 
         const p2 = rows.at(1)!;
         expect(p2.find("label").text()).toBe("param2");
-        const input2 = p2.find("input")!;
-        expect(input2.attributes("type")).toBe("number");
-        expect((input2.element as HTMLInputElement).value).toBe("2.2");
+        const input2 = p2.findComponent(NumericInput);
+        expect(input2.props("value")).toBe(2.2);
     });
 
     it("commits parameter value change", async () => {
         const mockUpdateParameterValues = jest.fn();
         const wrapper = getWrapper(getStore(mockUpdateParameterValues));
-        const input2 = wrapper.findAll("input").at(1)!;
-        await input2.setValue("3.3");
+        const input2 = wrapper.findAllComponents(NumericInput).at(1)!;
+        await input2.vm.$emit("update", 3.3);
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
         expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({ param2: 3.3 });
     });
 
-    it("does not commit parameter value change to empty string", async () => {
-        const mockUpdateParameterValues = jest.fn();
-        const wrapper = getWrapper(getStore(mockUpdateParameterValues));
-        const input2 = wrapper.findAll("input").at(1)!;
-        await input2.setValue("");
-        expect(mockUpdateParameterValues).not.toHaveBeenCalled();
-    });
-
     it("refreshes cleared input when odinSolution changes", async () => {
         const store = getStore();
-        const wrapper = getWrapper(store);
+        const wrapper = mount(ParameterValues, {
+            global: {
+                plugins: [store]
+            }
+        });
         wrapper.findAll("input").at(1)!.setValue("");
 
         store.commit(`model/${ModelMutation.SetOdinSolution}`, {});
         await nextTick();
+        expect(wrapper.findAllComponents(NumericInput).at(1)!.props("value")).toBe(2.2);
         expect((wrapper.findAll("input").at(1)!.element as HTMLInputElement).value).toBe("2.2");
     });
 });


### PR DESCRIPTION
This branch implements a custom numeric input for parameter values, which:
- allows decimal inputs
- does not show a value spinner
- formats large numbers with comma thousands separators

The user can enter numerals, decimal point and commas, and this will be parsed as a number where possible. If the user input is not correctly formatted (e.g. comma separator in wrong place), this formatting will be corrected on blur of control (it's a poor UX to correct on every keystroke as user may still be inputting value). If value is NaN e.g. all commas or multiple decimal points, the displayed value will also be updated to last saved numeric on next blur. 

We also want to update the displayed value if a change of numeric value has originated external to the control, e.g. during Model Fit (not merged into this branch yet) - hence adding a watch which reformats only if the new value does not match the last value emitted. 