### PR TITLE
Add redis to app

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -562,6 +562,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1722,6 +1727,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1897,6 +1907,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -3022,6 +3037,37 @@
         "side-channel": "^1.0.4"
       }
     },
+    "ioredis": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.2.tgz",
+      "integrity": "sha512-wryKc1ur8PcCmNwfcGkw5evouzpbDXxxkMkzPK8wl4xQfQf7lHe11Jotell5ikMVAtikXJEu/OJVaoV51BggRQ==",
+      "requires": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.0.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3886,6 +3932,16 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4388,6 +4444,19 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4609,6 +4678,11 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -16,9 +16,10 @@
     "body-parser": "^1.20.0",
     "express": "^4.17.2",
     "hbs": "^4.2.0",
+    "ioredis": "^5.2.2",
     "morgan": "^1.10.0",
-    "yargs": "^17.4.0",
-    "uid": "^2.0.0"
+    "uid": "^2.0.0",
+    "yargs": "^17.4.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/app/server/src/redis.ts
+++ b/app/server/src/redis.ts
@@ -1,10 +1,10 @@
 import Redis from "ioredis";
 
-export function redisConnection(url: string): Redis {
+export function redisConnection(url: string, errorCallback: (err: Error) => void): Redis {
     const redis = new Redis(url);
-    redis.on("error", (err) => {
+    redis.on("error", (err: Error) => {
         console.log(err);
-        throw Error(`Failed to connect to redis server ${url}`);
+        errorCallback(err);
     });
     redis.on("connect", () => {
         console.log(`Connected to Redis server ${url}`);

--- a/app/server/src/redis.ts
+++ b/app/server/src/redis.ts
@@ -4,6 +4,7 @@ export function redisConnection(url: string, errorCallback: (err: Error) => void
     const redis = new Redis(url);
     redis.on("error", (err: Error) => {
         console.log(err);
+        redis.disconnect();
         errorCallback(err);
     });
     redis.on("connect", () => {

--- a/app/server/src/redis.ts
+++ b/app/server/src/redis.ts
@@ -1,0 +1,13 @@
+import Redis from "ioredis";
+
+export function redisConnection(url: string): Redis {
+    const redis = new Redis(url);
+    redis.on("error", (err) => {
+        console.log(err);
+        throw Error(`Failed to connect to redis server ${url}`);
+    });
+    redis.on("connect", () => {
+        console.log(`Connected to Redis server ${url}`);
+    });
+    return redis;
+}

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -31,7 +31,10 @@ const defaultCodeReader = new DefaultCodeReader(`${configPath}/defaultCode`);
 // Use WODIN version from package.json
 const wodinVersion = process.env.npm_package_version;
 
-const redis = redisConnection(wodinConfig.redisURL);
+const redis = redisConnection(
+    wodinConfig.redisURL,
+    () => { throw Error(`Failed to connect to redis server ${wodinConfig.redisURL}`); }
+);
 
 // Make app locals available to controllers
 Object.assign(app.locals, {

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -7,6 +7,7 @@ import { registerRoutes } from "../routes";
 import { DefaultCodeReader } from "../defaultCodeReader";
 import { handleError } from "../errors/handleError";
 import { initialiseLogging } from "../logging";
+import { redisConnection } from "../redis";
 
 const express = require("express");
 const path = require("path");
@@ -30,9 +31,11 @@ const defaultCodeReader = new DefaultCodeReader(`${configPath}/defaultCode`);
 // Use WODIN version from package.json
 const wodinVersion = process.env.npm_package_version;
 
+const redis = redisConnection(wodinConfig.redisURL);
+
 // Make app locals available to controllers
 Object.assign(app.locals, {
-    appsPath, configPath, configReader, defaultCodeReader, odinAPI, wodinConfig, wodinVersion
+    appsPath, configPath, configReader, defaultCodeReader, odinAPI, redis, wodinConfig, wodinVersion
 });
 
 // Static content

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -5,6 +5,7 @@ export interface WodinConfig {
     courseTitle: string,
     port: number,
     odinAPI: string,
+    redisURL: string,
     appsPath: string
 }
 

--- a/app/server/tests/redis.test.ts
+++ b/app/server/tests/redis.test.ts
@@ -1,0 +1,31 @@
+import { redisConnection } from "../src/redis";
+
+describe("redis", () => {
+    const mockConsoleLog = jest.fn();
+    const realConsoleLog = console.log;
+    const realArgs = process.argv;
+
+    beforeAll(() => {
+        console.log = mockConsoleLog;
+    });
+
+    afterAll(() => {
+        console.log = realConsoleLog;
+        process.argv = realArgs;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("can connect", (done) => {
+        const redis = redisConnection("redis://localhost:6379");
+        setTimeout(() => {
+            redis.disconnect();
+            expect(mockConsoleLog).toBeCalledTimes(1);
+            expect(mockConsoleLog.mock.calls[0][0]).toBe(
+                "Connected to Redis server redis://localhost:6379");
+            done();
+        }, 200);
+    });
+});

--- a/app/server/tests/redis.test.ts
+++ b/app/server/tests/redis.test.ts
@@ -23,8 +23,8 @@ describe("redis", () => {
         setTimeout(() => {
             redis.disconnect();
             expect(mockConsoleLog).toBeCalledTimes(1);
-            expect(mockConsoleLog.mock.calls[0][0]).toBe(
-                "Connected to Redis server redis://localhost:6379");
+            expect(mockConsoleLog.mock.calls[0][0])
+                .toBe("Connected to Redis server redis://localhost:6379");
             done();
         }, 200);
     });

--- a/app/server/tests/redis.test.ts
+++ b/app/server/tests/redis.test.ts
@@ -19,12 +19,25 @@ describe("redis", () => {
     });
 
     it("can connect", (done) => {
-        const redis = redisConnection("redis://localhost:6379");
+        const errorCallback = jest.fn();
+        const redis = redisConnection("redis://localhost:6379", errorCallback);
         setTimeout(() => {
             redis.disconnect();
             expect(mockConsoleLog).toBeCalledTimes(1);
             expect(mockConsoleLog.mock.calls[0][0])
                 .toBe("Connected to Redis server redis://localhost:6379");
+            expect(errorCallback).not.toHaveBeenCalled();
+            done();
+        }, 200);
+    });
+
+    it("calls error callback if cannot connect", (done) => {
+        const errorCallback = jest.fn();
+        redisConnection("redis://localhost:1234", errorCallback);
+        setTimeout(() => {
+            expect(mockConsoleLog.mock.calls[0][0].message)
+                .toContain("connect ECONNREFUSED 127.0.0.1:1234");
+            expect(errorCallback).toHaveBeenCalled();
             done();
         }, 200);
     });

--- a/config/wodin.config.json
+++ b/config/wodin.config.json
@@ -2,5 +2,6 @@
     "courseTitle": "WODIN Example",
     "port": 3000,
     "appsPath": "apps",
-    "odinAPI": "http://localhost:8001"
+    "odinAPI": "http://localhost:8001",
+    "redisURL": "redis://localhost:6379"
 }

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -5,3 +5,4 @@ ODIN_API_BRANCH=main
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH
+docker run -d --name wodin-redis --rm -p 6379:6379 redis:6

--- a/scripts/run-dev-dependencies.sh
+++ b/scripts/run-dev-dependencies.sh
@@ -7,7 +7,9 @@ HERE=$(dirname "$0")
 
 # From now on, if the user presses Ctrl+C we should teardown gracefully
 function cleanup() {
+  set +x
   docker kill odin.api
+  docker kill wodin-redis
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
This is pretty basic, but hopefully an ok starting point. See https://github.com/mrc-ide/wodin-demo/pull/2 for deployment tweaks, which are fairly straightforward

I am stuck with the tests here, as my knowledge of how JS does async things is nonexistant. I tried adding a test file like:

```
import { redisConnection } from "../src/redis";

describe("redis", () => {
    const mockConsoleLog = jest.fn();
    const realConsoleLog = console.log;
    const realArgs = process.argv;

    beforeAll(() => {
        console.log = mockConsoleLog;
    });

    afterAll(() => {
        console.log = realConsoleLog;
        process.argv = realArgs;
    });

    afterEach(() => {
        jest.clearAllMocks();
    });
    
    it("can connect", () => {
        const redis = redisConnection("redis://localhost:6379");
        expect(mockConsoleLog).toBeCalledTimes(1);
        expect(mockConsoleLog.mock.calls[0][0]).toBe(
            "Connected to Redis server redis://localhost:6379");
    });

    it("errors if connection is impossible", async () => {
        expect(() => redisConnection("redis://localhost:12345"))
            .toThrow("Failed to connect to redis server redis://localhost:12345");
        expect(mockConsoleLog).toBeCalledTimes(1);
    });
});
```

but this fails with 

```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Connected to Redis server redis://localhost:6379".



      at console.log (node_modules/@jest/console/build/CustomConsole.js:187:10)
      at EventEmitter.<anonymous> (src/redis.ts:283:13)


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Error: connect ECONNREFUSED 127.0.0.1:12345
        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
      errno: -111,
      code: 'ECONNREFUSED',
      syscall: 'connect',
      address: '127.0.0.1',
      port: 12345
    }".



      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1157:16) {
        errno: -111,
        code: 'ECONNREFUSED',
        syscall: 'connect',
        address: '127.0.0.1',
        port: 12345
      }".
      at console.log (node_modules/@jest/console/build/CustomConsole.js:187:10)
      at EventEmitter.<anonymous> (src/redis.ts:270:13)
      at EventEmitter.silentEmit (node_modules/ioredis/built/Redis.js:460:30)
      at Socket.<anonymous> (node_modules/ioredis/built/redis/event_handler.js:189:14)

/home/rich/Documents/Projects/centre/wodin/app/server/src/redis.ts:274
    throw Error(`Failed to connect to redis server ${url}`);
    ^

Error: Failed to connect to redis server redis://localhost:12345
    at EventEmitter.<anonymous> (/home/rich/Documents/Projects/centre/wodin/app/server/src/redis.ts:274:11)
    at EventEmitter.emit (node:events:526:28)
    at EventEmitter.silentEmit (/home/rich/Documents/Projects/centre/wodin/app/server/node_modules/ioredis/built/Redis.js:460:30)
    at Socket.<anonymous> (/home/rich/Documents/Projects/centre/wodin/app/server/node_modules/ioredis/built/redis/event_handler.js:189:14)
    at Object.onceWrapper (node:events:646:26)
    at Socket.emit (node:events:538:35)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

my googling is not bringing up much joy here. On the plus side, it works empirically....