### PR TITLE
mrc-3433 Sensitivity plot options

### DIFF
--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -18,6 +18,8 @@
         <sensitivity-param-values :batch-pars="batchPars"></sensitivity-param-values>
         <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
       </div>
+      <hr/>
+      <sensitivity-plot-options></sensitivity-plot-options>
     </template>
     <div v-else id="sensitivity-options-msg">
       {{compileModelMessage}}
@@ -34,11 +36,13 @@ import VerticalCollapse from "../VerticalCollapse.vue";
 import EditParamSettings from "./EditParamSettings.vue";
 import { SensitivityGetter } from "../../store/sensitivity/getters";
 import SensitivityParamValues from "./SensitivityParamValues.vue";
+import SensitivityPlotOptions from "./SensitivityPlotOptions.vue";
 
 export default defineComponent({
     name: "SensitivityOptions",
     components: {
         SensitivityParamValues,
+        SensitivityPlotOptions,
         VerticalCollapse,
         EditParamSettings
     },

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -2,6 +2,7 @@
   <vertical-collapse title="Sensitivity Options" collapse-id="sensitivity-options">
     <template v-if="showOptions">
       <div class="mt-2 clearfix">
+        <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
         <ul>
           <li><strong>Parameter:</strong> {{settings.parameterToVary}}</li>
           <li><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
@@ -16,7 +17,6 @@
           <li><strong>Number of runs:</strong> {{ settings.numberOfRuns}}</li>
         </ul>
         <sensitivity-param-values :batch-pars="batchPars"></sensitivity-param-values>
-        <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
       </div>
       <hr/>
       <sensitivity-plot-options></sensitivity-plot-options>

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -1,33 +1,30 @@
 <template>
   <div class="container mb-4">
-    <div class="row mb-2" id="sensitivity-plot-type" >
-      <div class="col-5">
+    <div class="row mb-3" id="sensitivity-plot-type" >
+      <div class="col-11">
         <label class="col-form-label">Type of plot</label>
       </div>
-      <div class="col-6">
+      <div class="col-11">
         <select class="form-select" v-model="plotType">
-          <option value="TraceOverTime">Trace over time</option>
-          <option value="ValueAtTime">Value at a single time</option>
-          <option value="ValueAtExtreme">Value at its min/max</option>
-          <option value="TimeAtExtreme">Time at value's min/max</option>
+          <option v-for="option in plotTypeOptions" :value="option.value" :key="option.value">{{option.label}}</option>
         </select>
       </div>
     </div>
     <div v-if="extremePlotType" id="sensitivity-plot-extreme"  class="row mb-2">
-      <div class="col-5">
+      <div class="col-xl-5 col-11">
         <label class="col-form-label">Min/Max</label>
       </div>
-      <div class="col-6">
+      <div class="col-xl-6 col-11">
         <select class="form-select" v-model="extreme">
           <option v-for="extremeValue in extremeValues" :key="extremeValue">{{extremeValue}}</option>
         </select>
       </div>
     </div>
     <div v-if="timePlotType" id="sensitivity-plot-time" class="row mb-2">
-      <div class="col-5">
+      <div class="col-xl-5 col-11">
         <label class="col-form-label">Time to use</label>
       </div>
-      <div class="col-6">
+      <div class="col-xl-6 col-11">
         <input v-model="time" class="form-control" type="number">
       </div>
     </div>
@@ -74,6 +71,13 @@ export default defineComponent({
 
         const extremeValues = Object.keys(SensitivityPlotExtreme);
 
+        const plotTypeOptions = [
+            { value: SensitivityPlotType.TraceOverTime, label: "Trace over time" },
+            { value: SensitivityPlotType.ValueAtTime, label: "Value at a single time" },
+            { value: SensitivityPlotType.ValueAtExtreme, label: "Value at its min/max" },
+            { value: SensitivityPlotType.TimeAtExtreme, label: "Time at value's min/max" }
+        ];
+
         onMounted(() => {
         // if plot settings time has not been initialised, set to model end time
             if (store.state.sensitivity.plotSettings.time === null) {
@@ -87,7 +91,8 @@ export default defineComponent({
             extremeValues,
             plotType,
             extreme,
-            time
+            time,
+            plotTypeOptions
         };
     }
 });

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container mb-4">
-    <div class="row mb-2">
+    <div class="row mb-2" id="sensitivity-plot-type" >
       <div class="col-5">
         <label class="col-form-label">Type of plot</label>
       </div>
@@ -13,7 +13,7 @@
         </select>
       </div>
     </div>
-    <div v-if="extremePlotType" class="row mb-2">
+    <div v-if="extremePlotType" id="sensitivity-plot-extreme"  class="row mb-2">
       <div class="col-5">
         <label class="col-form-label">Min/Max</label>
       </div>
@@ -23,7 +23,7 @@
         </select>
       </div>
     </div>
-    <div v-if="timePlotType" class="row mb-2">
+    <div v-if="timePlotType" id="sensitivity-plot-time" class="row mb-2">
       <div class="col-5">
         <label class="col-form-label">Time to use</label>
       </div>

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -62,9 +62,8 @@ export default defineComponent({
         const time = computed({
             get: () => settings.value.time,
             set: (newVal) => {
-                // Don't allow time to exceed model end time, or be less than 0
-                const newTime = Math.max(0, Math.min(newVal, modelEndTime.value));
-                store.commit(`${namespace}/${SensitivityMutation.SetPlotTime}`, newTime);
+                // we let the user set any numeric value here, but will clip to 0 to endTime range when get data
+                store.commit(`${namespace}/${SensitivityMutation.SetPlotTime}`, newVal);
             }
         });
 

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="container mb-4">
+    <div class="row mb-2">
+      <div class="col-5">
+        <label class="col-form-label">Type of plot</label>
+      </div>
+      <div class="col-6">
+        <select class="form-select" v-model="plotType">
+          <option value="TraceOverTime">Trace over time</option>
+          <option value="ValueAtTime">Value at a single time</option>
+          <option value="ValueAtExtreme">Value at its min/max</option>
+          <option value="TimeAtExtreme">Time at value's min/max</option>
+        </select>
+      </div>
+    </div>
+    <div v-if="extremePlotType" class="row mb-2">
+      <div class="col-5">
+        <label class="col-form-label">Min/Max</label>
+      </div>
+      <div class="col-6">
+        <select class="form-select" v-model="extreme">
+          <option v-for="extremeValue in extremeValues">{{extremeValue}}</option>
+        </select>
+      </div>
+    </div>
+    <div v-if="timePlotType" class="row mb-2">
+      <div class="col-5">
+        <label class="col-form-label">Time to use</label>
+      </div>
+      <div class="col-6">
+        <input v-model="time" class="form-control" type="number">
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted } from "vue";
+import { useStore } from "vuex";
+import { SensitivityMutation } from "../../store/sensitivity/mutations";
+import { SensitivityPlotExtreme, SensitivityPlotType } from "../../store/sensitivity/state";
+
+export default defineComponent({
+    name: "SensitivityPlotOptions.vue",
+    setup() {
+        const namespace = "sensitivity";
+        const store = useStore();
+
+        const settings = computed(() => store.state.sensitivity.plotSettings);
+        const modelEndTime = computed(() => store.state.model.endTime);
+
+        const plotType = computed({
+            get: () => settings.value.plotType,
+            set: (newVal) => store.commit(`${namespace}/${SensitivityMutation.SetPlotType}`, newVal)
+        });
+
+        const extreme = computed({
+            get: () => settings.value.extreme,
+            set: (newVal) => store.commit(`${namespace}/${SensitivityMutation.SetPlotExtreme}`, newVal)
+        });
+
+        const time = computed({
+            get: () => settings.value.time,
+            set: (newVal) => {
+                // Don't allow time to exceed model end time, or be less than 0
+                const newTime = Math.max(0, Math.min(newVal, modelEndTime.value));
+                store.commit(`${namespace}/${SensitivityMutation.SetPlotTime}`, newTime);
+            }
+        });
+
+        const extremePlotType = computed(() => [SensitivityPlotType.TimeAtExtreme, SensitivityPlotType.ValueAtExtreme].includes(plotType.value));
+        const timePlotType = computed(() => plotType.value === SensitivityPlotType.ValueAtTime);
+
+        const extremeValues = Object.keys(SensitivityPlotExtreme);
+
+        onMounted(() => {
+        // if plot settings time has not been initialised, set to model end time
+            if (store.state.sensitivity.plotSettings.time === null) {
+                time.value = modelEndTime.value;
+            }
+        });
+
+        return {
+            extremePlotType,
+            timePlotType,
+            extremeValues,
+            plotType,
+            extreme,
+            time
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="col-6">
         <select class="form-select" v-model="extreme">
-          <option v-for="extremeValue in extremeValues">{{extremeValue}}</option>
+          <option v-for="extremeValue in extremeValues" :key="extremeValue">{{extremeValue}}</option>
         </select>
       </div>
     </div>
@@ -68,7 +68,9 @@ export default defineComponent({
             }
         });
 
-        const extremePlotType = computed(() => [SensitivityPlotType.TimeAtExtreme, SensitivityPlotType.ValueAtExtreme].includes(plotType.value));
+        const extremePlotType = computed(
+            () => [SensitivityPlotType.TimeAtExtreme, SensitivityPlotType.ValueAtExtreme].includes(plotType.value)
+        );
         const timePlotType = computed(() => plotType.value === SensitivityPlotType.ValueAtTime);
 
         const extremeValues = Object.keys(SensitivityPlotExtreme);

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -8,7 +8,7 @@
     </div>
     <action-required-message :message="updateMsg"></action-required-message>
     <sensitivity-traces-plot v-if="tracesPlot" :fade-plot="!!updateMsg" ></sensitivity-traces-plot>
-    <div v-else>Other plot types coming soon!</div>
+    <div v-else id="sensitivity-plot-placeholder">Other plot types coming soon!</div>
   </div>
 </template>
 

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -7,7 +7,8 @@
               @click="runSensitivity">Run sensitivity</button>
     </div>
     <action-required-message :message="updateMsg"></action-required-message>
-    <sensitivity-traces-plot :fade-plot="!!updateMsg" ></sensitivity-traces-plot>
+    <sensitivity-traces-plot v-if="tracesPlot" :fade-plot="!!updateMsg" ></sensitivity-traces-plot>
+    <div v-else>Other plot types coming soon!</div>
   </div>
 </template>
 
@@ -20,6 +21,7 @@ import { RequiredModelAction } from "../../store/model/state";
 import { SensitivityGetter } from "../../store/sensitivity/getters";
 import { SensitivityAction } from "../../store/sensitivity/actions";
 import userMessages from "../../userMessages";
+import {SensitivityPlotType} from "../../store/sensitivity/state";
 
 export default defineComponent({
     name: "SensitivityTab",
@@ -53,10 +55,13 @@ export default defineComponent({
             return "";
         });
 
+        const tracesPlot = computed(() => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.TraceOverTime);
+
         return {
             canRunSensitivity,
             runSensitivity,
-            updateMsg
+            updateMsg,
+            tracesPlot
         };
     }
 });

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -21,7 +21,7 @@ import { RequiredModelAction } from "../../store/model/state";
 import { SensitivityGetter } from "../../store/sensitivity/getters";
 import { SensitivityAction } from "../../store/sensitivity/actions";
 import userMessages from "../../userMessages";
-import {SensitivityPlotType} from "../../store/sensitivity/state";
+import { SensitivityPlotType } from "../../store/sensitivity/state";
 
 export default defineComponent({
     name: "SensitivityTab",
@@ -55,7 +55,9 @@ export default defineComponent({
             return "";
         });
 
-        const tracesPlot = computed(() => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.TraceOverTime);
+        const tracesPlot = computed(
+            () => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.TraceOverTime
+        );
 
         return {
             canRunSensitivity,

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -1,5 +1,7 @@
 import { MutationTree } from "vuex";
-import {SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState} from "./state";
+import {
+    SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState
+} from "./state";
 import { Batch } from "../../types/responseTypes";
 
 export enum SensitivityMutation {
@@ -40,6 +42,6 @@ export const mutations: MutationTree<SensitivityState> = {
     },
 
     [SensitivityMutation.SetPlotTime](state: SensitivityState, payload: number) {
-        state.plotSettings.time = payload
+        state.plotSettings.time = payload;
     }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -1,12 +1,15 @@
 import { MutationTree } from "vuex";
-import { SensitivityParameterSettings, SensitivityState } from "./state";
+import {SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState} from "./state";
 import { Batch } from "../../types/responseTypes";
 
 export enum SensitivityMutation {
     SetParameterToVary = "SetParameterToVary",
     SetParamSettings = "SetParamSettings",
     SetBatch = "SetBatch",
-    SetUpdateRequired = "SetUpdateRequired"
+    SetUpdateRequired = "SetUpdateRequired",
+    SetPlotType = "SetPlotType",
+    SetPlotExtreme = "SetPlotExtreme",
+    SetPlotTime = "SetPlotTime"
 }
 
 export const mutations: MutationTree<SensitivityState> = {
@@ -26,5 +29,17 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.SetUpdateRequired](state: SensitivityState, payload: boolean) {
         state.sensitivityUpdateRequired = payload;
+    },
+
+    [SensitivityMutation.SetPlotType](state: SensitivityState, payload: SensitivityPlotType) {
+        state.plotSettings.plotType = payload;
+    },
+
+    [SensitivityMutation.SetPlotExtreme](state: SensitivityState, payload: SensitivityPlotExtreme) {
+        state.plotSettings.extreme = payload;
+    },
+
+    [SensitivityMutation.SetPlotTime](state: SensitivityState, payload: number) {
+        state.plotSettings.time = payload
     }
 };

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -1,7 +1,13 @@
-import { SensitivityScaleType, SensitivityState, SensitivityVariationType } from "./state";
-import { mutations } from "./mutations";
-import { actions } from "./actions";
-import { getters } from "./getters";
+import {
+    SensitivityPlotExtreme,
+    SensitivityPlotType,
+    SensitivityScaleType,
+    SensitivityState,
+    SensitivityVariationType
+} from "./state";
+import {mutations} from "./mutations";
+import {actions} from "./actions";
+import {getters} from "./getters";
 
 export const defaultState: SensitivityState = {
     paramSettings: {
@@ -12,6 +18,11 @@ export const defaultState: SensitivityState = {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 10
+    },
+    plotSettings: {
+        plotType: SensitivityPlotType.TraceOverTime,
+        extreme: SensitivityPlotExtreme.Max,
+        time: null
     },
     batch: null,
     sensitivityUpdateRequired: false

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -5,9 +5,9 @@ import {
     SensitivityState,
     SensitivityVariationType
 } from "./state";
-import {mutations} from "./mutations";
-import {actions} from "./actions";
-import {getters} from "./getters";
+import { mutations } from "./mutations";
+import { actions } from "./actions";
+import { getters } from "./getters";
 
 export const defaultState: SensitivityState = {
     paramSettings: {

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -20,9 +20,28 @@ export interface SensitivityParameterSettings {
     numberOfRuns: number
 }
 
+export enum SensitivityPlotType {
+    TraceOverTime = "TraceOverTime",
+    ValueAtTime = "ValueAtTime",
+    ValueAtExtreme = "ValueAtExtreme",
+    TimeAtExtreme = "TimeAtExtreme"
+}
+
+export enum SensitivityPlotExtreme {
+    Min = "Min",
+    Max = "Max"
+}
+
+export interface SensitivityPlotSettings {
+    plotType: SensitivityPlotType,
+    extreme: SensitivityPlotExtreme,
+    time: null | number
+}
+
 export interface SensitivityState {
     paramSettings: SensitivityParameterSettings,
     batch: Batch | null,
     // Whether sensitivity needs to be re-run because of change to settings or model
     sensitivityUpdateRequired: boolean
+    plotSettings: SensitivityPlotSettings
 }

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -58,6 +58,30 @@ test.describe("Sensitivity tests", () => {
             .toBe(" 1.000, 1.158, 1.340, ..., 5.000");
     });
 
+    test("can edit sensitivity plot settings", async ({page}) => {
+        // Default settings are visible
+        await expect(await page.innerText("#sensitivity-plot-type label")).toBe("Type of plot");
+        await expect(await page.inputValue("#sensitivity-plot-type select")).toBe("TraceOverTime");
+
+        // Can change to extreme plot type
+        await page.locator("#sensitivity-plot-type select").selectOption("ValueAtExtreme");
+        await expect(await page.innerText("#sensitivity-plot-extreme label")).toBe("Min/Max");
+        await expect(await page.inputValue("#sensitivity-plot-extreme select")).toBe("Max");
+
+        // Can change to value at time plot type
+        await page.locator("#sensitivity-plot-type select").selectOption("ValueAtTime");
+        await expect(await page.innerText("#sensitivity-plot-time label")).toBe("Time to use");
+        await expect(await page.inputValue("#sensitivity-plot-time input")).toBe("100");
+        await page.fill("#sensitivity-plot-time input", "50");
+
+        // Changes are persisted between tabs
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+        await expect(page.locator(".code-tab")).toBeVisible();
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+        await expect(await page.inputValue("#sensitivity-plot-type select")).toBe("ValueAtTime");
+        await expect(await page.inputValue("#sensitivity-plot-time input")).toBe("50");
+    });
+
     test("can run sensitivity", async ({ page }) => {
         // see pre-run placeholder
         await expect(await page.innerText(".sensitivity-tab .plot-placeholder")).toBe("Sensitivity has not been run.");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -58,7 +58,7 @@ test.describe("Sensitivity tests", () => {
             .toBe(" 1.000, 1.158, 1.340, ..., 5.000");
     });
 
-    test("can edit sensitivity plot settings", async ({page}) => {
+    test("can edit sensitivity plot settings", async ({ page }) => {
         // Default settings are visible
         await expect(await page.innerText("#sensitivity-plot-type label")).toBe("Type of plot");
         await expect(await page.inputValue("#sensitivity-plot-type select")).toBe("TraceOverTime");

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -1,14 +1,16 @@
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import {BasicState} from "../src/app/store/basic/state";
-import {FitState} from "../src/app/store/fit/state";
-import {StochasticState} from "../src/app/store/stochastic/state";
-import {BatchPars, ResponseFailure, ResponseSuccess, WodinError} from "../src/app/types/responseTypes";
-import {ModelState} from "../src/app/store/model/state";
-import {CodeState} from "../src/app/store/code/state";
-import {FitDataState} from "../src/app/store/fitData/state";
-import {AppType, VisualisationTab} from "../src/app/store/appState/state";
-import {ModelFitState} from "../src/app/store/modelFit/state";
+import { BasicState } from "../src/app/store/basic/state";
+import { FitState } from "../src/app/store/fit/state";
+import { StochasticState } from "../src/app/store/stochastic/state";
+import {
+    BatchPars, ResponseFailure, ResponseSuccess, WodinError
+} from "../src/app/types/responseTypes";
+import { ModelState } from "../src/app/store/model/state";
+import { CodeState } from "../src/app/store/code/state";
+import { FitDataState } from "../src/app/store/fitData/state";
+import { AppType, VisualisationTab } from "../src/app/store/appState/state";
+import { ModelFitState } from "../src/app/store/modelFit/state";
 import {
     SensitivityPlotExtreme,
     SensitivityPlotType,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -1,18 +1,21 @@
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import { BasicState } from "../src/app/store/basic/state";
-import { FitState } from "../src/app/store/fit/state";
-import { StochasticState } from "../src/app/store/stochastic/state";
+import {BasicState} from "../src/app/store/basic/state";
+import {FitState} from "../src/app/store/fit/state";
+import {StochasticState} from "../src/app/store/stochastic/state";
+import {BatchPars, ResponseFailure, ResponseSuccess, WodinError} from "../src/app/types/responseTypes";
+import {ModelState} from "../src/app/store/model/state";
+import {CodeState} from "../src/app/store/code/state";
+import {FitDataState} from "../src/app/store/fitData/state";
+import {AppType, VisualisationTab} from "../src/app/store/appState/state";
+import {ModelFitState} from "../src/app/store/modelFit/state";
 import {
-    ResponseSuccess, ResponseFailure, WodinError, OdinSolution, BatchPars
-} from "../src/app/types/responseTypes";
-import { ModelState } from "../src/app/store/model/state";
-import { CodeState } from "../src/app/store/code/state";
-import { FitDataState } from "../src/app/store/fitData/state";
-import { AppType, VisualisationTab } from "../src/app/store/appState/state";
-import { ModelFitState } from "../src/app/store/modelFit/state";
-import { SensitivityScaleType, SensitivityState, SensitivityVariationType } from "../src/app/store/sensitivity/state";
-import { Dict } from "../src/app/types/utilTypes";
+    SensitivityPlotExtreme,
+    SensitivityPlotType,
+    SensitivityScaleType,
+    SensitivityState,
+    SensitivityVariationType
+} from "../src/app/store/sensitivity/state";
 
 export const mockAxios = new MockAdapter(axios);
 
@@ -87,6 +90,11 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
             rangeFrom: 0,
             rangeTo: 0,
             numberOfRuns: 10
+        },
+        plotSettings: {
+            plotType: SensitivityPlotType.TraceOverTime,
+            extreme: SensitivityPlotExtreme.Max,
+            time: null
         },
         batch: null,
         sensitivityUpdateRequired: false,

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -5,7 +5,7 @@ import Vuex from "vuex";
 import { mount } from "@vue/test-utils";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockModelState } from "../../../mocks";
+import {mockBasicState, mockModelState, mockSensitivityState} from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
@@ -36,6 +36,10 @@ describe("BasicApp", () => {
                     actions: {
                         [ModelAction.FetchOdinRunner]: jest.fn()
                     }
+                },
+                sensitivity: {
+                    namespaced: true,
+                    state: mockSensitivityState()
                 },
                 errors: {
                     namespaced: true,

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -5,7 +5,7 @@ import Vuex from "vuex";
 import { mount } from "@vue/test-utils";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {mockBasicState, mockModelState, mockSensitivityState} from "../../../mocks";
+import { mockBasicState, mockModelState, mockSensitivityState } from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -7,7 +7,7 @@ import FitApp from "../../../../src/app/components/fit/FitApp.vue";
 import { FitState } from "../../../../src/app/store/fit/state";
 import { AppStateAction } from "../../../../src/app/store/appState/actions";
 import {
-    mockFitDataState, mockFitState, mockModelFitState, mockModelState
+    mockFitDataState, mockFitState, mockModelFitState, mockModelState, mockSensitivityState
 } from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
@@ -48,6 +48,10 @@ describe("FitApp", () => {
                 modelFit: {
                     namespaced: true,
                     state: mockModelFitState()
+                },
+                sensitivity: {
+                    namespaced: true,
+                    state: mockSensitivityState()
                 },
                 errors: {
                     namespaced: true,

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -11,6 +11,7 @@ import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vu
 import EditParamSettings from "../../../../src/app/components/options/EditParamSettings.vue";
 import { SensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
 import SensitivityParamValues from "../../../../src/app/components/options/SensitivityParamValues.vue";
+import SensitivityPlotOptions from "../../../../src/app/components/options/SensitivityPlotOptions.vue";
 
 describe("SensitivityOptions", () => {
     const mockBatchPars = {
@@ -24,7 +25,10 @@ describe("SensitivityOptions", () => {
             modules: {
                 sensitivity: {
                     namespaced: true,
-                    state: { paramSettings },
+                    state: {
+                        paramSettings,
+                        plotSettings: {}
+                    },
                     getters: {
                         [SensitivityGetter.batchPars]: () => mockBatchPars
                     }
@@ -75,6 +79,8 @@ describe("SensitivityOptions", () => {
         expect(wrapper.findComponent(EditParamSettings).props("open")).toBe(false);
 
         expect(wrapper.find("#sensitivity-options-msg").exists()).toBe(false);
+
+        expect(wrapper.findComponent(SensitivityPlotOptions).exists()).toBe(true);
     });
 
     it("displays range variance as expected", () => {
@@ -114,5 +120,6 @@ describe("SensitivityOptions", () => {
         expect(wrapper.find("#sensitivity-options-msg").text())
             .toBe("Please compile a valid model in order to set sensitivity options.");
         expect(wrapper.find("#sensitivity-options").findComponent(SensitivityParamValues).exists()).toBe(false);
+        expect(wrapper.findComponent(SensitivityPlotOptions).exists()).toBe(false);
     });
 });

--- a/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
@@ -1,0 +1,118 @@
+import {
+    SensitivityPlotExtreme,
+    SensitivityPlotSettings,
+    SensitivityPlotType
+} from "../../../../src/app/store/sensitivity/state";
+import Vuex from "vuex";
+import {mockBasicState} from "../../../mocks";
+import {BasicState} from "../../../../src/app/store/basic/state";
+import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import {shallowMount} from "@vue/test-utils";
+import SensitivityPlotOptions from "../../../../src/app/components/options/SensitivityPlotOptions.vue";
+
+describe("SensitivityPlotOptions", () => {
+    const plotSettings = {
+        plotType: SensitivityPlotType.TraceOverTime,
+        extreme: SensitivityPlotExtreme.Min,
+        time: 100
+    };
+
+    const mockSetPlotType = jest.fn();
+    const mockSetPlotExtreme = jest.fn();
+    const mockSetPlotTime = jest.fn();
+
+    const getWrapper = (settings: Partial<SensitivityPlotSettings> = {}) => {
+        const store = new Vuex.Store<BasicState>({
+            state: mockBasicState(),
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: {
+                        endTime: 100
+                    }
+                },
+                sensitivity: {
+                    namespaced: true,
+                    state: {
+                        plotSettings: {...plotSettings, ...settings}
+                    },
+                    mutations: {
+                        [SensitivityMutation.SetPlotType]: mockSetPlotType,
+                        [SensitivityMutation.SetPlotTime]: mockSetPlotTime,
+                        [SensitivityMutation.SetPlotExtreme]: mockSetPlotExtreme
+                    }
+                }
+            }
+        });
+
+        return shallowMount(SensitivityPlotOptions, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders as expected for Trace over time", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("#sensitivity-plot-type label").text()).toBe("Type of plot");
+        expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotType.TraceOverTime);
+        const plotTypeOptions = wrapper.findAll("#sensitivity-plot-type select option");
+        expect(plotTypeOptions.length).toBe(4);
+        expect(plotTypeOptions.at(0)!.attributes("value")).toBe(SensitivityPlotType.TraceOverTime);
+        expect(plotTypeOptions.at(0)!.text()).toBe("Trace over time");
+        expect(plotTypeOptions.at(1)!.attributes("value")).toBe(SensitivityPlotType.ValueAtTime);
+        expect(plotTypeOptions.at(1)!.text()).toBe("Value at a single time");
+        expect(plotTypeOptions.at(2)!.attributes("value")).toBe(SensitivityPlotType.ValueAtExtreme);
+        expect(plotTypeOptions.at(2)!.text()).toBe("Value at its min/max");
+        expect(plotTypeOptions.at(3)!.attributes("value")).toBe(SensitivityPlotType.TimeAtExtreme);
+        expect(plotTypeOptions.at(3)!.text()).toBe("Time at value's min/max");
+
+        expect(wrapper.find("#sensitivity-plot-extreme").exists()).toBe(false);
+        expect(wrapper.find("#sensitivity-plot-time").exists()).toBe(false);
+    });
+
+    it("renders as expected for Value at a single time", () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotType.ValueAtTime);
+
+        expect(wrapper.find("#sensitivity-plot-extreme").exists()).toBe(false);
+
+        expect(wrapper.find("#sensitivity-plot-time label").text()).toBe("Time to use");
+        expect(wrapper.find("#sensitivity-plot-time input").attributes("type")).toBe("number");
+        expect((wrapper.find("#sensitivity-plot-time input").element as HTMLInputElement).value).toBe("100");
+    });
+
+    it("renders as expected for Value at min/max", () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtExtreme});
+        expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotType.ValueAtExtreme);
+        expect(wrapper.find("#sensitivity-plot-extreme label").text()).toBe("Min/Max");
+        expect((wrapper.find("#sensitivity-plot-extreme select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotExtreme.Min);
+        const extremeOptions = wrapper.findAll("#sensitivity-plot-extreme select option");
+        expect(extremeOptions.length).toBe(2);
+        expect(extremeOptions.at(0)!.text()).toBe(SensitivityPlotExtreme.Min);
+        expect(extremeOptions.at(1)!.text()).toBe(SensitivityPlotExtreme.Max);
+
+        expect(wrapper.find("#sensitivity-plot-time").exists()).toBe(false);
+    });
+
+    it("renders as expected for Time at value's min/max", () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.TimeAtExtreme});
+        expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotType.TimeAtExtreme);
+        expect(wrapper.find("#sensitivity-plot-extreme label").text()).toBe("Min/Max");
+        expect((wrapper.find("#sensitivity-plot-extreme select").element as HTMLSelectElement).value)
+            .toBe(SensitivityPlotExtreme.Min);
+        const extremeOptions = wrapper.findAll("#sensitivity-plot-extreme select option");
+        expect(extremeOptions.length).toBe(2);
+
+        expect(wrapper.find("#sensitivity-plot-time").exists()).toBe(false);
+    });
+});

--- a/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
@@ -115,4 +115,57 @@ describe("SensitivityPlotOptions", () => {
 
         expect(wrapper.find("#sensitivity-plot-time").exists()).toBe(false);
     });
+
+    it("updates plot type", async () => {
+        const wrapper = getWrapper();
+        const plotTypeSelect = wrapper.find("#sensitivity-plot-type select");
+        (plotTypeSelect.element as HTMLSelectElement).value = SensitivityPlotType.TimeAtExtreme;
+        await plotTypeSelect.trigger("change");
+
+        expect(mockSetPlotType).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotType.mock.calls[0][1]).toBe(SensitivityPlotType.TimeAtExtreme);
+    });
+
+    it("updates time", async () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const timeInput = wrapper.find("#sensitivity-plot-time input");
+        await timeInput.setValue("50");
+
+        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotTime.mock.calls[0][1]).toBe(50);
+    });
+
+    it("updates extreme type", async () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.TimeAtExtreme});
+        const extremeSelect = wrapper.find("#sensitivity-plot-extreme select");
+        (extremeSelect.element as HTMLSelectElement).value = SensitivityPlotExtreme.Max;
+        await extremeSelect.trigger("change");
+
+        expect(mockSetPlotExtreme).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotExtreme.mock.calls[0][1]).toBe(SensitivityPlotExtreme.Max);
+    });
+
+    it("reverts time to 0 if negative value entered", async () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const timeInput = wrapper.find("#sensitivity-plot-time input");
+        await timeInput.setValue("-1");
+
+        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotTime.mock.calls[0][1]).toBe(0);
+    });
+
+    it("reverts time to model end if higher value entered", async () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const timeInput = wrapper.find("#sensitivity-plot-time input");
+        await timeInput.setValue("200");
+
+        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
+    });
+
+    it("on mounted, initialises time to model end if null", () => {
+        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime, time: null});
+        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
+        expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
+    });
 });

--- a/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
@@ -145,24 +145,6 @@ describe("SensitivityPlotOptions", () => {
         expect(mockSetPlotExtreme.mock.calls[0][1]).toBe(SensitivityPlotExtreme.Max);
     });
 
-    it("reverts time to 0 if negative value entered", async () => {
-        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
-        const timeInput = wrapper.find("#sensitivity-plot-time input");
-        await timeInput.setValue("-1");
-
-        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
-        expect(mockSetPlotTime.mock.calls[0][1]).toBe(0);
-    });
-
-    it("reverts time to model end if higher value entered", async () => {
-        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
-        const timeInput = wrapper.find("#sensitivity-plot-time input");
-        await timeInput.setValue("200");
-
-        expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
-        expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
-    });
-
     it("on mounted, initialises time to model end if null", () => {
         const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime, time: null });
         expect(mockSetPlotTime).toHaveBeenCalledTimes(1);

--- a/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
@@ -1,13 +1,13 @@
+import Vuex from "vuex";
+import { shallowMount } from "@vue/test-utils";
 import {
     SensitivityPlotExtreme,
     SensitivityPlotSettings,
     SensitivityPlotType
 } from "../../../../src/app/store/sensitivity/state";
-import Vuex from "vuex";
-import {mockBasicState} from "../../../mocks";
-import {BasicState} from "../../../../src/app/store/basic/state";
-import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
-import {shallowMount} from "@vue/test-utils";
+import { mockBasicState } from "../../../mocks";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivityPlotOptions from "../../../../src/app/components/options/SensitivityPlotOptions.vue";
 
 describe("SensitivityPlotOptions", () => {
@@ -34,7 +34,7 @@ describe("SensitivityPlotOptions", () => {
                 sensitivity: {
                     namespaced: true,
                     state: {
-                        plotSettings: {...plotSettings, ...settings}
+                        plotSettings: { ...plotSettings, ...settings }
                     },
                     mutations: {
                         [SensitivityMutation.SetPlotType]: mockSetPlotType,
@@ -77,7 +77,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("renders as expected for Value at a single time", () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
         expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
             .toBe(SensitivityPlotType.ValueAtTime);
 
@@ -89,7 +89,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("renders as expected for Value at min/max", () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtExtreme});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtExtreme });
         expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
             .toBe(SensitivityPlotType.ValueAtExtreme);
         expect(wrapper.find("#sensitivity-plot-extreme label").text()).toBe("Min/Max");
@@ -104,7 +104,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("renders as expected for Time at value's min/max", () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.TimeAtExtreme});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.TimeAtExtreme });
         expect((wrapper.find("#sensitivity-plot-type select").element as HTMLSelectElement).value)
             .toBe(SensitivityPlotType.TimeAtExtreme);
         expect(wrapper.find("#sensitivity-plot-extreme label").text()).toBe("Min/Max");
@@ -127,7 +127,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("updates time", async () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
         const timeInput = wrapper.find("#sensitivity-plot-time input");
         await timeInput.setValue("50");
 
@@ -136,7 +136,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("updates extreme type", async () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.TimeAtExtreme});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.TimeAtExtreme });
         const extremeSelect = wrapper.find("#sensitivity-plot-extreme select");
         (extremeSelect.element as HTMLSelectElement).value = SensitivityPlotExtreme.Max;
         await extremeSelect.trigger("change");
@@ -146,7 +146,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("reverts time to 0 if negative value entered", async () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
         const timeInput = wrapper.find("#sensitivity-plot-time input");
         await timeInput.setValue("-1");
 
@@ -155,7 +155,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("reverts time to model end if higher value entered", async () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
         const timeInput = wrapper.find("#sensitivity-plot-time input");
         await timeInput.setValue("200");
 
@@ -164,7 +164,7 @@ describe("SensitivityPlotOptions", () => {
     });
 
     it("on mounted, initialises time to model end if null", () => {
-        const wrapper = getWrapper({plotType: SensitivityPlotType.ValueAtTime, time: null});
+        const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime, time: null });
         expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
         expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
     });

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -8,7 +8,7 @@ import ActionRequiredMessage from "../../../../src/app/components/ActionRequired
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { SensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
-import { SensitivityState } from "../../../../src/app/store/sensitivity/state";
+import {SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
 import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 
 jest.mock("plotly.js", () => {});
@@ -33,6 +33,9 @@ describe("SensitivityTab", () => {
                         sensitivityUpdateRequired: false,
                         batch: {
                             solutions: []
+                        },
+                        plotSettings: {
+                            plotType: SensitivityPlotType.TraceOverTime
                         },
                         ...sensitivityState
                     },
@@ -62,6 +65,19 @@ describe("SensitivityTab", () => {
         expect(wrapper.find("button").element.disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(false);
+
+        expect(wrapper.find("#sensitivity-plot-placeholder").exists()).toBe(false);
+    });
+
+    it("renders placeholder if plot type is not Trace over time", () => {
+        const sensitivityState = {
+            plotSettings: {
+                plotType: SensitivityPlotType.ValueAtTime
+            }
+        } as any;
+        const wrapper = getWrapper({}, sensitivityState);
+        expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
+        expect(wrapper.find("#sensitivity-plot-placeholder").text()).toBe("Other plot types coming soon!");
     });
 
     it("disables run button when no odinRunner", () => {

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -8,7 +8,7 @@ import ActionRequiredMessage from "../../../../src/app/components/ActionRequired
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { SensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
-import {SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
+import { SensitivityPlotType, SensitivityState } from "../../../../src/app/store/sensitivity/state";
 import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 
 jest.mock("plotly.js", () => {});

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -1,8 +1,8 @@
 // Mock plotly before import RunTab, which indirectly imports plotly via WodinPlot
+/* eslint-disable import/first */
 import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import { ModelState, RequiredModelAction } from "../../../../src/app/store/model/state";
-/* eslint-disable import/first */
 import SensitivityTab from "../../../../src/app/components/sensitivity/SensitivityTab.vue";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -1,5 +1,5 @@
 import { mutations, SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
-import {SensitivityPlotExtreme, SensitivityPlotType} from "../../../../src/app/store/sensitivity/state";
+import { SensitivityPlotExtreme, SensitivityPlotType } from "../../../../src/app/store/sensitivity/state";
 
 describe("Sensitivity mutations", () => {
     it("sets parameter to vary", () => {
@@ -47,19 +47,19 @@ describe("Sensitivity mutations", () => {
     };
 
     it("sets plot type", () => {
-        const state = {plotSettings} as any;
+        const state = { plotSettings } as any;
         mutations[SensitivityMutation.SetPlotType](state, SensitivityPlotType.ValueAtTime);
         expect(state.plotSettings.plotType).toBe(SensitivityPlotType.ValueAtTime);
     });
 
     it("sets plot extreme", () => {
-        const state = {plotSettings} as any;
+        const state = { plotSettings } as any;
         mutations[SensitivityMutation.SetPlotExtreme](state, SensitivityPlotExtreme.Min);
         expect(state.plotSettings.extreme).toBe(SensitivityPlotExtreme.Min);
     });
 
     it("sets plot time", () => {
-        const state = {plotSettings} as any;
+        const state = { plotSettings } as any;
         mutations[SensitivityMutation.SetPlotTime](state, 50);
         expect(state.plotSettings.time).toBe(50);
     });

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -1,4 +1,5 @@
 import { mutations, SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import {SensitivityPlotExtreme, SensitivityPlotType} from "../../../../src/app/store/sensitivity/state";
 
 describe("Sensitivity mutations", () => {
     it("sets parameter to vary", () => {
@@ -37,5 +38,29 @@ describe("Sensitivity mutations", () => {
         } as any;
         mutations[SensitivityMutation.SetUpdateRequired](state, true);
         expect(state.sensitivityUpdateRequired).toBe(true);
+    });
+
+    const plotSettings = {
+        plotType: SensitivityPlotType.TraceOverTime,
+        extreme: SensitivityPlotExtreme.Max,
+        time: null
+    };
+
+    it("sets plot type", () => {
+        const state = {plotSettings} as any;
+        mutations[SensitivityMutation.SetPlotType](state, SensitivityPlotType.ValueAtTime);
+        expect(state.plotSettings.plotType).toBe(SensitivityPlotType.ValueAtTime);
+    });
+
+    it("sets plot extreme", () => {
+        const state = {plotSettings} as any;
+        mutations[SensitivityMutation.SetPlotExtreme](state, SensitivityPlotExtreme.Min);
+        expect(state.plotSettings.extreme).toBe(SensitivityPlotExtreme.Min);
+    });
+
+    it("sets plot time", () => {
+        const state = {plotSettings} as any;
+        mutations[SensitivityMutation.SetPlotTime](state, 50);
+        expect(state.plotSettings.time).toBe(50);
     });
 });


### PR DESCRIPTION
This branch adds UI for selecting sensitivity plot type and related settings (min/max and time). Related settings are only shown for the relevant plot types. Settings are saved to the state, but are not yet used to plot sensitivity data for plot types other than Trace over time (a placeholder message is shown for other trace types). 

As per the shiny app, we let the user set any numeric time value, but will clip to 0 to model endTime range when we run the batch method to get the plot data

NB re the UI in the Options tab for this, Nick has suggested moving the Edit button for the Parameter variance up to the top right of that area to more closely link the bullet point value with the button. I think it might be useful to add headings to the two sections ('Parameter variance'/'Plot settings') as well/instead of to clarify the meaning of the two parts. Thoughts on this @richfitz @LekanAnni ?