### PR TITLE
mrc-3518 Catch and display sensitivity run errors

### DIFF
--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -10,6 +10,7 @@
     <sensitivity-traces-plot v-if="tracesPlot" :fade-plot="!!updateMsg"></sensitivity-traces-plot>
     <sensitivity-summary-plot v-else-if="valueAtTimePlot" :fade-plot="!!updateMsg"></sensitivity-summary-plot>
     <div v-else id="sensitivity-plot-placeholder">Other plot types coming soon!</div>
+    <error-info :error="error"></error-info>
   </div>
 </template>
 
@@ -23,10 +24,12 @@ import { SensitivityAction } from "../../store/sensitivity/actions";
 import userMessages from "../../userMessages";
 import { SensitivityPlotType } from "../../store/sensitivity/state";
 import SensitivitySummaryPlot from "./SensitivitySummaryPlot.vue";
+import ErrorInfo from "../ErrorInfo.vue";
 
 export default defineComponent({
     name: "SensitivityTab",
     components: {
+      ErrorInfo,
         SensitivitySummaryPlot,
         ActionRequiredMessage,
         SensitivityTracesPlot
@@ -65,12 +68,15 @@ export default defineComponent({
             () => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.ValueAtTime
         );
 
+        const error = computed(() => store.state.sensitivity.error);
+
         return {
             canRunSensitivity,
             runSensitivity,
             updateMsg,
             tracesPlot,
-            valueAtTimePlot
+            valueAtTimePlot,
+            error
         };
     }
 });

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -29,7 +29,7 @@ import ErrorInfo from "../ErrorInfo.vue";
 export default defineComponent({
     name: "SensitivityTab",
     components: {
-      ErrorInfo,
+        ErrorInfo,
         SensitivitySummaryPlot,
         ActionRequiredMessage,
         SensitivityTracesPlot

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -2,7 +2,7 @@ import { MutationTree } from "vuex";
 import {
     SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState
 } from "./state";
-import {Batch, WodinError} from "../../types/responseTypes";
+import { Batch, WodinError } from "../../types/responseTypes";
 
 export enum SensitivityMutation {
     SetParameterToVary = "SetParameterToVary",

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -2,7 +2,7 @@ import { MutationTree } from "vuex";
 import {
     SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState
 } from "./state";
-import { Batch } from "../../types/responseTypes";
+import {Batch, WodinError} from "../../types/responseTypes";
 
 export enum SensitivityMutation {
     SetParameterToVary = "SetParameterToVary",
@@ -11,7 +11,8 @@ export enum SensitivityMutation {
     SetUpdateRequired = "SetUpdateRequired",
     SetPlotType = "SetPlotType",
     SetPlotExtreme = "SetPlotExtreme",
-    SetPlotTime = "SetPlotTime"
+    SetPlotTime = "SetPlotTime",
+    SetError = "SetError"
 }
 
 export const mutations: MutationTree<SensitivityState> = {
@@ -27,6 +28,7 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.SetBatch](state: SensitivityState, payload: Batch) {
         state.batch = payload;
+        state.error = null;
     },
 
     [SensitivityMutation.SetUpdateRequired](state: SensitivityState, payload: boolean) {
@@ -43,5 +45,9 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.SetPlotTime](state: SensitivityState, payload: number) {
         state.plotSettings.time = payload;
+    },
+
+    [SensitivityMutation.SetError](state: SensitivityState, payload: WodinError) {
+        state.error = payload;
     }
 };

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -25,7 +25,8 @@ export const defaultState: SensitivityState = {
         time: null
     },
     batch: null,
-    sensitivityUpdateRequired: false
+    sensitivityUpdateRequired: false,
+    error: null
 };
 
 export const sensitivity = {

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -1,4 +1,4 @@
-import {Batch, WodinError} from "../../types/responseTypes";
+import { Batch, WodinError } from "../../types/responseTypes";
 
 export enum SensitivityScaleType {
     Arithmetic = "Arithmetic",

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -1,4 +1,4 @@
-import { Batch } from "../../types/responseTypes";
+import {Batch, WodinError} from "../../types/responseTypes";
 
 export enum SensitivityScaleType {
     Arithmetic = "Arithmetic",
@@ -43,5 +43,6 @@ export interface SensitivityState {
     batch: Batch | null,
     // Whether sensitivity needs to be re-run because of change to settings or model
     sensitivityUpdateRequired: boolean
-    plotSettings: SensitivityPlotSettings
+    plotSettings: SensitivityPlotSettings,
+    error: WodinError | null
 }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -6,7 +6,8 @@ export default {
         isNotValid: "Code is not valid"
     },
     errors: {
-        wodinRunError: "An error occurred while running the model"
+        wodinRunError: "An error occurred while running the model",
+        wodinSensitivityError: "An error occurred while running sensitivity"
     },
     fitData: {
         errorLoadingData: "An error occurred when loading data",

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -108,6 +108,7 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
         },
         batch: null,
         sensitivityUpdateRequired: false,
+        error: null,
         ...state
     };
 };

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -12,6 +12,7 @@ import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/Se
 import { SensitivityPlotType, SensitivityState } from "../../../../src/app/store/sensitivity/state";
 import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
+import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
 
 jest.mock("plotly.js", () => {});
 
@@ -39,6 +40,7 @@ describe("SensitivityTab", () => {
                         plotSettings: {
                             plotType: SensitivityPlotType.TraceOverTime
                         },
+                        error: null,
                         ...sensitivityState
                     },
                     getters: {
@@ -67,6 +69,7 @@ describe("SensitivityTab", () => {
         expect(wrapper.find("button").element.disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(false);
+        expect(wrapper.findComponent(ErrorInfo).props("error")).toBe(null);
 
         expect(wrapper.findComponent(SensitivitySummaryPlot).exists()).toBe(false);
         expect(wrapper.find("#sensitivity-plot-placeholder").exists()).toBe(false);
@@ -92,6 +95,12 @@ describe("SensitivityTab", () => {
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
         expect(wrapper.find("#sensitivity-plot-placeholder").text()).toBe("Other plot types coming soon!");
+    });
+
+    it("renders error", () => {
+        const testError = { error: "Test Error", detail: "test error detail" };
+        const wrapper = getWrapper({}, { error: testError });
+        expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(testError);
     });
 
     it("disables run button when no odinRunner", () => {

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -47,6 +47,37 @@ describe("Sensitivity actions", () => {
         expect(dispatch).not.toHaveBeenCalled();
     });
 
+    it("catches and commits run sensitivity error", () => {
+        const errorRunner = {
+            batchRun: () => { throw new Error("a test error"); }
+        };
+        const modelState = {
+            odin: {},
+            odinRunner: errorRunner
+        };
+
+        const rootState = {
+            model: modelState,
+            run: mockRunState
+        };
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+
+        (actions[SensitivityAction.RunSensitivity] as any)({
+            rootState, getters, commit, dispatch
+        });
+
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetError);
+        expect(commit.mock.calls[0][1]).toStrictEqual({
+            error: "An error occurred while running sensitivity",
+            detail: "a test error"
+        });
+
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
     it("RunSensitivity does nothing if no odinRunner", () => {
         const rootState = {
             model: {

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -25,11 +25,13 @@ describe("Sensitivity mutations", () => {
 
     it("sets batch", () => {
         const state = {
-            batch: null
+            batch: null,
+            error: { error: "TEST ERROR", detail: "test detail" }
         } as any;
         const batch = { solutions: [] } as any;
         mutations[SensitivityMutation.SetBatch](state, batch);
         expect(state.batch).toBe(batch);
+        expect(state.error).toBe(null);
     });
 
     it("sets update required", () => {
@@ -62,5 +64,12 @@ describe("Sensitivity mutations", () => {
         const state = { plotSettings } as any;
         mutations[SensitivityMutation.SetPlotTime](state, 50);
         expect(state.plotSettings.time).toBe(50);
+    });
+
+    it("sets error", () => {
+        const state = { error: null } as any;
+        const error = { error: "TEST ERROR", detail: "test error detail" };
+        mutations[SensitivityMutation.SetError](state, error);
+        expect(state.error).toBe(error);
     });
 });


### PR DESCRIPTION
This branch catches any error which occurs when running sensitivity (`batchRun`) and displays it in `SensitivityTab`. The error is cleared on the next successful sensitivity run. 

You can force an error to be throwin in the day2 app, by editing Sensitivity Options to use VariationType: Range, and From: 0 with any positive value for To. 