### PR TITLE
Allow NA values in csv parse

### DIFF
--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -68,8 +68,14 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
     }
 
     // There might be trailing empty rows to drop.
-    while (all(Object.values(last(processedData)).map((v) => Number.isNaN(v)))) {
-        processedData.pop();
+    while (processedData.length > 0) {
+        const row = processedData[processedData.length - 1];
+        const missing = Object.values(row).map((v) => Number.isNaN(v));
+        if (missing.reduce((a, b) => a && b, true)) { // all missing
+            processedData.pop();
+        } else {
+            break;
+        }
     }
 
     // Only after discarding missing blank rows should we check to see if we have sufficient
@@ -99,12 +105,4 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
     return {
         ...emptyResult, data: processedData, columns, timeVariableCandidates
     };
-}
-
-function all(data: boolean[]) {
-    return data.reduce((a, b) => a && b, true);
-}
-
-function last<T>(data: Array<T>) {
-    return data[data.length - 1];
 }

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -70,7 +70,7 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
     // There might be trailing empty rows to drop.
     while (processedData.length > 0) {
         const row = processedData[processedData.length - 1];
-       if (Object.values(row).every((v) => Number.isNaN(v))) { // all missing
+        if (Object.values(row).every((v) => Number.isNaN(v))) { // all missing
             processedData.pop();
         } else {
             break;

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -70,8 +70,7 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
     // There might be trailing empty rows to drop.
     while (processedData.length > 0) {
         const row = processedData[processedData.length - 1];
-        const missing = Object.values(row).map((v) => Number.isNaN(v));
-        if (missing.reduce((a, b) => a && b, true)) { // all missing
+       if (Object.values(row).every((v) => Number.isNaN(v))) { // all missing
             processedData.pop();
         } else {
             break;

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -51,7 +51,9 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
         const processedRow: Dict<number> = {};
         Object.keys(row).forEach((key) => {
             const value = Number(row[key]);
-            if (Number.isNaN(value)) {
+            if (row[key] === "" || row[key] === "NA") {
+                processedRow[key] = NaN;
+            } else if (Number.isNaN(value)) {
                 nonNumValues.push(row[key]);
             } else {
                 processedRow[key] = value;
@@ -74,7 +76,7 @@ export function processFitData(data: Dict<string>[], errorMsg: string): ProcessF
         if (index > 0) {
             const toRemove: string[] = [];
             timeVariableCandidates.forEach((key) => {
-                if (row[key] <= processedData[index - 1][key]) {
+                if (Number.isNaN(row[key]) || row[key] <= processedData[index - 1][key]) {
                     toRemove.push(key);
                 }
             });

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -174,4 +174,46 @@ describe("processFitData", () => {
             detail: "Data contains no suitable time variable. A time variable must strictly increase per row."
         });
     });
+
+    it("strips trailing blank rows", () => {
+        const data = [
+            { a: "1", b: "2" },
+            { a: "3.5", b: "-100" },
+            { a: "5", b: "6" },
+            { a: "7", b: "8" },
+            { a: "9", b: "10" },
+            { a: "", b: "" },
+            { a: "", b: "" },
+            { a: "", b: "" }
+        ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.error).toBe(undefined);
+        expect(result.data).toStrictEqual([
+            { a: 1, b: 2 },
+            { a: 3.5, b: -100 },
+            { a: 5, b: 6 },
+            { a: 7, b: 8 },
+            { a: 9, b: 10 }
+        ]);
+        expect(result.timeVariableCandidates).toStrictEqual(["a"]);
+    });
+
+    it("returns error if less than 5 rows, after stripping blanks", () => {
+        const data = [
+            { a: "1", b: "2" },
+            { a: "3.5", b: "-100" },
+            { a: "5", b: "6" },
+            { a: "7", b: "8" },
+            { a: "", b: ""},
+            { a: "", b: ""},
+            { a: "", b: ""},
+            { a: "", b: ""}
+        ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.data).toBe(null);
+        expect(result.error).toStrictEqual({
+            error: "Error occurred",
+            detail: "File must contain at least 5 data rows."
+        });
+    });
 });

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -204,11 +204,21 @@ describe("processFitData", () => {
             { a: "3.5", b: "-100" },
             { a: "5", b: "6" },
             { a: "7", b: "8" },
-            { a: "", b: ""},
-            { a: "", b: ""},
-            { a: "", b: ""},
-            { a: "", b: ""}
+            { a: "", b: "" },
+            { a: "", b: "" },
+            { a: "", b: "" },
+            { a: "", b: "" }
         ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.data).toBe(null);
+        expect(result.error).toStrictEqual({
+            error: "Error occurred",
+            detail: "File must contain at least 5 data rows."
+        });
+    });
+
+    it("copes with pathalogical empty csv", () => {
+        const data = Array(5).fill({ a: "", b: "" });
         const result = processFitData(data, "Error occurred");
         expect(result.data).toBe(null);
         expect(result.error).toStrictEqual({

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -157,4 +157,21 @@ describe("processFitData", () => {
         ]);
         expect(result.timeVariableCandidates).toStrictEqual(["a"]);
     });
+
+    it("disallows columns with missing values as time variables", () => {
+        // both are increasing here
+        const data = [
+            { a: "1", b: "2" },
+            { a: "2", b: "3" },
+            { a: "5", b: "4.5" },
+            { a: "NA", b: "7" },
+            { a: "9", b: "" }
+        ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.data).toBe(null);
+        expect(result.error).toStrictEqual({
+            error: "Error occurred",
+            detail: "Data contains no suitable time variable. A time variable must strictly increase per row."
+        });
+    });
 });

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -137,4 +137,24 @@ describe("processFitData", () => {
             detail: "Data contains no suitable time variable. A time variable must strictly increase per row."
         });
     });
+
+    it("allows missing values in data columns", () => {
+        const data = [
+            { a: "1", b: "2" },
+            { a: "3.5", b: "" },
+            { a: "5", b: "20" },
+            { a: "7", b: "NA" },
+            { a: "9", b: "10" }
+        ];
+        const result = processFitData(data, "Error occurred");
+        expect(result.error).toBe(undefined);
+        expect(result.data).toStrictEqual([
+            { a: 1, b: 2 },
+            { a: 3.5, b: NaN },
+            { a: 5, b: 20 },
+            { a: 7, b: NaN },
+            { a: 9, b: 10 }
+        ]);
+        expect(result.timeVariableCandidates).toStrictEqual(["a"]);
+    });
 });


### PR DESCRIPTION
This PR allows missing values, either `""` or `NA` to be included within the upload, translating them to `NaN` in order to match the interface in odin-js (https://github.com/mrc-ide/odin-js/pull/12).

Some slight changes that follow from this:

* missing values are not allowed in the time column, so presence of a missing value there disallows the column from eligibility, even if the values are otherwise sorted
* blocks of missing data at the end of the file, which Excel can leave, are discarded
* because of the above, the "sufficient rows" check is done after the missing values are processed