### PR TITLE
mrc-3514 Run sensitivity re-runs model if required

### DIFF
--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -3,6 +3,8 @@ import { AppState } from "../appState/state";
 import { SensitivityState } from "./state";
 import { SensitivityGetter } from "./getters";
 import { SensitivityMutation } from "./mutations";
+import { RequiredModelAction } from "../model/state";
+import { ModelAction } from "../model/actions";
 
 export enum SensitivityAction {
     RunSensitivity = "RunSensitivity"
@@ -10,7 +12,9 @@ export enum SensitivityAction {
 
 export const actions: ActionTree<SensitivityState, AppState> = {
     [SensitivityAction.RunSensitivity](context) {
-        const { rootState, getters, commit } = context;
+        const {
+            rootState, getters, commit, dispatch
+        } = context;
         const { odinRunner, odin, endTime } = rootState.model;
         const batchPars = getters[SensitivityGetter.batchPars];
 
@@ -18,6 +22,11 @@ export const actions: ActionTree<SensitivityState, AppState> = {
             const batch = odinRunner.batchRun(odin, batchPars, 0, endTime, {});
             commit(SensitivityMutation.SetBatch, batch);
             commit(SensitivityMutation.SetUpdateRequired, false);
+
+            // Also re-run model if required so that plotted central traces are correct
+            if (rootState.model.requiredAction === RequiredModelAction.Run) {
+                dispatch(`model/${ModelAction.RunModel}`, null, { root: true });
+            }
         }
     }
 };


### PR DESCRIPTION
Fixes a bug where, if a parameter value is changed, and sensitivity re-run, the plotted 'central' values on sensitivity plot showed the old parameter value trace. The central values use the odin solution in `model` module - the same one which is shown on the 'Run' tab. This module already has a flag indicating if run is required because the solution is of of date. So when we run sensitivity we now check that and dispatch `RunModel` action if run is required. 