### PR TITLE
Decouple the two plots

### DIFF
--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -1,0 +1,207 @@
+<template>
+    <div class="run-plot-container" :style="plotStyle">
+      <div class="fit-plot" ref="plot">
+      </div>
+      <div v-if="!hasPlotData" class="plot-placeholder">
+        {{ placeholderMessage }}
+      </div>
+      <slot></slot>
+    </div>
+</template>
+
+<script lang="ts">
+import {
+    computed, defineComponent, ref, watch, onMounted, onUnmounted
+} from "vue";
+import { useStore } from "vuex";
+import { EventEmitter } from "events";
+import {
+    Data, newPlot, react, PlotData, PlotRelayoutEvent, Plots
+} from "plotly.js";
+import { FitDataGetter } from "../../store/fitData/getters";
+import userMessages from "../../userMessages";
+import { OdinSeriesSet } from "../../types/responseTypes";
+import { Dict } from "../../types/utilTypes";
+
+export default defineComponent({
+    name: "FitPlot",
+    props: {
+        fadePlot: Boolean,
+        modelFit: Boolean
+    },
+    setup(props) {
+        const store = useStore();
+
+        const placeholderMessage = computed(() => (props.modelFit ? userMessages.modelFit.notFittedYet
+            : userMessages.run.notRunYet));
+
+        const plotStyle = computed(() => (props.fadePlot ? "opacity:0.5;" : ""));
+        const solution = computed(() => (props.modelFit ? store.state.modelFit.solution
+            : store.state.model.odinSolution));
+
+        // mrc-3331 start time should always be zero.
+        const startTime = computed(() => {
+            return props.modelFit ? store.getters[`fitData/${FitDataGetter.dataStart}`] : 0;
+        });
+        const endTime = computed(() => {
+            return props.modelFit ? store.getters[`fitData/${FitDataGetter.dataEnd}`] : store.state.model.endTime;
+        });
+
+        const palette = computed(() => store.state.model.paletteModel);
+
+        const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
+        const baseData = ref<Data[]>([]);
+        const nPoints = 1000; // TODO: appropriate value could be derived from width of element
+
+        const hasPlotData = computed(() => !!(baseData.value?.length));
+
+        const seriesColour = (variable: string) => ({ color: palette.value[variable] });
+
+        const filterSeriesSet = (s: OdinSeriesSet, name: string): OdinSeriesSet => {
+            const idx = s.names.indexOf(name);
+            return {
+                names: [s.names[idx]],
+                x: s.x,
+                y: [s.y[idx]]
+            };
+        };
+
+        const odinToPlotly = (s: OdinSeriesSet): Partial<PlotData>[] => s.y.map(
+            (el: number[], i: number): Partial<PlotData> => ({
+                line: seriesColour(s.names[i]),
+                name: s.names[i],
+                x: s.x,
+                y: s.y[i]
+            })
+        );
+
+        // translate fit data into a form that can be plotted - only supported for modelFit for now
+        const fitDataSeries = (start: number, end: number): Partial<PlotData>[] => {
+            const { fitData } = store.state;
+            const timeVar = fitData?.timeVariable;
+            const dataVar = fitData?.columnToFit;
+            if (props.modelFit && fitData.data && dataVar && timeVar) {
+                const filteredData = fitData.data.filter(
+                    (row: Dict<number>) => row[timeVar] >= start && row[timeVar] <= end
+                );
+                const modelVar = fitData.linkedVariables[dataVar];
+                return [{
+                    name: dataVar,
+                    x: filteredData.map((row: Dict<number>) => row[timeVar]),
+                    y: filteredData.map((row: Dict<number>) => row[dataVar]),
+                    mode: "markers",
+                    type: "scatter",
+                    marker: seriesColour(modelVar)
+                }];
+            }
+            return [];
+        };
+
+        const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
+            let result = solution.value(start, end, nPoints);
+            if (!result) {
+                return [];
+            }
+            if (props.modelFit) {
+                const { fitData } = store.state;
+                const dataVar = fitData?.columnToFit;
+                const modelVar = fitData.linkedVariables[dataVar];
+                result = filterSeriesSet(result, modelVar);
+            }
+            return [...odinToPlotly(result), ...fitDataSeries(start, end)];
+        };
+
+        const config = {
+            responsive: true
+        };
+
+        // This is enough top margin to accomodate the plotly options
+        // bar without it interfering with the first series in the
+        // legend.
+        const margin = {
+            t: 25
+        };
+
+        const relayout = async (event: PlotRelayoutEvent) => {
+            let data;
+            if (event["xaxis.autorange"] === true) {
+                data = baseData.value;
+            } else {
+                const t0 = event["xaxis.range[0]"];
+                const t1 = event["xaxis.range[1]"];
+                if (t0 === undefined || t1 === undefined) {
+                    return;
+                }
+                data = allPlotData(t0, t1);
+            }
+
+            const layout = {
+                margin,
+                uirevision: "true",
+                xaxis: { autorange: true },
+                yaxis: { autorange: true }
+            };
+
+            const el = plot.value as HTMLElement;
+            await react(el, data, layout, config);
+        };
+
+        const resize = () => {
+            if (plot.value) {
+                Plots.resize(plot.value as HTMLElement);
+            }
+        };
+
+        let resizeObserver: null | ResizeObserver = null;
+
+        const drawPlot = () => {
+            if (solution.value) {
+                baseData.value = allPlotData(startTime.value, endTime.value);
+
+                if (hasPlotData.value) {
+                    const el = plot.value as unknown;
+                    const layout = {
+                        margin
+                    };
+                    newPlot(el as HTMLElement, baseData.value, layout, config);
+                    (el as EventEmitter).on("plotly_relayout", relayout);
+                    resizeObserver = new ResizeObserver(resize);
+                    resizeObserver.observe(plot.value as HTMLElement);
+                }
+            }
+        };
+
+        onMounted(drawPlot);
+
+        watch(solution, drawPlot);
+
+        onUnmounted(() => {
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+            }
+        });
+
+        return {
+            placeholderMessage,
+            plotStyle,
+            plot,
+            relayout,
+            resize,
+            solution,
+            baseData,
+            hasPlotData
+        };
+    }
+});
+</script>
+<style scoped lang="scss">
+  .plot-placeholder {
+    width: 100%;
+    height: 450px;
+    background-color: #eee;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+</style>

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -16,12 +16,12 @@ import {
 import { useStore } from "vuex";
 import { EventEmitter } from "events";
 import {
-    Data, newPlot, react, PlotData, PlotRelayoutEvent, Plots
+    newPlot, react, PlotRelayoutEvent, Plots
 } from "plotly.js";
 import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
 import { Dict } from "../../types/utilTypes";
-import { filterSeriesSet, odinToPlotly } from "../../plot";
+import { filterSeriesSet, odinToPlotly, WodinPlotData } from "../../plot";
 
 export default defineComponent({
     name: "FitPlot",
@@ -42,14 +42,14 @@ export default defineComponent({
         const palette = computed(() => store.state.model.paletteModel);
 
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
-        const baseData = ref<Data[]>([]);
+        const baseData = ref<WodinPlotData>([]);
         const nPoints = 1000; // TODO: appropriate value could be derived from width of element
 
         const hasPlotData = computed(() => !!(baseData.value?.length));
 
         const seriesColour = (variable: string) => ({ color: palette.value[variable] });
 
-        const fitDataSeries = (start: number, end: number): Partial<PlotData>[] => {
+        const fitDataSeries = (start: number, end: number): WodinPlotData => {
             const { fitData } = store.state;
             const timeVar = fitData?.timeVariable;
             const dataVar = fitData?.columnToFit;
@@ -70,7 +70,7 @@ export default defineComponent({
             return [];
         };
 
-        const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
+        const allPlotData = (start: number, end: number): WodinPlotData => {
             const result = solution.value(start, end, nPoints);
             if (!result) {
                 return [];
@@ -78,7 +78,7 @@ export default defineComponent({
             const { fitData } = store.state;
             const dataVar = fitData?.columnToFit;
             const modelVar = fitData.linkedVariables[dataVar];
-            return [...odinToPlotly(filterSeriesSet(result, modelVar)), ...fitDataSeries(start, end)];
+            return [...odinToPlotly(filterSeriesSet(result, modelVar), palette.value), ...fitDataSeries(start, end)];
         };
 
         const config = {

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -20,8 +20,8 @@ import {
 } from "plotly.js";
 import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
-import { OdinSeriesSet } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
+import { filterSeriesSet, odinToPlotly } from "../../plot";
 
 export default defineComponent({
     name: "FitPlot",
@@ -49,24 +49,6 @@ export default defineComponent({
 
         const seriesColour = (variable: string) => ({ color: palette.value[variable] });
 
-        const filterSeriesSet = (s: OdinSeriesSet, name: string): OdinSeriesSet => {
-            const idx = s.names.indexOf(name);
-            return {
-                names: [s.names[idx]],
-                x: s.x,
-                y: [s.y[idx]]
-            };
-        };
-
-        const odinToPlotly = (s: OdinSeriesSet): Partial<PlotData>[] => s.y.map(
-            (el: number[], i: number): Partial<PlotData> => ({
-                line: seriesColour(s.names[i]),
-                name: s.names[i],
-                x: s.x,
-                y: s.y[i]
-            })
-        );
-
         const fitDataSeries = (start: number, end: number): Partial<PlotData>[] => {
             const { fitData } = store.state;
             const timeVar = fitData?.timeVariable;
@@ -89,7 +71,7 @@ export default defineComponent({
         };
 
         const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
-            let result = solution.value(start, end, nPoints);
+            const result = solution.value(start, end, nPoints);
             if (!result) {
                 return [];
             }

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -25,7 +25,7 @@
 import { computed } from "vue";
 import { useStore } from "vuex";
 import VueFeather from "vue-feather";
-import FitPlot from "../fit/FitPlot.vue";
+import FitPlot from "./FitPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { ModelFitAction } from "../../store/modelFit/actions";
 import { ModelFitGetter } from "../../store/modelFit/getters";

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -4,7 +4,7 @@
       <button class="btn btn-primary me-2" id="fit-btn" :disabled="!canFitModel" @click="fitModel">Fit model</button>
       <button class="btn btn-outline" id="cancel-fit-btn" :disabled="!fitting" @click="cancelFit">Cancel fit</button>
       <action-required-message :message="actionRequiredMessage"></action-required-message>
-      <run-model-plot :fade-plot="!!actionRequiredMessage" :model-fit="true">
+      <fit-plot :fade-plot="!!actionRequiredMessage" :model-fit="true">
         <div v-if="iterations">
           <vue-feather v-if="iconType"
                        class="inline-icon"
@@ -16,7 +16,7 @@
           <span class="ms-2">Sum of squares: {{sumOfSquares}}</span>
           <div v-if="cancelled" id="fit-cancelled-msg" class="small text-danger">{{cancelledMsg}}</div>
         </div>
-      </run-model-plot>
+      </fit-plot>
     </div>
   </div>
 </template>
@@ -25,7 +25,7 @@
 import { computed } from "vue";
 import { useStore } from "vuex";
 import VueFeather from "vue-feather";
-import RunModelPlot from "../run/RunModelPlot.vue";
+import FitPlot from "../fit/FitPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { ModelFitAction } from "../../store/modelFit/actions";
 import { ModelFitGetter } from "../../store/modelFit/getters";
@@ -38,7 +38,7 @@ export default {
     name: "FitTab",
     components: {
         LoadingSpinner,
-        RunModelPlot,
+        FitPlot,
         ActionRequiredMessage,
         VueFeather
     },

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -16,10 +16,10 @@ import {
 import { useStore } from "vuex";
 import { EventEmitter } from "events";
 import {
-    Data, newPlot, react, PlotData, PlotRelayoutEvent, Plots
+    newPlot, react, PlotRelayoutEvent, Plots
 } from "plotly.js";
 import userMessages from "../../userMessages";
-import { odinToPlotly } from "../../plot";
+import { odinToPlotly, WodinPlotData } from "../../plot";
 
 export default defineComponent({
     name: "RunPlot",
@@ -41,17 +41,17 @@ export default defineComponent({
         const palette = computed(() => store.state.model.paletteModel);
 
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
-        const baseData = ref<Data[]>([]);
+        const baseData = ref<WodinPlotData>([]);
         const nPoints = 1000; // TODO: appropriate value could be derived from width of element
 
         const hasPlotData = computed(() => !!(baseData.value?.length));
 
-        const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
+        const allPlotData = (start: number, end: number): WodinPlotData => {
             const result = solution.value(start, end, nPoints);
             if (!result) {
                 return [];
             }
-            return [...odinToPlotly(result)];
+            return [...odinToPlotly(result, palette.value)];
         };
 
         const config = {

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -19,8 +19,7 @@ import {
     Data, newPlot, react, PlotData, PlotRelayoutEvent, Plots
 } from "plotly.js";
 import userMessages from "../../userMessages";
-import { OdinSeriesSet } from "../../types/responseTypes";
-import { Dict } from "../../types/utilTypes";
+import { odinToPlotly } from "../../plot";
 
 export default defineComponent({
     name: "RunPlot",
@@ -47,19 +46,8 @@ export default defineComponent({
 
         const hasPlotData = computed(() => !!(baseData.value?.length));
 
-        const seriesColour = (variable: string) => ({ color: palette.value[variable] });
-
-        const odinToPlotly = (s: OdinSeriesSet): Partial<PlotData>[] => s.y.map(
-            (el: number[], i: number): Partial<PlotData> => ({
-                line: seriesColour(s.names[i]),
-                name: s.names[i],
-                x: s.x,
-                y: s.y[i]
-            })
-        );
-
         const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
-            let result = solution.value(start, end, nPoints);
+            const result = solution.value(start, end, nPoints);
             if (!result) {
                 return [];
             }

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="run-plot-container" :style="plotStyle">
-      <div class="run-model-plot" ref="plot">
+      <div class="run-plot" ref="plot">
       </div>
       <div v-if="!hasPlotData" class="plot-placeholder">
         {{ placeholderMessage }}
@@ -24,7 +24,7 @@ import { OdinSeriesSet } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
 
 export default defineComponent({
-    name: "RunModelPlot",
+    name: "RunPlot",
     props: {
         fadePlot: Boolean,
         modelFit: Boolean

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -18,7 +18,6 @@ import { EventEmitter } from "events";
 import {
     Data, newPlot, react, PlotData, PlotRelayoutEvent, Plots
 } from "plotly.js";
-import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
 import { OdinSeriesSet } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
@@ -26,26 +25,19 @@ import { Dict } from "../../types/utilTypes";
 export default defineComponent({
     name: "RunPlot",
     props: {
-        fadePlot: Boolean,
-        modelFit: Boolean
+        fadePlot: Boolean
     },
     setup(props) {
         const store = useStore();
 
-        const placeholderMessage = computed(() => (props.modelFit ? userMessages.modelFit.notFittedYet
-            : userMessages.run.notRunYet));
+        const placeholderMessage = computed(() => (userMessages.run.notRunYet));
 
         const plotStyle = computed(() => (props.fadePlot ? "opacity:0.5;" : ""));
-        const solution = computed(() => (props.modelFit ? store.state.modelFit.solution
-            : store.state.model.odinSolution));
+        const solution = computed(() => (store.state.model.odinSolution));
 
         // mrc-3331 start time should always be zero.
-        const startTime = computed(() => {
-            return props.modelFit ? store.getters[`fitData/${FitDataGetter.dataStart}`] : 0;
-        });
-        const endTime = computed(() => {
-            return props.modelFit ? store.getters[`fitData/${FitDataGetter.dataEnd}`] : store.state.model.endTime;
-        });
+        const startTime = 0;
+        const endTime = computed(() => store.state.model.endTime);
 
         const palette = computed(() => store.state.model.paletteModel);
 
@@ -57,15 +49,6 @@ export default defineComponent({
 
         const seriesColour = (variable: string) => ({ color: palette.value[variable] });
 
-        const filterSeriesSet = (s: OdinSeriesSet, name: string): OdinSeriesSet => {
-            const idx = s.names.indexOf(name);
-            return {
-                names: [s.names[idx]],
-                x: s.x,
-                y: [s.y[idx]]
-            };
-        };
-
         const odinToPlotly = (s: OdinSeriesSet): Partial<PlotData>[] => s.y.map(
             (el: number[], i: number): Partial<PlotData> => ({
                 line: seriesColour(s.names[i]),
@@ -75,40 +58,12 @@ export default defineComponent({
             })
         );
 
-        // translate fit data into a form that can be plotted - only supported for modelFit for now
-        const fitDataSeries = (start: number, end: number): Partial<PlotData>[] => {
-            const { fitData } = store.state;
-            const timeVar = fitData?.timeVariable;
-            const dataVar = fitData?.columnToFit;
-            if (props.modelFit && fitData.data && dataVar && timeVar) {
-                const filteredData = fitData.data.filter(
-                    (row: Dict<number>) => row[timeVar] >= start && row[timeVar] <= end
-                );
-                const modelVar = fitData.linkedVariables[dataVar];
-                return [{
-                    name: dataVar,
-                    x: filteredData.map((row: Dict<number>) => row[timeVar]),
-                    y: filteredData.map((row: Dict<number>) => row[dataVar]),
-                    mode: "markers",
-                    type: "scatter",
-                    marker: seriesColour(modelVar)
-                }];
-            }
-            return [];
-        };
-
         const allPlotData = (start: number, end: number): Partial<PlotData>[] => {
             let result = solution.value(start, end, nPoints);
             if (!result) {
                 return [];
             }
-            if (props.modelFit) {
-                const { fitData } = store.state;
-                const dataVar = fitData?.columnToFit;
-                const modelVar = fitData.linkedVariables[dataVar];
-                result = filterSeriesSet(result, modelVar);
-            }
-            return [...odinToPlotly(result), ...fitDataSeries(start, end)];
+            return [...odinToPlotly(result)];
         };
 
         const config = {
@@ -156,7 +111,7 @@ export default defineComponent({
 
         const drawPlot = () => {
             if (solution.value) {
-                baseData.value = allPlotData(startTime.value, endTime.value);
+                baseData.value = allPlotData(startTime, endTime.value);
 
                 if (hasPlotData.value) {
                     const el = plot.value as unknown;

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -4,7 +4,7 @@
             <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
         </div>
         <action-required-message :message="updateMsg"></action-required-message>
-        <run-model-plot :fade-plot="!!updateMsg" :model-fit="false"></run-model-plot>
+        <run-plot :fade-plot="!!updateMsg" :model-fit="false"></run-plot>
         <error-info :error="error"></error-info>
   </div>
 </template>
@@ -12,7 +12,7 @@
 <script lang="ts">
 import { useStore } from "vuex";
 import { computed, defineComponent } from "vue";
-import RunModelPlot from "./RunModelPlot.vue";
+import RunPlot from "./RunPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { ModelAction } from "../../store/model/actions";
 import { RequiredModelAction } from "../../store/model/state";
@@ -22,7 +22,7 @@ import ErrorInfo from "../ErrorInfo.vue";
 export default defineComponent({
     name: "RunTab",
     components: {
-        RunModelPlot,
+        RunPlot,
         ErrorInfo,
         ActionRequiredMessage
     },

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,0 +1,25 @@
+import { Palette } from "./palette";
+import { OdinSeriesSet } from "./types/responseTypes";
+
+export type WodinPlotData = Partial<PlotData>[];
+export type AllPlotData = (t0: number, t1: number) => WodinPlotData;
+
+export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
+    const idx = s.names.indexOf(name);
+    return {
+        names: [s.names[idx]],
+        x: s.x,
+        y: [s.y[idx]]
+    };
+}
+
+export function odinToPlotly(s: OdinSeriesSet, palette: Palette): WodinPlotData {
+    return s.y.map(
+        (el: number[], i: number): Partial<PlotData> => ({
+            line: { color: palette[variable] },
+            name: s.names[i],
+            x: s.x,
+            y: s.y[i]
+        })
+    );
+}

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -3,7 +3,6 @@ import { Palette } from "./palette";
 import { OdinSeriesSet } from "./types/responseTypes";
 
 export type WodinPlotData = Partial<PlotData>[];
-export type AllPlotData = (t0: number, t1: number) => WodinPlotData;
 
 export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
     const idx = s.names.indexOf(name);

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,3 +1,4 @@
+import { PlotData } from "plotly.js";
 import { Palette } from "./palette";
 import { OdinSeriesSet } from "./types/responseTypes";
 
@@ -16,7 +17,7 @@ export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
 export function odinToPlotly(s: OdinSeriesSet, palette: Palette): WodinPlotData {
     return s.y.map(
         (el: number[], i: number): Partial<PlotData> => ({
-            line: { color: palette[variable] },
+            line: { color: palette[s.names[i]] },
             name: s.names[i],
             x: s.x,
             y: s.y[i]

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -166,7 +166,7 @@ const startModelFit = async (page: Page, data: string = realisticFitData) => {
 };
 
 const waitForModelFitCompletion = async (page: Page) => {
-    await expect(await page.getAttribute(".run-plot-container .vue-feather", "data-type")).toBe("check");
+    await expect(await page.getAttribute(".fit-plot-container .vue-feather", "data-type")).toBe("check");
 };
 
 const runFit = async (page: Page) => {
@@ -231,8 +231,8 @@ test.describe("Wodin App model fit tests", () => {
         await startModelFit(page);
         await waitForModelFitCompletion(page);
 
-        await expect(await page.innerText(":nth-match(.run-plot-container span, 1)")).toContain("Iterations:");
-        const sumOfSquares = await page.innerText(":nth-match(.run-plot-container span, 2)");
+        await expect(await page.innerText(":nth-match(.fit-plot-container span, 1)")).toContain("Iterations:");
+        const sumOfSquares = await page.innerText(":nth-match(.fit-plot-container span, 2)");
         expect(sumOfSquares).toContain("Sum of squares:");
 
         const plotSelector = ".wodin-right .wodin-content div.mt-4 .js-plotly-plot";
@@ -255,7 +255,7 @@ test.describe("Wodin App model fit tests", () => {
         await page.click(":nth-match(input.vary-param-check, 2)");
         await page.click(".wodin-right .wodin-content div.mt-4 button");
         await waitForModelFitCompletion(page);
-        const newSumOfSquares = await page.innerText(":nth-match(.run-plot-container span, 2)");
+        const newSumOfSquares = await page.innerText(":nth-match(.fit-plot-container span, 2)");
         expect(newSumOfSquares).not.toEqual(sumOfSquares);
     });
 
@@ -350,9 +350,9 @@ test.describe("Wodin App model fit tests", () => {
         await startModelFit(page);
         await page.click(".wodin-right .wodin-content div.mt-4 button#cancel-fit-btn");
 
-        await expect(await page.getAttribute(".run-plot-container .vue-feather", "data-type")).toBe("alert-circle");
-        await expect(await page.innerText(":nth-match(.run-plot-container span, 1)")).toContain("Iterations:");
-        await expect(await page.innerText(":nth-match(.run-plot-container span, 2)"))
+        await expect(await page.getAttribute(".fit-plot-container .vue-feather", "data-type")).toBe("alert-circle");
+        await expect(await page.innerText(":nth-match(.fit-plot-container span, 1)")).toContain("Iterations:");
+        await expect(await page.innerText(":nth-match(.fit-plot-container span, 2)"))
             .toContain("Sum of squares:");
         await expect(await page.innerText("#fit-cancelled-msg")).toBe("Model fit was cancelled before converging");
     });

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -64,9 +64,9 @@ describe("FitPlot", () => {
         });
     };
 
-    const getWrapper = (store = getStore(), fadePlot = false, modelFit = false) => {
+    const getWrapper = (store = getStore(), fadePlot = false) => {
         return shallowMount(FitPlot, {
-            props: { fadePlot, modelFit },
+            props: { fadePlot },
             global: {
                 plugins: [store]
             }
@@ -84,24 +84,24 @@ describe("FitPlot", () => {
         jest.clearAllMocks();
     });
 
-    it("renders plot ref element", () => {
-        const wrapper = getWrapper();
-        const div = wrapper.find("div.fit-plot");
-        expect(div.exists()).toBe(true);
-        expect((wrapper.vm as any).plot).toBe(div.element);
-    });
+    // it("renders plot ref element", () => {
+    //     const wrapper = getWrapper();
+    //     const div = wrapper.find("div.fit-plot");
+    //     expect(div.exists()).toBe(true);
+    //     expect((wrapper.vm as any).plot).toBe(div.element);
+    // });
 
-    it("does not render fade style when fadePlot is false", () => {
-        const wrapper = getWrapper();
-        const div = wrapper.find("div.run-plot-container");
-        expect(div.attributes("style")).toBe("");
-    });
+    // it("does not render fade style when fadePlot is false", () => {
+    //     const wrapper = getWrapper();
+    //     const div = wrapper.find("div.fit-plot-container");
+    //     expect(div.attributes("style")).toBe("");
+    // });
 
-    it("renders fade style when fade plot is true", () => {
-        const wrapper = getWrapper(getStore(), true);
-        const div = wrapper.find("div.run-plot-container");
-        expect(div.attributes("style")).toBe("opacity: 0.5;");
-    });
+    // it("renders fade style when fade plot is true", () => {
+    //     const wrapper = getWrapper(getStore(), true);
+    //     const div = wrapper.find("div.fit-plot-container");
+    //     expect(div.attributes("style")).toBe("opacity: 0.5;");
+    // });
 
     it("renders slot content", () => {
         const store = getStore();
@@ -113,7 +113,7 @@ describe("FitPlot", () => {
                 default: "<h3>test slot content</h3>"
             }
         });
-        expect(wrapper.find("div.run-plot-container").find("h3").text()).toBe("test slot content");
+        expect(wrapper.find("div.fit-plot-container").find("h3").text()).toBe("test slot content");
     });
 
     const mockSolutionNull = (param1: number, param2: number) => null;
@@ -175,26 +175,26 @@ describe("FitPlot", () => {
         }
     ];
 
-    it("draws run plot and sets event handler when odin solution is updated", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        const mockOn = mockPlotElementOn(wrapper);
+    // it("draws run plot and sets event handler when odin solution is updated", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     const mockOn = mockPlotElementOn(wrapper);
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
-        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
-        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-        expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
+    //     expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
+    //     expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+    //     expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
 
-        expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
-        const { relayout } = wrapper.vm as any;
-        expect(mockOn.mock.calls[0][1]).toBe(relayout);
-    });
+    //     expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
+    //     const { relayout } = wrapper.vm as any;
+    //     expect(mockOn.mock.calls[0][1]).toBe(relayout);
+    // });
 
     it("draws model fit plot and sets event handler when modelFit solution is updated", async () => {
         const store = getStore(jest.fn(), mockFitData);
-        const wrapper = getWrapper(store, false, true);
+        const wrapper = getWrapper(store, false);
         const mockOn = mockPlotElementOn(wrapper);
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
         store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
@@ -213,18 +213,18 @@ describe("FitPlot", () => {
         expect(mockOn.mock.calls[0][1]).toBe(relayout);
     });
 
-    it("does not draw run plot if base data is null", async () => {
-        const store = getStore();
-        getWrapper(store);
+    // it("does not draw run plot if base data is null", async () => {
+    //     const store = getStore();
+    //     getWrapper(store);
 
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolutionNull);
-        await nextTick();
-        expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
-    });
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolutionNull);
+    //     await nextTick();
+    //     expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
+    // });
 
     it("does not draw modelFit plot if base data is null", async () => {
         const store = getStore();
-        getWrapper(store, false, true);
+        getWrapper(store, false);
 
         store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
             data: {
@@ -242,33 +242,33 @@ describe("FitPlot", () => {
         yaxis: { autorange: true }
     };
 
-    it("for run plot, relayout reruns solution and calls react if not autorange", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
+    // it("for run plot, relayout reruns solution and calls react if not autorange", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        const relayoutEvent = {
-            "xaxis.autorange": false,
-            "xaxis.range[0]": 2,
-            "xaxis.range[1]": 7
-        };
+    //     const relayoutEvent = {
+    //         "xaxis.autorange": false,
+    //         "xaxis.range[0]": 2,
+    //         "xaxis.range[1]": 7
+    //     };
 
-        const { relayout } = wrapper.vm as any;
-        await relayout(relayoutEvent);
+    //     const { relayout } = wrapper.vm as any;
+    //     await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.fit-plot").element;
-        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
-        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
-    });
+    //     const divElement = wrapper.find("div.fit-plot").element;
+    //     expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+    //     expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+    //     expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    // });
 
     it("modelFit run plot, relayout reruns solution and calls react if not autorange", async () => {
         const store = getStore(jest.fn(), mockFitData);
-        const wrapper = getWrapper(store, false, true);
+        const wrapper = getWrapper(store, false);
         mockPlotElementOn(wrapper);
 
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
@@ -306,31 +306,31 @@ describe("FitPlot", () => {
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
     });
 
-    it("for run plot, relayout uses base data and calls react if autorange", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
+    // it("for run plot, relayout uses base data and calls react if autorange", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        const relayoutEvent = {
-            "xaxis.autorange": true
-        };
+    //     const relayoutEvent = {
+    //         "xaxis.autorange": true
+    //     };
 
-        const { relayout } = wrapper.vm as any;
-        await relayout(relayoutEvent);
+    //     const { relayout } = wrapper.vm as any;
+    //     await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.fit-plot").element;
-        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
-        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
-    });
+    //     const divElement = wrapper.find("div.fit-plot").element;
+    //     expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+    //     expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+    //     expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    // });
 
     it("for modelFit plot, relayout uses base data and calls react if autorange", async () => {
         const store = getStore(jest.fn(), mockFitData);
-        const wrapper = getWrapper(store, false, true);
+        const wrapper = getWrapper(store, false);
         mockPlotElementOn(wrapper);
 
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
@@ -354,101 +354,101 @@ describe("FitPlot", () => {
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
     });
 
-    it("relayout does nothing on autorange false if t0 is undefined", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    // it("relayout does nothing on autorange false if t0 is undefined", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        const relayoutEvent = {
-            "xaxis.autorange": false,
-            "xaxis.range[0]": undefined,
-            "xaxis.range[1]": 7
-        };
+    //     const relayoutEvent = {
+    //         "xaxis.autorange": false,
+    //         "xaxis.range[0]": undefined,
+    //         "xaxis.range[1]": 7
+    //     };
 
-        const { relayout } = wrapper.vm as any;
-        await relayout(relayoutEvent);
+    //     const { relayout } = wrapper.vm as any;
+    //     await relayout(relayoutEvent);
 
-        expect(mockPlotlyReact).not.toHaveBeenCalled();
-    });
+    //     expect(mockPlotlyReact).not.toHaveBeenCalled();
+    // });
 
-    it("relayout does nothing on autorange false if t1 is undefined", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
+    // it("relayout does nothing on autorange false if t1 is undefined", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        const relayoutEvent = {
-            "xaxis.autorange": false,
-            "xaxis.range[0]": 2,
-            "xaxis.range[1]": undefined
-        };
+    //     const relayoutEvent = {
+    //         "xaxis.autorange": false,
+    //         "xaxis.range[0]": 2,
+    //         "xaxis.range[1]": undefined
+    //     };
 
-        const { relayout } = wrapper.vm as any;
-        await relayout(relayoutEvent);
+    //     const { relayout } = wrapper.vm as any;
+    //     await relayout(relayoutEvent);
 
-        expect(mockPlotlyReact).not.toHaveBeenCalled();
-    });
+    //     expect(mockPlotlyReact).not.toHaveBeenCalled();
+    // });
 
-    it("initialises ResizeObserver", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    // it("initialises ResizeObserver", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        const divElement = wrapper.find("div.fit-plot").element;
-        expect(mockObserve).toHaveBeenCalledWith(divElement);
-    });
+    //     const divElement = wrapper.find("div.fit-plot").element;
+    //     expect(mockObserve).toHaveBeenCalledWith(divElement);
+    // });
 
-    it("resize method resizes Plot", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    // it("resize method resizes Plot", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        (wrapper.vm as any).resize();
-        const divElement = wrapper.find("div.fit-plot").element;
-        expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
-    });
+    //     (wrapper.vm as any).resize();
+    //     const divElement = wrapper.find("div.fit-plot").element;
+    //     expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
+    // });
 
-    it("disconnects resizeObserver on unmount", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
+    // it("disconnects resizeObserver on unmount", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
 
-        wrapper.unmount();
-        expect(mockDisconnect).toHaveBeenCalled();
-    });
+    //     wrapper.unmount();
+    //     expect(mockDisconnect).toHaveBeenCalled();
+    // });
 
-    it("does not attempt to disconnect resizeObserver if not initialised", () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        wrapper.unmount();
-        expect(mockDisconnect).not.toHaveBeenCalled();
-    });
+    // it("does not attempt to disconnect resizeObserver if not initialised", () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     wrapper.unmount();
+    //     expect(mockDisconnect).not.toHaveBeenCalled();
+    // });
 
-    it("renders placeholder div before solution is available", async () => {
-        const store = getStore();
-        const wrapper = getWrapper(store);
-        mockPlotElementOn(wrapper);
-        expect(wrapper.find(".plot-placeholder").text()).toBe("Model has not been run.");
+    // it("renders placeholder div before solution is available", async () => {
+    //     const store = getStore();
+    //     const wrapper = getWrapper(store);
+    //     mockPlotElementOn(wrapper);
+    //     expect(wrapper.find(".plot-placeholder").text()).toBe("Model has not been run.");
 
-        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-        await nextTick();
-        expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
-    });
+    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+    //     await nextTick();
+    //     expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
+    // });
 });

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -84,25 +84,6 @@ describe("FitPlot", () => {
         jest.clearAllMocks();
     });
 
-    // it("renders plot ref element", () => {
-    //     const wrapper = getWrapper();
-    //     const div = wrapper.find("div.fit-plot");
-    //     expect(div.exists()).toBe(true);
-    //     expect((wrapper.vm as any).plot).toBe(div.element);
-    // });
-
-    // it("does not render fade style when fadePlot is false", () => {
-    //     const wrapper = getWrapper();
-    //     const div = wrapper.find("div.fit-plot-container");
-    //     expect(div.attributes("style")).toBe("");
-    // });
-
-    // it("renders fade style when fade plot is true", () => {
-    //     const wrapper = getWrapper(getStore(), true);
-    //     const div = wrapper.find("div.fit-plot-container");
-    //     expect(div.attributes("style")).toBe("opacity: 0.5;");
-    // });
-
     it("renders slot content", () => {
         const store = getStore();
         const wrapper = shallowMount(FitPlot, {
@@ -125,6 +106,11 @@ describe("FitPlot", () => {
             [1, 2, 3]
         ]
     });
+    const mockFitResult = {
+        data: {
+            solution: mockSolution
+        }
+    };
 
     const mockFitData = {
         data: [{ t: 0, v: 10 }, { t: 1, v: 20 }],
@@ -175,33 +161,12 @@ describe("FitPlot", () => {
         }
     ];
 
-    // it("draws run plot and sets event handler when odin solution is updated", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     const mockOn = mockPlotElementOn(wrapper);
-
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
-    //     expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
-    //     expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-    //     expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
-
-    //     expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
-    //     const { relayout } = wrapper.vm as any;
-    //     expect(mockOn.mock.calls[0][1]).toBe(relayout);
-    // });
-
     it("draws model fit plot and sets event handler when modelFit solution is updated", async () => {
         const store = getStore(jest.fn(), mockFitData);
         const wrapper = getWrapper(store, false);
         const mockOn = mockPlotElementOn(wrapper);
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
-            data: {
-                solution: mockSolution
-            }
-        });
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
 
         await nextTick();
         expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
@@ -212,15 +177,6 @@ describe("FitPlot", () => {
         const { relayout } = wrapper.vm as any;
         expect(mockOn.mock.calls[0][1]).toBe(relayout);
     });
-
-    // it("does not draw run plot if base data is null", async () => {
-    //     const store = getStore();
-    //     getWrapper(store);
-
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolutionNull);
-    //     await nextTick();
-    //     expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
-    // });
 
     it("does not draw modelFit plot if base data is null", async () => {
         const store = getStore();
@@ -242,41 +198,13 @@ describe("FitPlot", () => {
         yaxis: { autorange: true }
     };
 
-    // it("for run plot, relayout reruns solution and calls react if not autorange", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
-
-    //     const relayoutEvent = {
-    //         "xaxis.autorange": false,
-    //         "xaxis.range[0]": 2,
-    //         "xaxis.range[1]": 7
-    //     };
-
-    //     const { relayout } = wrapper.vm as any;
-    //     await relayout(relayoutEvent);
-
-    //     const divElement = wrapper.find("div.fit-plot").element;
-    //     expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
-    //     expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-    //     expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
-    // });
-
     it("modelFit run plot, relayout reruns solution and calls react if not autorange", async () => {
         const store = getStore(jest.fn(), mockFitData);
         const wrapper = getWrapper(store, false);
         mockPlotElementOn(wrapper);
 
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
-            data: {
-                solution: mockSolution
-            }
-        });
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
         await nextTick();
 
         const relayoutEvent = {
@@ -306,39 +234,13 @@ describe("FitPlot", () => {
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
     });
 
-    // it("for run plot, relayout uses base data and calls react if autorange", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
-
-    //     const relayoutEvent = {
-    //         "xaxis.autorange": true
-    //     };
-
-    //     const { relayout } = wrapper.vm as any;
-    //     await relayout(relayoutEvent);
-
-    //     const divElement = wrapper.find("div.fit-plot").element;
-    //     expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
-    //     expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
-    //     expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
-    // });
-
     it("for modelFit plot, relayout uses base data and calls react if autorange", async () => {
         const store = getStore(jest.fn(), mockFitData);
         const wrapper = getWrapper(store, false);
         mockPlotElementOn(wrapper);
 
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
-            data: {
-                solution: mockSolution
-            }
-        });
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
         await nextTick();
 
         const relayoutEvent = {
@@ -354,101 +256,101 @@ describe("FitPlot", () => {
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
     });
 
-    // it("relayout does nothing on autorange false if t0 is undefined", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
+    it("relayout does nothing on autorange false if t0 is undefined", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
 
-    //     const relayoutEvent = {
-    //         "xaxis.autorange": false,
-    //         "xaxis.range[0]": undefined,
-    //         "xaxis.range[1]": 7
-    //     };
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": undefined,
+            "xaxis.range[1]": 7
+        };
 
-    //     const { relayout } = wrapper.vm as any;
-    //     await relayout(relayoutEvent);
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
 
-    //     expect(mockPlotlyReact).not.toHaveBeenCalled();
-    // });
+        expect(mockPlotlyReact).not.toHaveBeenCalled();
+    });
 
-    // it("relayout does nothing on autorange false if t1 is undefined", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
+    it("relayout does nothing on autorange false if t1 is undefined", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
 
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
 
-    //     const relayoutEvent = {
-    //         "xaxis.autorange": false,
-    //         "xaxis.range[0]": 2,
-    //         "xaxis.range[1]": undefined
-    //     };
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": 2,
+            "xaxis.range[1]": undefined
+        };
 
-    //     const { relayout } = wrapper.vm as any;
-    //     await relayout(relayoutEvent);
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
 
-    //     expect(mockPlotlyReact).not.toHaveBeenCalled();
-    // });
+        expect(mockPlotlyReact).not.toHaveBeenCalled();
+    });
 
-    // it("initialises ResizeObserver", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
+    it("initialises ResizeObserver", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
 
-    //     const divElement = wrapper.find("div.fit-plot").element;
-    //     expect(mockObserve).toHaveBeenCalledWith(divElement);
-    // });
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockObserve).toHaveBeenCalledWith(divElement);
+    });
 
-    // it("resize method resizes Plot", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
+    it("resize method resizes Plot", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
 
-    //     (wrapper.vm as any).resize();
-    //     const divElement = wrapper.find("div.fit-plot").element;
-    //     expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
-    // });
+        (wrapper.vm as any).resize();
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
+    });
 
-    // it("disconnects resizeObserver on unmount", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
+    it("disconnects resizeObserver on unmount", async () => {
+        const store = getStore(jest.fn(), mockFitData);
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
 
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
 
-    //     wrapper.unmount();
-    //     expect(mockDisconnect).toHaveBeenCalled();
-    // });
+        wrapper.unmount();
+        expect(mockDisconnect).toHaveBeenCalled();
+    });
 
-    // it("does not attempt to disconnect resizeObserver if not initialised", () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     wrapper.unmount();
-    //     expect(mockDisconnect).not.toHaveBeenCalled();
-    // });
+    it("does not attempt to disconnect resizeObserver if not initialised", () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        wrapper.unmount();
+        expect(mockDisconnect).not.toHaveBeenCalled();
+    });
 
-    // it("renders placeholder div before solution is available", async () => {
-    //     const store = getStore();
-    //     const wrapper = getWrapper(store);
-    //     mockPlotElementOn(wrapper);
-    //     expect(wrapper.find(".plot-placeholder").text()).toBe("Model has not been run.");
+    it("renders placeholder div before solution is available", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        expect(wrapper.find(".plot-placeholder").text()).toBe("Model has not been fitted.");
 
-    //     store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
-    //     store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
-    //     await nextTick();
-    //     expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
-    // });
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, mockFitResult);
+        await nextTick();
+        expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
+    });
 });

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -1,0 +1,454 @@
+// Mock the import of plotly so we can mock Plotly methods
+jest.mock("plotly.js", () => ({
+    newPlot: jest.fn(),
+    react: jest.fn(),
+    Plots: {
+        resize: jest.fn()
+    }
+}));
+
+/* eslint-disable import/first */
+import { shallowMount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import Vuex from "vuex";
+import * as plotly from "plotly.js";
+import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
+import { ModelFitMutation, mutations as modelFitMutations } from "../../../../src/app/store/modelFit/mutations";
+import {
+    mockBasicState, mockFitDataState, mockModelFitState, mockModelState
+} from "../../../mocks";
+import { FitDataState } from "../../../../src/app/store/fitData/state";
+
+describe("FitPlot", () => {
+    const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
+    const mockPlotlyReact = jest.spyOn(plotly, "react");
+
+    const mockObserve = jest.fn();
+    const mockDisconnect = jest.fn();
+    function mockResizeObserver(this: any) {
+        this.observe = mockObserve;
+        this.disconnect = mockDisconnect;
+    }
+    (global.ResizeObserver as any) = mockResizeObserver;
+
+    const getStore = (mockRunModel = jest.fn, fitData: Partial<FitDataState> = {}) => {
+        return new Vuex.Store<BasicState>({
+            state: mockBasicState(),
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: mockModelState({
+                        endTime: 99
+                    }),
+                    actions: {
+                        RunModel: mockRunModel
+                    },
+                    mutations
+                },
+                modelFit: {
+                    namespaced: true,
+                    state: mockModelFitState(),
+                    mutations: modelFitMutations
+                },
+                fitData: {
+                    namespaced: true,
+                    state: mockFitDataState(fitData),
+                    getters: {
+                        dataStart: () => 0,
+                        dataEnd: () => 1
+                    }
+                }
+            }
+        });
+    };
+
+    const getWrapper = (store = getStore(), fadePlot = false, modelFit = false) => {
+        return shallowMount(FitPlot, {
+            props: { fadePlot, modelFit },
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    const mockPlotElementOn = (wrapper: VueWrapper<any>) => {
+        const divElement = wrapper.find("div.fit-plot").element;
+        const mockOn = jest.fn();
+        (divElement as any).on = mockOn;
+        return mockOn;
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders plot ref element", () => {
+        const wrapper = getWrapper();
+        const div = wrapper.find("div.fit-plot");
+        expect(div.exists()).toBe(true);
+        expect((wrapper.vm as any).plot).toBe(div.element);
+    });
+
+    it("does not render fade style when fadePlot is false", () => {
+        const wrapper = getWrapper();
+        const div = wrapper.find("div.run-plot-container");
+        expect(div.attributes("style")).toBe("");
+    });
+
+    it("renders fade style when fade plot is true", () => {
+        const wrapper = getWrapper(getStore(), true);
+        const div = wrapper.find("div.run-plot-container");
+        expect(div.attributes("style")).toBe("opacity: 0.5;");
+    });
+
+    it("renders slot content", () => {
+        const store = getStore();
+        const wrapper = shallowMount(FitPlot, {
+            global: {
+                plugins: [store]
+            },
+            slots: {
+                default: "<h3>test slot content</h3>"
+            }
+        });
+        expect(wrapper.find("div.run-plot-container").find("h3").text()).toBe("test slot content");
+    });
+
+    const mockSolutionNull = (param1: number, param2: number) => null;
+    const mockSolution = (param1: number, param2: number) => ({
+        names: ["y", "z"],
+        x: [0, 0.5, 1],
+        y: [
+            [5, 6, 7],
+            [1, 2, 3]
+        ]
+    });
+
+    const mockFitData = {
+        data: [{ t: 0, v: 10 }, { t: 1, v: 20 }],
+        timeVariable: "t",
+        columnToFit: "v",
+        linkedVariables: { v: "y" }
+    };
+
+    const mockPalette = { y: "#0000ff", z: "#ff0000" };
+
+    const expectedModelPlotDataRun = [
+        {
+            name: "y",
+            x: [0, 0.5, 1],
+            y: [5, 6, 7],
+            line: {
+                color: "#0000ff"
+            }
+        },
+        {
+            name: "z",
+            x: [0, 0.5, 1],
+            y: [1, 2, 3],
+            line: {
+                color: "#ff0000"
+            }
+        }
+    ];
+
+    const expectedModelPlotDataFit = [
+        {
+            name: "y",
+            x: [0, 0.5, 1],
+            y: [5, 6, 7],
+            line: {
+                color: "#0000ff"
+            }
+        },
+        {
+            name: "v",
+            x: [0, 1],
+            y: [10, 20],
+            mode: "markers",
+            type: "scatter",
+            marker: {
+                color: "#0000ff"
+            }
+        }
+    ];
+
+    it("draws run plot and sets event handler when odin solution is updated", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        const mockOn = mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
+        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+        expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
+
+        expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
+        const { relayout } = wrapper.vm as any;
+        expect(mockOn.mock.calls[0][1]).toBe(relayout);
+    });
+
+    it("draws model fit plot and sets event handler when modelFit solution is updated", async () => {
+        const store = getStore(jest.fn(), mockFitData);
+        const wrapper = getWrapper(store, false, true);
+        const mockOn = mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
+            data: {
+                solution: mockSolution
+            }
+        });
+
+        await nextTick();
+        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.fit-plot").element);
+        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataFit);
+        expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
+
+        expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
+        const { relayout } = wrapper.vm as any;
+        expect(mockOn.mock.calls[0][1]).toBe(relayout);
+    });
+
+    it("does not draw run plot if base data is null", async () => {
+        const store = getStore();
+        getWrapper(store);
+
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolutionNull);
+        await nextTick();
+        expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
+    });
+
+    it("does not draw modelFit plot if base data is null", async () => {
+        const store = getStore();
+        getWrapper(store, false, true);
+
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
+            data: {
+                solution: mockSolutionNull
+            }
+        });
+        await nextTick();
+        expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
+    });
+
+    const expectedLayout = {
+        margin: { t: 25 },
+        uirevision: "true",
+        xaxis: { autorange: true },
+        yaxis: { autorange: true }
+    };
+
+    it("for run plot, relayout reruns solution and calls react if not autorange", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": 2,
+            "xaxis.range[1]": 7
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    });
+
+    it("modelFit run plot, relayout reruns solution and calls react if not autorange", async () => {
+        const store = getStore(jest.fn(), mockFitData);
+        const wrapper = getWrapper(store, false, true);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
+            data: {
+                solution: mockSolution
+            }
+        });
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": 0,
+            "xaxis.range[1]": 0.5
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual([
+            expectedModelPlotDataRun[0],
+            {
+                name: "v",
+                x: [0],
+                y: [10],
+                mode: "markers",
+                type: "scatter",
+                marker: {
+                    color: "#0000ff"
+                }
+            }
+        ]);
+        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    });
+
+    it("for run plot, relayout uses base data and calls react if autorange", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": true
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
+        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    });
+
+    it("for modelFit plot, relayout uses base data and calls react if autorange", async () => {
+        const store = getStore(jest.fn(), mockFitData);
+        const wrapper = getWrapper(store, false, true);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`modelFit/${ModelFitMutation.SetResult}`, {
+            data: {
+                solution: mockSolution
+            }
+        });
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": true
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataFit);
+        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
+    });
+
+    it("relayout does nothing on autorange false if t0 is undefined", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": undefined,
+            "xaxis.range[1]": 7
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        expect(mockPlotlyReact).not.toHaveBeenCalled();
+    });
+
+    it("relayout does nothing on autorange false if t1 is undefined", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": 2,
+            "xaxis.range[1]": undefined
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        expect(mockPlotlyReact).not.toHaveBeenCalled();
+    });
+
+    it("initialises ResizeObserver", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(mockObserve).toHaveBeenCalledWith(divElement);
+    });
+
+    it("resize method resizes Plot", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        (wrapper.vm as any).resize();
+        const divElement = wrapper.find("div.fit-plot").element;
+        expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
+    });
+
+    it("disconnects resizeObserver on unmount", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+
+        wrapper.unmount();
+        expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it("does not attempt to disconnect resizeObserver if not initialised", () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        wrapper.unmount();
+        expect(mockDisconnect).not.toHaveBeenCalled();
+    });
+
+    it("renders placeholder div before solution is available", async () => {
+        const store = getStore();
+        const wrapper = getWrapper(store);
+        mockPlotElementOn(wrapper);
+        expect(wrapper.find(".plot-placeholder").text()).toBe("Model has not been run.");
+
+        store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
+        store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
+        await nextTick();
+        expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
+    });
+});

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -1,4 +1,4 @@
-// Mock plotly before import RunTab, which indirectly imports plotly via RunModelPlot
+// Mock plotly before import RunTab, which indirectly imports plotly via FitPlot
 jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
@@ -9,7 +9,7 @@ import FitTab from "../../../../src/app/components/fit/FitTab.vue";
 import { FitState } from "../../../../src/app/store/fit/state";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
-import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
+import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
 import { RequiredModelAction } from "../../../../src/app/store/model/state";
 import { mockFitState } from "../../../mocks";
 
@@ -69,14 +69,14 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(false);
-        expect(runModelPlot.findComponent(VueFeather).props("type")).toBe("check");
-        expect(runModelPlot.findComponent(VueFeather).classes()).toContain("text-success");
-        expect(runModelPlot.findComponent(LoadingSpinner).exists()).toBe(false);
-        expect(runModelPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
-        expect(runModelPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
-        expect(runModelPlot.find("#fit-cancelled-msg").exists()).toBe(false);
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(false);
+        expect(fitPlot.findComponent(VueFeather).props("type")).toBe("check");
+        expect(fitPlot.findComponent(VueFeather).classes()).toContain("text-success");
+        expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);
+        expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
+        expect(fitPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
+        expect(fitPlot.find("#fit-cancelled-msg").exists()).toBe(false);
     });
 
     it("renders as expected when fit is running", () => {
@@ -84,14 +84,14 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(false);
-        expect(runModelPlot.props("modelFit")).toBe(true);
-        expect(runModelPlot.findComponent(VueFeather).exists()).toBe(false);
-        expect(runModelPlot.findComponent(LoadingSpinner).props("size")).toBe("xs");
-        expect(runModelPlot.findAll("span").at(0)!.text()).toBe("Iterations: 5");
-        expect(runModelPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 123.45");
-        expect(runModelPlot.find("#fit-cancelled-msg").exists()).toBe(false);
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(false);
+        expect(fitPlot.props("modelFit")).toBe(true);
+        expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);
+        expect(fitPlot.findComponent(LoadingSpinner).props("size")).toBe("xs");
+        expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 5");
+        expect(fitPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 123.45");
+        expect(fitPlot.find("#fit-cancelled-msg").exists()).toBe(false);
     });
 
     it("renders as expected before fit runs", () => {
@@ -99,12 +99,12 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(false);
-        expect(runModelPlot.findComponent(VueFeather).exists()).toBe(false);
-        expect(runModelPlot.findComponent(LoadingSpinner).exists()).toBe(false);
-        expect(runModelPlot.findAll("span").length).toBe(0);
-        expect(runModelPlot.find("#fit-cancelled-msg").exists()).toBe(false);
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(false);
+        expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);
+        expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);
+        expect(fitPlot.findAll("span").length).toBe(0);
+        expect(fitPlot.find("#fit-cancelled-msg").exists()).toBe(false);
     });
 
     it("renders as expected when fit has been cancelled", () => {
@@ -112,14 +112,14 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(false);
-        expect(runModelPlot.findComponent(VueFeather).props("type")).toBe("alert-circle");
-        expect(runModelPlot.findComponent(VueFeather).classes()).toContain("text-secondary");
-        expect(runModelPlot.findComponent(LoadingSpinner).exists()).toBe(false);
-        expect(runModelPlot.findAll("span").at(0)!.text()).toBe("Iterations: 1");
-        expect(runModelPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 121.2");
-        expect(runModelPlot.find("#fit-cancelled-msg").text())
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(false);
+        expect(fitPlot.findComponent(VueFeather).props("type")).toBe("alert-circle");
+        expect(fitPlot.findComponent(VueFeather).classes()).toContain("text-secondary");
+        expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);
+        expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 1");
+        expect(fitPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 121.2");
+        expect(fitPlot.find("#fit-cancelled-msg").text())
             .toBe("Model fit was cancelled before converging");
     });
 
@@ -130,12 +130,12 @@ describe("Fit Tab", () => {
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
             .toBe("Cannot fit model. Please provide valid data and code, link at least one variable and "
                 + "select parameters to vary.");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(true);
-        expect(runModelPlot.findComponent(VueFeather).exists()).toBe(false);
-        expect(runModelPlot.findComponent(LoadingSpinner).exists()).toBe(false);
-        expect(runModelPlot.findAll("span").length).toBe(0);
-        expect(runModelPlot.find("#fit-cancelled-msg").exists()).toBe(false);
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(true);
+        expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);
+        expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);
+        expect(fitPlot.findAll("span").length).toBe(0);
+        expect(fitPlot.find("#fit-cancelled-msg").exists()).toBe(false);
     });
 
     it("renders as expected when compile is required", () => {
@@ -143,11 +143,11 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
             .toBe("Model code has been updated. Compile code and Fit Model for updated best fit.");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(true);
-        expect(runModelPlot.findComponent(VueFeather).props("type")).toBe("check");
-        expect(runModelPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
-        expect(runModelPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(true);
+        expect(fitPlot.findComponent(VueFeather).props("type")).toBe("check");
+        expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
+        expect(fitPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
     });
 
     it("renders as expected when fit update is required", () => {
@@ -156,11 +156,11 @@ describe("Fit Tab", () => {
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
             .toBe("Model code has been recompiled, or options or data have been updated. "
                 + "Fit Model for updated best fit.");
-        const runModelPlot = wrapper.findComponent(RunModelPlot);
-        expect(runModelPlot.props("fadePlot")).toBe(true);
-        expect(runModelPlot.findComponent(LoadingSpinner).exists()).toBe(false);
-        expect(runModelPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
-        expect(runModelPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
+        const fitPlot = wrapper.findComponent(FitPlot);
+        expect(fitPlot.props("fadePlot")).toBe(true);
+        expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);
+        expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 10");
+        expect(fitPlot.findAll("span").at(1)!.text()).toBe("Sum of squares: 2.1");
     });
 
     it("dispatches fit action on click button", async () => {

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -86,7 +86,6 @@ describe("Fit Tab", () => {
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(false);
-        expect(fitPlot.props("modelFit")).toBe(true);
         expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);
         expect(fitPlot.findComponent(LoadingSpinner).props("size")).toBe("xs");
         expect(fitPlot.findAll("span").at(0)!.text()).toBe("Iterations: 5");

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -12,7 +12,7 @@ import { shallowMount, VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import Vuex from "vuex";
 import * as plotly from "plotly.js";
-import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
+import RunPlot from "../../../../src/app/components/run/RunPlot.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
 import { ModelFitMutation, mutations as modelFitMutations } from "../../../../src/app/store/modelFit/mutations";
@@ -21,7 +21,7 @@ import {
 } from "../../../mocks";
 import { FitDataState } from "../../../../src/app/store/fitData/state";
 
-describe("RunModelPlot", () => {
+describe("RunPlot", () => {
     const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
     const mockPlotlyReact = jest.spyOn(plotly, "react");
 
@@ -65,7 +65,7 @@ describe("RunModelPlot", () => {
     };
 
     const getWrapper = (store = getStore(), fadePlot = false, modelFit = false) => {
-        return shallowMount(RunModelPlot, {
+        return shallowMount(RunPlot, {
             props: { fadePlot, modelFit },
             global: {
                 plugins: [store]
@@ -74,7 +74,7 @@ describe("RunModelPlot", () => {
     };
 
     const mockPlotElementOn = (wrapper: VueWrapper<any>) => {
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         const mockOn = jest.fn();
         (divElement as any).on = mockOn;
         return mockOn;
@@ -86,7 +86,7 @@ describe("RunModelPlot", () => {
 
     it("renders plot ref element", () => {
         const wrapper = getWrapper();
-        const div = wrapper.find("div.run-model-plot");
+        const div = wrapper.find("div.run-plot");
         expect(div.exists()).toBe(true);
         expect((wrapper.vm as any).plot).toBe(div.element);
     });
@@ -105,7 +105,7 @@ describe("RunModelPlot", () => {
 
     it("renders slot content", () => {
         const store = getStore();
-        const wrapper = shallowMount(RunModelPlot, {
+        const wrapper = shallowMount(RunPlot, {
             global: {
                 plugins: [store]
             },
@@ -183,7 +183,7 @@ describe("RunModelPlot", () => {
         store.commit(`model/${ModelMutation.SetPaletteModel}`, mockPalette);
         store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
         await nextTick();
-        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.run-model-plot").element);
+        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.run-plot").element);
         expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
         expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
 
@@ -204,7 +204,7 @@ describe("RunModelPlot", () => {
         });
 
         await nextTick();
-        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.run-model-plot").element);
+        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(wrapper.find("div.run-plot").element);
         expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataFit);
         expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({ margin: { t: 25 } });
 
@@ -260,7 +260,7 @@ describe("RunModelPlot", () => {
         const { relayout } = wrapper.vm as any;
         await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
         expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
@@ -288,7 +288,7 @@ describe("RunModelPlot", () => {
         const { relayout } = wrapper.vm as any;
         await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
         expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual([
             expectedModelPlotDataRun[0],
@@ -322,7 +322,7 @@ describe("RunModelPlot", () => {
         const { relayout } = wrapper.vm as any;
         await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
         expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataRun);
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
@@ -348,7 +348,7 @@ describe("RunModelPlot", () => {
         const { relayout } = wrapper.vm as any;
         await relayout(relayoutEvent);
 
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
         expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(expectedModelPlotDataFit);
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLayout);
@@ -403,7 +403,7 @@ describe("RunModelPlot", () => {
         store.commit(`model/${ModelMutation.SetOdinSolution}`, mockSolution);
         await nextTick();
 
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(mockObserve).toHaveBeenCalledWith(divElement);
     });
 
@@ -416,7 +416,7 @@ describe("RunModelPlot", () => {
         await nextTick();
 
         (wrapper.vm as any).resize();
-        const divElement = wrapper.find("div.run-model-plot").element;
+        const divElement = wrapper.find("div.run-plot").element;
         expect(plotly.Plots.resize).toHaveBeenCalledWith(divElement);
     });
 

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -1,4 +1,4 @@
-// Mock plotly before import RunTab, which indirectly imports plotly via RunModelPlot
+// Mock plotly before import RunTab, which indirectly imports plotly via RunPlot
 jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
@@ -8,7 +8,7 @@ import { BasicState } from "../../../../src/app/store/basic/state";
 import { mockBasicState, mockModelState } from "../../../mocks";
 import { ModelState, RequiredModelAction } from "../../../../src/app/store/model/state";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
-import RunModelPlot from "../../../../src/app/components/run/RunModelPlot.vue";
+import RunPlot from "../../../../src/app/components/run/RunPlot.vue";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 
@@ -50,7 +50,7 @@ describe("RunTab", () => {
         expect(wrapper.find("button").text()).toBe("Run model");
         expect(wrapper.find("button").element.disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
-        expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(false);
+        expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(false);
     });
 
     it("disables run button when state has no odinRunner", () => {
@@ -73,7 +73,7 @@ describe("RunTab", () => {
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe(
             "Model code has been updated. Compile code and Run Model to view updated graph."
         );
-        expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(true);
+        expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(true);
     });
 
     it("fades plot and shows message when model run required", () => {
@@ -81,7 +81,7 @@ describe("RunTab", () => {
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe(
             "Model code has been recompiled or options have been updated. Run Model to view updated graph."
         );
-        expect(wrapper.findComponent(RunModelPlot).props("fadePlot")).toBe(true);
+        expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(true);
     });
 
     it("invokes run model action when run button is clicked", () => {


### PR DESCRIPTION
This PR does a very literal decoupling of the plotting components, ahead of any refactoring.

I've copied the RunModelPlot component into run/RunPlot and fit/FitPlot and removed all the logic that switched on the fit prop, then reworked the tests so that everything remains.

There's some pretty obvious work to refactor the resizeable plotly plot. I can take a stab at that, but I don't know enough about Vue components to do a proper job really.