### PR TITLE
mrc-3435 Value at Time sensitivity plot

### DIFF
--- a/app/static/playwright.config.ts
+++ b/app/static/playwright.config.ts
@@ -7,7 +7,7 @@ const config: PlaywrightTestConfig = {
         screenshot: "only-on-failure",
         actionTimeout: 0
     },
-    timeout: 30000,
+    timeout: 60000,
     workers: 1
 };
 

--- a/app/static/playwright.config.ts
+++ b/app/static/playwright.config.ts
@@ -7,7 +7,7 @@ const config: PlaywrightTestConfig = {
         screenshot: "only-on-failure",
         actionTimeout: 0
     },
-    timeout: 20000,
+    timeout: 30000,
     workers: 1
 };
 

--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -17,7 +17,9 @@ import { EventEmitter } from "events";
 import {
     newPlot, react, PlotRelayoutEvent, Plots
 } from "plotly.js";
-import { WodinPlotData, fadePlotStyle, margin, config } from "../plot";
+import {
+    WodinPlotData, fadePlotStyle, margin, config
+} from "../plot";
 import { OdinSolution } from "../types/responseTypes";
 
 export default defineComponent({

--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -17,7 +17,7 @@ import { EventEmitter } from "events";
 import {
     newPlot, react, PlotRelayoutEvent, Plots
 } from "plotly.js";
-import { WodinPlotData } from "../plot";
+import { WodinPlotData, fadePlotStyle, margin, config } from "../plot";
 import { OdinSolution } from "../types/responseTypes";
 
 export default defineComponent({
@@ -41,7 +41,7 @@ export default defineComponent({
         }
     },
     setup(props) {
-        const plotStyle = computed(() => (props.fadePlot ? "opacity:0.5;" : ""));
+        const plotStyle = computed(() => (props.fadePlot ? fadePlotStyle : ""));
 
         const startTime = 0;
 
@@ -50,17 +50,6 @@ export default defineComponent({
         const nPoints = 1000; // TODO: appropriate value could be derived from width of element
 
         const hasPlotData = computed(() => !!(baseData.value?.length));
-
-        const config = {
-            responsive: true
-        };
-
-        // This is enough top margin to accommodate the plotly options
-        // bar without it interfering with the first series in the
-        // legend.
-        const margin = {
-            t: 25
-        };
 
         const relayout = async (event: PlotRelayoutEvent) => {
             let data;
@@ -132,14 +121,3 @@ export default defineComponent({
     }
 });
 </script>
-<style scoped lang="scss">
-.plot-placeholder {
-  width: 100%;
-  height: 450px;
-  background-color: #eee;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-}
-</style>

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -27,6 +27,10 @@ export default defineComponent({
         value: {
             type: Number,
             required: true
+        },
+        allowNegative: {
+            type: Boolean,
+            default: true
         }
     },
     emits: ["update"],
@@ -45,7 +49,10 @@ export default defineComponent({
         const updateValue = (event: Event) => {
             // 1. Apply character mask - only allow numerics, decimal point, comma, and hyphen (for negatives)
             const element = event.target as HTMLInputElement;
-            const newVal = element.value.replace(/[^0-9,.-]/g, "");
+            let newVal = element.value.replace(/[^0-9,.-]/g, "");
+            if (!props.allowNegative) {
+                newVal = newVal.replace("-", "");
+            }
 
             // within the event handler we need to update the element directly to apply character mask as well as
             // updating reactive value

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -5,11 +5,9 @@
         <label class="col-form-label">End time</label>
       </div>
       <div class="col-6">
-        <input class="form-control parameter-input"
-               type="number"
-               min="1"
-               :value="endTime"
-               @input="updateEndTime"/>
+        <numeric-input :value="endTime"
+                       :allow-negative="false"
+                       @update="updateEndTime"></numeric-input>
       </div>
     </div>
   </div>
@@ -20,15 +18,18 @@ import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { RunMutation } from "../../store/run/mutations";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
+import NumericInput from "./NumericInput.vue";
 
 export default defineComponent({
     name: "RunOptions",
+    components: {
+        NumericInput
+    },
     setup() {
         const store = useStore();
         const endTime = computed(() => store.state.run.endTime);
 
-        const updateEndTime = (e: Event) => {
-            const newValue = parseFloat((e.target as HTMLInputElement).value);
+        const updateEndTime = (newValue: number) => {
             store.commit(`run/${RunMutation.SetEndTime}`, newValue);
             store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true);
         };

--- a/app/static/src/app/components/options/SensitivityPlotOptions.vue
+++ b/app/static/src/app/components/options/SensitivityPlotOptions.vue
@@ -25,7 +25,9 @@
         <label class="col-form-label">Time to use</label>
       </div>
       <div class="col-xl-6 col-11">
-        <input v-model="time" class="form-control" type="number">
+        <numeric-input  :value="time"
+                        :allow-negative="false"
+                        @update="(n) => time = n"></numeric-input>
       </div>
     </div>
   </div>
@@ -36,9 +38,13 @@ import { computed, defineComponent, onMounted } from "vue";
 import { useStore } from "vuex";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
 import { SensitivityPlotExtreme, SensitivityPlotType } from "../../store/sensitivity/state";
+import NumericInput from "./NumericInput.vue";
 
 export default defineComponent({
     name: "SensitivityPlotOptions.vue",
+    components: {
+        NumericInput
+    },
     setup() {
         const namespace = "sensitivity";
         const store = useStore();

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="summary-plot-container" :style="plotStyle">
+    <div class="plot" ref="plot">
+    </div>
+    <div v-if="!hasPlotData" class="plot-placeholder">
+      {{ placeholderMessage }}
+    </div>
+    <slot></slot>
+  </div>
+</template>
+
+<script lang="ts">
+
+import {
+    computed, defineComponent, onMounted, onUnmounted, ref, watch
+} from "vue";
+import { newPlot, Plots } from "plotly.js";
+import { useStore } from "vuex";
+import {fadePlotStyle, margin, config} from "../../plot";
+import {SensitivityPlotType} from "../../store/sensitivity/state";
+import userMessages from "../../userMessages";
+
+export default defineComponent({
+    name: "SensitivitySummaryPlot",
+    props: {
+        fadePlot: Boolean
+    },
+    setup(props) {
+        const store = useStore();
+        const plotStyle = computed(() => (props.fadePlot ? fadePlotStyle : ""));
+        const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
+        const placeholderMessage = userMessages.sensitivity.notRunYet;
+
+        const batch = computed(() => store.state.sensitivity.batch);
+        const plotSettings = computed(() => store.state.sensitivity.plotSettings);
+        const plotData = computed(() => {
+          if (batch.value) {
+            // TODO: implement other summary plot types
+            if (plotSettings.value.plotType === SensitivityPlotType.ValueAtTime) {
+              // TODO: check - this should update automatically when time in settings changes
+              // TODO: make sure time is valid for model
+              return [batch.value.valueAtTime(plotSettings.value.time)];
+            }
+          }
+          return [];
+        });
+        const hasPlotData = computed(() => !!(plotData.value?.length));
+
+        const resize = () => {
+            if (plot.value) {
+                Plots.resize(plot.value as HTMLElement);
+            }
+        };
+
+        let resizeObserver: null | ResizeObserver = null;
+
+        const drawPlot = () => {
+            if (hasPlotData.value) {
+                const el = plot.value as unknown;
+                const layout = {
+                    margin
+                };
+                newPlot(el as HTMLElement, plotData.value, layout, config);
+                resizeObserver = new ResizeObserver(resize);
+                resizeObserver.observe(plot.value as HTMLElement);
+            }
+        };
+
+        onMounted(drawPlot);
+
+        watch(plotData, drawPlot);
+
+        onUnmounted(() => {
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+            }
+        });
+
+        return {
+            placeholderMessage,
+            plot,
+            plotStyle,
+            plotData,
+            hasPlotData
+        };
+    }
+});
+
+</script>

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -16,8 +16,10 @@ import {
 } from "vue";
 import { newPlot, Plots } from "plotly.js";
 import { useStore } from "vuex";
-import {fadePlotStyle, margin, config} from "../../plot";
-import {SensitivityPlotType} from "../../store/sensitivity/state";
+import {
+    fadePlotStyle, margin, config, odinToPlotly
+} from "../../plot";
+import { SensitivityPlotType } from "../../store/sensitivity/state";
 import userMessages from "../../userMessages";
 
 export default defineComponent({
@@ -33,16 +35,17 @@ export default defineComponent({
 
         const batch = computed(() => store.state.sensitivity.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
+        const palette = computed(() => store.state.model.paletteModel);
         const plotData = computed(() => {
-          if (batch.value) {
+            if (batch.value) {
             // TODO: implement other summary plot types
-            if (plotSettings.value.plotType === SensitivityPlotType.ValueAtTime) {
-              // TODO: check - this should update automatically when time in settings changes
-              // TODO: make sure time is valid for model
-              return [batch.value.valueAtTime(plotSettings.value.time)];
+                if (plotSettings.value.plotType === SensitivityPlotType.ValueAtTime) {
+                    // TODO: make sure time is valid for model
+                    const data = batch.value.valueAtTime(plotSettings.value.time);
+                    return [...odinToPlotly(data, palette.value)];
+                }
             }
-          }
-          return [];
+            return [];
         });
         const hasPlotData = computed(() => !!(plotData.value?.length));
 

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -37,6 +37,7 @@ export default defineComponent({
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
         const plotData = computed(() => {
+
             if (batch.value) {
             // TODO: implement other summary plot types
                 if (plotSettings.value.plotType === SensitivityPlotType.ValueAtTime) {

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -101,7 +101,8 @@ export default defineComponent({
             plot,
             plotStyle,
             plotData,
-            hasPlotData
+            hasPlotData,
+            resize
         };
     }
 });

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -7,7 +7,8 @@
               @click="runSensitivity">Run sensitivity</button>
     </div>
     <action-required-message :message="updateMsg"></action-required-message>
-    <sensitivity-traces-plot v-if="tracesPlot" :fade-plot="!!updateMsg" ></sensitivity-traces-plot>
+    <sensitivity-traces-plot v-if="tracesPlot" :fade-plot="!!updateMsg"></sensitivity-traces-plot>
+    <sensitivity-summary-plot v-else-if="valueAtTimePlot" :fade-plot="!!updateMsg"></sensitivity-summary-plot>
     <div v-else id="sensitivity-plot-placeholder">Other plot types coming soon!</div>
   </div>
 </template>
@@ -22,10 +23,12 @@ import { SensitivityGetter } from "../../store/sensitivity/getters";
 import { SensitivityAction } from "../../store/sensitivity/actions";
 import userMessages from "../../userMessages";
 import { SensitivityPlotType } from "../../store/sensitivity/state";
+import SensitivitySummaryPlot from "./SensitivitySummaryPlot.vue";
 
 export default defineComponent({
     name: "SensitivityTab",
     components: {
+        SensitivitySummaryPlot,
         ActionRequiredMessage,
         SensitivityTracesPlot
     },
@@ -59,11 +62,17 @@ export default defineComponent({
             () => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.TraceOverTime
         );
 
+        // TODO: we can remove this once other summary plot types are implemented
+        const valueAtTimePlot = computed(
+            () => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.ValueAtTime
+        );
+
         return {
             canRunSensitivity,
             runSensitivity,
             updateMsg,
-            tracesPlot
+            tracesPlot,
+            valueAtTimePlot
         };
     }
 });

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -4,6 +4,19 @@ import { OdinSeriesSet } from "./types/responseTypes";
 
 export type WodinPlotData = Partial<PlotData>[];
 
+export const fadePlotStyle = "opacity:0.5;";
+
+// This is enough top margin to accommodate the plotly options
+// bar without it interfering with the first series in the
+// legend.
+export const margin = {
+    t: 25
+};
+
+export const config = {
+    responsive: true
+};
+
 export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
     const idx = s.names.indexOf(name);
     return {

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -46,6 +46,7 @@ export function odinToPlotly(s: OdinSeriesSet, palette: Palette, options: Partia
 
     return s.y.map(
         (el: number[], i: number): Partial<PlotData> => ({
+            mode: "lines",
             line: {
                 color: palette[s.names[i]],
                 width: plotlyOptions.lineWidth

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -71,13 +71,6 @@ export type OdinSeriesSet = {
     y: number[][];
 }
 
-// This is Odin's Series
-export type OdinSeries = {
-    name: string,
-    x: number[],
-    y: number
-};
-
 // This is Odin's InterpolatedSolution
 export type OdinSolution = (t0: number, t1: number, nPoints: number) => OdinSeriesSet;
 
@@ -119,7 +112,7 @@ export type OdeControl = Dict<unknown>;
 export interface Batch {
     pars: BatchPars,
     solutions: OdinSolution[],
-    valueAtTime: (time: number) => OdinSeries
+    valueAtTime: (time: number) => OdinSeriesSet
 }
 
 export interface OdinRunner {

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -71,6 +71,13 @@ export type OdinSeriesSet = {
     y: number[][];
 }
 
+// This is Odin's Series
+export type OdinSeries = {
+    name: string,
+    x: number[],
+    y: number
+};
+
 // This is Odin's InterpolatedSolution
 export type OdinSolution = (t0: number, t1: number, nPoints: number) => OdinSeriesSet;
 
@@ -111,7 +118,8 @@ export type OdeControl = Dict<unknown>;
 
 export interface Batch {
     pars: BatchPars,
-    solutions: OdinSolution[]
+    solutions: OdinSolution[],
+    valueAtTime: (time: number) => OdinSeries
 }
 
 export interface OdinRunner {

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -21,3 +21,13 @@ $brand: #479fb6;
   border-color: #0d6efd;
   color: #0d6efd !important;
 }
+
+.plot-placeholder {
+  width: 100%;
+  height: 450px;
+  background-color: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -1,14 +1,16 @@
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import {BasicState} from "../src/app/store/basic/state";
-import {FitState} from "../src/app/store/fit/state";
-import {StochasticState} from "../src/app/store/stochastic/state";
-import {BatchPars, ResponseFailure, ResponseSuccess, WodinError} from "../src/app/types/responseTypes";
-import {ModelState} from "../src/app/store/model/state";
-import {CodeState} from "../src/app/store/code/state";
-import {FitDataState} from "../src/app/store/fitData/state";
-import {AppType, VisualisationTab} from "../src/app/store/appState/state";
-import {ModelFitState} from "../src/app/store/modelFit/state";
+import { BasicState } from "../src/app/store/basic/state";
+import { FitState } from "../src/app/store/fit/state";
+import { StochasticState } from "../src/app/store/stochastic/state";
+import {
+    BatchPars, ResponseFailure, ResponseSuccess, WodinError
+} from "../src/app/types/responseTypes";
+import { ModelState } from "../src/app/store/model/state";
+import { CodeState } from "../src/app/store/code/state";
+import { FitDataState } from "../src/app/store/fitData/state";
+import { AppType, VisualisationTab } from "../src/app/store/appState/state";
+import { ModelFitState } from "../src/app/store/modelFit/state";
 import {
     SensitivityPlotExtreme,
     SensitivityPlotType,

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -5,7 +5,7 @@ import Vuex from "vuex";
 import { mount } from "@vue/test-utils";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {mockBasicState, mockModelState, mockSensitivityState} from "../../../mocks";
+import { mockBasicState, mockModelState, mockSensitivityState } from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -25,6 +25,7 @@ describe("FitPlot", () => {
 
     const expectedPlotData = [
         {
+            mode: "lines",
             name: "y",
             x: [0, 0.5, 1],
             y: [5, 6, 7],

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -70,6 +70,20 @@ describe("NumericInput", () => {
         expect(wrapper.emitted("update")![0]).toStrictEqual([100]);
     });
 
+    it("masks out hyphen if allowNegative is false", async () => {
+        const wrapper = mount(NumericInput, { props: { allowNegative: false, value: 1 } });
+        await wrapper.find("input").setValue("-100");
+        expectInputToHaveValue(wrapper, "100");
+        expect(wrapper.emitted("update")![0]).toStrictEqual([100]);
+    });
+
+    it("does not mask out hyphen if allowNegative is true", async () => {
+        const wrapper = mount(NumericInput, { props: { allowNegative: true, value: 1 } });
+        await wrapper.find("input").setValue("-100");
+        expectInputToHaveValue(wrapper, "-100");
+        expect(wrapper.emitted("update")![0]).toStrictEqual([-100]);
+    });
+
     it("does not emit update if value is not parseable as numeric", async () => {
         const wrapper = mount(NumericInput, { props: { value: 12 } });
         await nextTick();

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -2,6 +2,7 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
+import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
 describe("RunOptions", () => {
     const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn()) => {
@@ -35,18 +36,17 @@ describe("RunOptions", () => {
     it("renders as expected", () => {
         const wrapper = getWrapper();
         expect(wrapper.find("label").text()).toBe("End time");
-        const input = wrapper.find("input");
-        expect(input.attributes("type")).toBe("number");
-        expect(input.attributes("min")).toBe("1");
-        expect((input.element as HTMLInputElement).value).toBe("99");
+        const input = wrapper.findComponent(NumericInput);
+        expect(input.props("value")).toBe(99);
+        expect(input.props("allowNegative")).toBe(false);
     });
 
     it("commits end time change", () => {
         const mockSetEndTime = jest.fn();
         const mockSetSensitivityUpdateRequired = jest.fn();
         const wrapper = getWrapper(mockSetEndTime, mockSetSensitivityUpdateRequired);
-        const input = wrapper.find("input");
-        input.setValue("101");
+        const input = wrapper.findComponent(NumericInput);
+        input.vm.$emit("update", 101);
         expect(mockSetEndTime).toHaveBeenCalledTimes(1);
         expect(mockSetEndTime.mock.calls[0][1]).toBe(101);
         expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);

--- a/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityPlotOptions.test.ts
@@ -9,6 +9,7 @@ import { mockBasicState } from "../../../mocks";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivityPlotOptions from "../../../../src/app/components/options/SensitivityPlotOptions.vue";
+import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
 describe("SensitivityPlotOptions", () => {
     const plotSettings = {
@@ -89,8 +90,9 @@ describe("SensitivityPlotOptions", () => {
         expect(wrapper.find("#sensitivity-plot-extreme").exists()).toBe(false);
 
         expect(wrapper.find("#sensitivity-plot-time label").text()).toBe("Time to use");
-        expect(wrapper.find("#sensitivity-plot-time input").attributes("type")).toBe("number");
-        expect((wrapper.find("#sensitivity-plot-time input").element as HTMLInputElement).value).toBe("100");
+        const timeInput = wrapper.find("#sensitivity-plot-time").findComponent(NumericInput);
+        expect(timeInput.props("value")).toBe(100);
+        expect(timeInput.props("allowNegative")).toBe(false);
     });
 
     it("renders as expected for Value at min/max", () => {
@@ -133,8 +135,8 @@ describe("SensitivityPlotOptions", () => {
 
     it("updates time", async () => {
         const wrapper = getWrapper({ plotType: SensitivityPlotType.ValueAtTime });
-        const timeInput = wrapper.find("#sensitivity-plot-time input");
-        await timeInput.setValue("50");
+        const timeInput = wrapper.find("#sensitivity-plot-time").findComponent(NumericInput);
+        await timeInput.vm.$emit("update", 50);
 
         expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
         expect(mockSetPlotTime.mock.calls[0][1]).toBe(50);

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -54,6 +54,7 @@ describe("RunPlot", () => {
         const data = plotData(0, 1, 10);
         expect(data).toStrictEqual([
             {
+                mode: "lines",
                 line: {
                     color: "#ff0000",
                     width: 2
@@ -65,6 +66,7 @@ describe("RunPlot", () => {
                 legendgroup: undefined
             },
             {
+                mode: "lines",
                 line: {
                     color: "#00ff00",
                     width: 2

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -1,13 +1,13 @@
 // Mock the import of plotly so we can mock Plotly methods
-import {BasicState} from "../../../../src/app/store/basic/state";
-import Vuex, {Store} from "vuex";
-import {mockBasicState} from "../../../mocks";
-import {SensitivityPlotExtreme, SensitivityPlotType} from "../../../../src/app/store/sensitivity/state";
-import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
-import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
-import {shallowMount, VueWrapper} from "@vue/test-utils";
+import Vuex, { Store } from "vuex";
+import { shallowMount, VueWrapper } from "@vue/test-utils";
 import * as plotly from "plotly.js";
-import {nextTick} from "vue";
+import { nextTick } from "vue";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import { mockBasicState } from "../../../mocks";
+import { SensitivityPlotExtreme, SensitivityPlotType } from "../../../../src/app/store/sensitivity/state";
+import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
 
 jest.mock("plotly.js", () => ({
     newPlot: jest.fn(),
@@ -121,7 +121,7 @@ describe("SensitivitySummaryPlot", () => {
                 t: 25
             }
         });
-        expect(mockPlotlyNewPlot.mock.calls[0][3]).toStrictEqual({responsive: true});
+        expect(mockPlotlyNewPlot.mock.calls[0][3]).toStrictEqual({ responsive: true });
     };
 
     it("plots data as expected", () => {

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -1,0 +1,124 @@
+// Mock the import of plotly so we can mock Plotly methods
+import {BasicState} from "../../../../src/app/store/basic/state";
+import Vuex from "vuex";
+import {mockBasicState} from "../../../mocks";
+import {SensitivityPlotExtreme, SensitivityPlotType} from "../../../../src/app/store/sensitivity/state";
+import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
+import {shallowMount} from "@vue/test-utils";
+import * as plotly from "plotly.js";
+
+jest.mock("plotly.js", () => ({
+    newPlot: jest.fn(),
+    Plots: {
+        resize: jest.fn()
+    }
+}));
+
+describe("SensitivitySummaryPlot", () => {
+    const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
+
+    const mockObserve = jest.fn();
+    const mockDisconnect = jest.fn();
+    function mockResizeObserver(this: any) {
+        this.observe = mockObserve;
+        this.disconnect = mockDisconnect;
+    }
+    (global.ResizeObserver as any) = mockResizeObserver;
+
+    const mockSetPlotTime = jest.fn();
+
+    const mockValueAtTimeData = {
+        names: ["S", "I"],
+        x: [1, 1.1],
+        y: [[10, 10.1], [20, 19.9]]
+    };
+
+    const mockValueAtTime = jest.fn().mockReturnValue(mockValueAtTimeData);
+
+    const getWrapper = () => {
+        const store = new Vuex.Store<BasicState>({
+            state: mockBasicState(),
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: {
+                        paletteModel: {
+                            S: "#ff0000",
+                            I: "#0000ff"
+                        },
+                        endTime: 100
+                    }
+                },
+                sensitivity: {
+                    namespaced: true,
+                    state: {
+                        batch: {
+                            valueAtTime: mockValueAtTime
+                        },
+                        plotSettings: {
+                            plotType: SensitivityPlotType.ValueAtTime,
+                            time: 99,
+                            extreme: SensitivityPlotExtreme.Min
+                        }
+                    },
+                    mutations: {
+                        [SensitivityMutation.SetPlotTime]: mockSetPlotTime
+                    }
+                }
+            }
+        });
+
+        return shallowMount(SensitivitySummaryPlot, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("plots data as expected", () => {
+        const wrapper = getWrapper();
+        expect(mockPlotlyNewPlot).toHaveBeenCalledTimes(1);
+        const plotEl = wrapper.find(".plot").element;
+        expect(mockPlotlyNewPlot.mock.calls[0][0]).toBe(plotEl);
+        const expectedPlotData = [
+            {
+                mode: "lines",
+                line: {
+                    color: "#ff0000",
+                    width: 2
+                },
+                name: "S",
+                x: [1, 1.1],
+                y: [10, 10.1],
+                legendgroup: undefined,
+                showlegend: true
+            },
+            {
+                mode: "lines",
+                line: {
+                    color: "#0000ff",
+                    width: 2
+                },
+                name: "I",
+                x: [1, 1.1],
+                y: [20, 19.9],
+                legendgroup: undefined,
+                showlegend: true
+            }
+        ];
+        expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedPlotData);
+        expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({
+            margin: {
+                t: 25
+            }
+        });
+        expect(mockPlotlyNewPlot.mock.calls[0][3]).toStrictEqual({responsive: true});
+    });
+
+    //it("renders as expected when no data
+});

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -1,15 +1,15 @@
 // Mock plotly before import RunTab, which indirectly imports plotly via WodinPlot
 /* eslint-disable import/first */
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
-import {ModelState, RequiredModelAction} from "../../../../src/app/store/model/state";
+import { ModelState, RequiredModelAction } from "../../../../src/app/store/model/state";
 import SensitivityTab from "../../../../src/app/components/sensitivity/SensitivityTab.vue";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
-import {BasicState} from "../../../../src/app/store/basic/state";
-import {SensitivityGetter} from "../../../../src/app/store/sensitivity/getters";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import { SensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
-import {SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
-import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import { SensitivityPlotType, SensitivityState } from "../../../../src/app/store/sensitivity/state";
+import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
 
 jest.mock("plotly.js", () => {});
@@ -72,7 +72,7 @@ describe("SensitivityTab", () => {
     });
 
     it("renders as expected when Value at Time", () => {
-        const wrapper = getWrapper({}, {plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any});
+        const wrapper = getWrapper({}, { plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any });
         expect(wrapper.find("button").text()).toBe("Run sensitivity");
         expect(wrapper.find("button").element.disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -42,6 +42,7 @@ const mockSolutions = [mockSln1, mockSln2];
 const expectedPlotData = [
     // sln1
     {
+        mode: "lines",
         line: {
             color: "#0000ff",
             width: 1
@@ -53,6 +54,7 @@ const expectedPlotData = [
         legendgroup: "y"
     },
     {
+        mode: "lines",
         line: {
             color: "#ff0000",
             width: 1
@@ -65,6 +67,7 @@ const expectedPlotData = [
     },
     // sln2
     {
+        mode: "lines",
         line: {
             color: "#0000ff",
             width: 1
@@ -76,6 +79,7 @@ const expectedPlotData = [
         legendgroup: "y"
     },
     {
+        mode: "lines",
         line: {
             color: "#ff0000",
             width: 1
@@ -88,6 +92,7 @@ const expectedPlotData = [
     },
     // central
     {
+        mode: "lines",
         line: {
             color: "#0000ff",
             width: 2
@@ -99,6 +104,7 @@ const expectedPlotData = [
         legendgroup: "y"
     },
     {
+        mode: "lines",
         line: {
             color: "#ff0000",
             width: 2

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -15,6 +15,7 @@ describe("odinToPlotly", () => {
     it("uses default options", () => {
         expect(odinToPlotly(series, palette)).toStrictEqual([
             {
+                mode: "lines",
                 line: {
                     color: "#ff0000",
                     width: 2
@@ -26,6 +27,7 @@ describe("odinToPlotly", () => {
                 showlegend: true
             },
             {
+                mode: "lines",
                 line: {
                     color: "#0000ff",
                     width: 2
@@ -48,6 +50,7 @@ describe("odinToPlotly", () => {
 
         expect(odinToPlotly(series, palette, options)).toStrictEqual([
             {
+                mode: "lines",
                 line: {
                     color: "#ff0000",
                     width: 3
@@ -59,6 +62,7 @@ describe("odinToPlotly", () => {
                 showlegend: false
             },
             {
+                mode: "lines",
                 line: {
                     color: "#0000ff",
                     width: 3


### PR DESCRIPTION
This branch implements 'Value at a single time' sensitivity plot. It includes a new plot component, `SensitivitySummaryPlot` which will call the appropriate methods on the sensitvity module's `batch` to get the sensitivity plot data. A future branch will implement the min/max plot types. 

The `SensitivitySummaryPlot` does share some code with `WodinOdePlot` around setting up the resize observer and calling `newPlot`. I didn't think it was worth making a further base component for them both to share, particularly since there are differences (the `WodinOdePlot` regenerates data on relayout (zoom) which we don't need to do here) so any base component would need to accommodate both of these requirements. I've pulled out common bits of config into the `plot` module.  

To test, run sensitivity, and change 'Type of plot'  in 'Sensitivity options' to 'Value at a single time'. Plot should change to single trace for each variable, showing value variance over the range of parameter values at a single time. Plot should be updated when 'Time to use' value is changed. 

The new component uses some model state and will be slightly impacted by the state refactor: https://github.com/mrc-ide/wodin/pull/56
