### PR TITLE
mrc-3524 Endpoint to save session state

### DIFF
--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from "express";
+import {AppLocals} from "../types";
+import {SessionStore} from "../db/sessionStore";
+
+export class SessionsController {
+    static postSession = async (req: Request, res: Response) => {
+        console.log("posting session")
+        const { redis, wodinConfig } = req.app.locals as AppLocals;
+        const { appName, id } = req.params;
+        const store = new SessionStore(redis, wodinConfig.courseTitle, appName);
+        console.log("created store")
+        await store.saveSession(id, req.body);
+        console.log("saved session")
+        res.end();
+    };
+}

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -6,8 +6,8 @@ export class SessionsController {
     static postSession = async (req: Request, res: Response) => {
         const { redis, wodinConfig } = req.app.locals as AppLocals;
         const { appName, id } = req.params;
-        const store = new SessionStore(redis, wodinConfig.courseTitle, appName);
-        await store.saveSession(id, req.body);
+        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        await store.saveSession(id, req.body as string);
         res.end();
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -4,13 +4,10 @@ import {SessionStore} from "../db/sessionStore";
 
 export class SessionsController {
     static postSession = async (req: Request, res: Response) => {
-        console.log("posting session")
         const { redis, wodinConfig } = req.app.locals as AppLocals;
         const { appName, id } = req.params;
         const store = new SessionStore(redis, wodinConfig.courseTitle, appName);
-        console.log("created store")
         await store.saveSession(id, req.body);
-        console.log("saved session")
         res.end();
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
-import {AppLocals} from "../types";
-import {SessionStore} from "../db/sessionStore";
+import { AppLocals } from "../types";
+import { SessionStore } from "../db/sessionStore";
 
 export class SessionsController {
     static postSession = async (req: Request, res: Response) => {

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -5,17 +5,17 @@ export class SessionStore {
 
     private readonly _sessionPrefix: string;
 
-    constructor(redis: Redis, course: string, app: string) {
+    constructor(redis: Redis, savePrefix: string, app: string) {
         this._redis = redis;
-        this._sessionPrefix = `${course}:${app}:sessions:`;
+        this._sessionPrefix = `${savePrefix}:${app}:sessions:`;
     }
 
     private sessionKey = (name: string) => `${this._sessionPrefix}${name}`;
 
-    async saveSession(id: string, data: any) {
+    async saveSession(id: string, data: string) {
         await this._redis.pipeline()
             .hset(this.sessionKey("time"), id, new Date(Date.now()).toISOString())
-            .hset(this.sessionKey("data"), id, JSON.stringify(data))
+            .hset(this.sessionKey("data"), id, data)
             .exec();
     }
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -13,8 +13,6 @@ export class SessionStore {
     private sessionKey = (name: string) => `${this._sessionPrefix}${name}`;
 
     async saveSession(id: string, data: any) {
-        console.log(`posting data to key: ${this.sessionKey("data")}`);
-        console.log(`posting data: ${JSON.stringify(data)}`);
         await this._redis.pipeline()
             .hset(this.sessionKey("time"), id, new Date().toISOString())
             .hset(this.sessionKey("data"), id, JSON.stringify(data))

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -14,7 +14,7 @@ export class SessionStore {
 
     async saveSession(id: string, data: any) {
         await this._redis.pipeline()
-            .hset(this.sessionKey("time"), id, new Date().toISOString())
+            .hset(this.sessionKey("time"), id, new Date(Date.now()).toISOString())
             .hset(this.sessionKey("data"), id, JSON.stringify(data))
             .exec();
     }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -1,0 +1,23 @@
+import Redis from "ioredis";
+
+export class SessionStore {
+    private readonly _redis: Redis;
+
+    private readonly _sessionPrefix: string;
+
+    constructor(redis: Redis, course: string, app: string) {
+        this._redis = redis;
+        this._sessionPrefix = `${course}:${app}:sessions:`;
+    }
+
+    private sessionKey = (name: string) => `${this._sessionPrefix}${name}`;
+
+    async saveSession(id: string, data: any) {
+        console.log(`posting data to key: ${this.sessionKey("data")}`);
+        console.log(`posting data: ${JSON.stringify(data)}`);
+        await this._redis.pipeline()
+            .hset(this.sessionKey("time"), id, new Date().toISOString())
+            .hset(this.sessionKey("data"), id, JSON.stringify(data))
+            .exec();
+    }
+}

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -2,8 +2,11 @@ import { AppsController } from "../controllers/appsController";
 import { SessionsController } from "../controllers/sessionsController";
 
 const router = require("express").Router();
+const bodyParser = require("body-parser");
 
 router.get("/:appName", AppsController.getApp);
-router.post("/:appName/sessions/:id", SessionsController.postSession);
+
+// Parse the posted JSON as text since all we are going to do with it is to save it to redis
+router.post("/:appName/sessions/:id", bodyParser.text({ type: "application/json" }), SessionsController.postSession);
 
 export default router;

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -1,5 +1,5 @@
 import { AppsController } from "../controllers/appsController";
-import {SessionsController} from "../controllers/sessionsController";
+import { SessionsController } from "../controllers/sessionsController";
 
 const router = require("express").Router();
 

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -1,7 +1,9 @@
 import { AppsController } from "../controllers/appsController";
+import {SessionsController} from "../controllers/sessionsController";
 
 const router = require("express").Router();
 
 router.get("/:appName", AppsController.getApp);
+router.post("/:appName/sessions/:id", SessionsController.postSession);
 
 export default router;

--- a/app/server/src/routes/odin.ts
+++ b/app/server/src/routes/odin.ts
@@ -1,8 +1,9 @@
 import { OdinController } from "../controllers/odinController";
 
 const router = require("express").Router();
+const bodyParser = require("body-parser");
 
 router.get("/runner", OdinController.getRunner);
-router.post("/model", OdinController.postModel);
+router.post("/model", bodyParser.json(), OdinController.postModel);
 
 export default router;

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -11,10 +11,8 @@ import { redisConnection } from "../redis";
 
 const express = require("express");
 const path = require("path");
-const bodyParser = require("body-parser");
 
 const app = express();
-app.use(bodyParser.json());
 initialiseLogging(app);
 
 const rootDir = path.join(__dirname, "../..");

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -1,5 +1,6 @@
 import { ConfigReader } from "./configReader";
 import { DefaultCodeReader } from "./defaultCodeReader";
+import Redis from "ioredis";
 
 export interface WodinConfig {
     courseTitle: string,
@@ -22,5 +23,6 @@ export interface AppLocals {
     configReader: ConfigReader,
     defaultCodeReader: DefaultCodeReader,
     wodinConfig: WodinConfig,
-    wodinVersion: String
+    wodinVersion: String,
+    redis: Redis
 }

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -4,6 +4,7 @@ import { DefaultCodeReader } from "./defaultCodeReader";
 
 export interface WodinConfig {
     courseTitle: string,
+    savePrefix: string,
     port: number,
     odinAPI: string,
     redisURL: string,

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -1,6 +1,6 @@
+import Redis from "ioredis";
 import { ConfigReader } from "./configReader";
 import { DefaultCodeReader } from "./defaultCodeReader";
-import Redis from "ioredis";
 
 export interface WodinConfig {
     courseTitle: string,

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -1,0 +1,16 @@
+import {SessionStore} from "../../src/db/sessionStore";
+import Mock = jest.Mock;
+
+jest.mock("../../src/db/sessionStore");
+
+describe("SessionsController", () => {
+    beforeEach(() => {
+        (SessionStore as Mock).mockClear();
+    });
+
+    it("can save session", () => {
+        // TODO: case sessionStore to mock above and use that in tests
+        // expect(SessionStore).toHaveBeenCalledTimes(1);  //expect store constructor
+    });
+});
+

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -1,6 +1,6 @@
 import { SessionStore } from "../../src/db/sessionStore";
 import Mock = jest.Mock;
-import {SessionsController} from "../../src/controllers/sessionsController";
+import { SessionsController } from "../../src/controllers/sessionsController";
 
 jest.mock("../../src/db/sessionStore");
 
@@ -33,7 +33,7 @@ describe("SessionsController", () => {
 
     it("can save session", () => {
         SessionsController.postSession(req, res);
-        expect(mockSessionStore).toHaveBeenCalledTimes(1);  //expect store constructor
+        expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
         expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
         expect(mockSessionStore.mock.calls[0][1]).toBe("Test Title");
         expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -12,7 +12,7 @@ describe("SessionsController", () => {
             locals: {
                 redis: {},
                 wodinConfig: {
-                    courseTitle: "Test Title"
+                    savePrefix: "testPrefix"
                 }
             }
         },
@@ -35,7 +35,7 @@ describe("SessionsController", () => {
         SessionsController.postSession(req, res);
         expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
         expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
-        expect(mockSessionStore.mock.calls[0][1]).toBe("Test Title");
+        expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
         expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
         const storeInstance = mockSessionStore.mock.instances[0];
         expect(storeInstance.saveSession).toHaveBeenCalledTimes(1);

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -1,16 +1,45 @@
-import {SessionStore} from "../../src/db/sessionStore";
+import { SessionStore } from "../../src/db/sessionStore";
 import Mock = jest.Mock;
+import {SessionsController} from "../../src/controllers/sessionsController";
 
 jest.mock("../../src/db/sessionStore");
 
 describe("SessionsController", () => {
+    const mockSessionStore = SessionStore as Mock;
+
+    const req = {
+        app: {
+            locals: {
+                redis: {},
+                wodinConfig: {
+                    courseTitle: "Test Title"
+                }
+            }
+        },
+        params: {
+            appName: "testApp",
+            id: "1234"
+        },
+        body: "testBody"
+    } as any;
+
+    const res = {
+        end: jest.fn()
+    } as any;
+
     beforeEach(() => {
-        (SessionStore as Mock).mockClear();
+        jest.clearAllMocks();
     });
 
     it("can save session", () => {
-        // TODO: case sessionStore to mock above and use that in tests
-        // expect(SessionStore).toHaveBeenCalledTimes(1);  //expect store constructor
+        SessionsController.postSession(req, res);
+        expect(mockSessionStore).toHaveBeenCalledTimes(1);  //expect store constructor
+        expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
+        expect(mockSessionStore.mock.calls[0][1]).toBe("Test Title");
+        expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
+        const storeInstance = mockSessionStore.mock.instances[0];
+        expect(storeInstance.saveSession).toHaveBeenCalledTimes(1);
+        expect(storeInstance.saveSession.mock.calls[0][0]).toBe("1234");
+        expect(storeInstance.saveSession.mock.calls[0][1]).toBe("testBody");
     });
 });
-

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -1,7 +1,7 @@
-import {SessionStore} from "../../src/db/sessionStore";
+import { SessionStore } from "../../src/db/sessionStore";
 
 // Mock Date.now to return hardcoded date
-Date.now = jest.spyOn(Date, 'now').mockImplementation(() => new Date(2022, 7, 24, 17).getTime()) as any;
+Date.now = jest.spyOn(Date, "now").mockImplementation(() => new Date(2022, 7, 24, 17).getTime()) as any;
 
 describe("Sessionstore", () => {
     beforeEach(() => {
@@ -17,9 +17,8 @@ describe("Sessionstore", () => {
         pipeline: jest.fn().mockReturnValue(mockPipeline)
     } as any;
 
-
     it("can save session", async () => {
-        const data = {value: "test"};
+        const data = { value: "test" };
         const sut = new SessionStore(mockRedis, "Test Course", "testApp");
         await sut.saveSession("1234", data);
 
@@ -30,7 +29,7 @@ describe("Sessionstore", () => {
         expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-08-24T16:00:00.000Z");
         expect(mockPipeline.hset.mock.calls[1][0]).toBe("Test Course:testApp:sessions:data");
         expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
-        expect(mockPipeline.hset.mock.calls[1][2]).toBe(`{"value":"test"}`);
+        expect(mockPipeline.hset.mock.calls[1][2]).toBe("{\"value\":\"test\"}");
         expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
     });
 });

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -1,0 +1,36 @@
+import {SessionStore} from "../../src/db/sessionStore";
+
+// Mock Date.now to return hardcoded date
+Date.now = jest.spyOn(Date, 'now').mockImplementation(() => new Date(2022, 7, 24, 17).getTime()) as any;
+
+describe("Sessionstore", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const mockPipeline = {
+        exec: jest.fn()
+    } as any;
+    mockPipeline.hset = jest.fn().mockReturnValue(mockPipeline);
+
+    const mockRedis = {
+        pipeline: jest.fn().mockReturnValue(mockPipeline)
+    } as any;
+
+
+    it("can save session", async () => {
+        const data = {value: "test"};
+        const sut = new SessionStore(mockRedis, "Test Course", "testApp");
+        await sut.saveSession("1234", data);
+
+        expect(mockRedis.pipeline).toHaveBeenCalledTimes(1);
+        expect(mockPipeline.hset).toHaveBeenCalledTimes(2);
+        expect(mockPipeline.hset.mock.calls[0][0]).toBe("Test Course:testApp:sessions:time");
+        expect(mockPipeline.hset.mock.calls[0][1]).toBe("1234");
+        expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-08-24T16:00:00.000Z");
+        expect(mockPipeline.hset.mock.calls[1][0]).toBe("Test Course:testApp:sessions:data");
+        expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
+        expect(mockPipeline.hset.mock.calls[1][2]).toBe(`{"value":"test"}`);
+        expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
+    });
+});

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -1,7 +1,7 @@
 import { SessionStore } from "../../src/db/sessionStore";
 
 // Mock Date.now to return hardcoded date
-Date.now = jest.spyOn(Date, "now").mockImplementation(() => new Date(2022, 7, 24, 17).getTime()) as any;
+Date.now = jest.spyOn(Date, "now").mockImplementation(() => new Date(2022, 0, 24, 17).getTime()) as any;
 
 describe("Sessionstore", () => {
     beforeEach(() => {
@@ -26,7 +26,7 @@ describe("Sessionstore", () => {
         expect(mockPipeline.hset).toHaveBeenCalledTimes(2);
         expect(mockPipeline.hset.mock.calls[0][0]).toBe("Test Course:testApp:sessions:time");
         expect(mockPipeline.hset.mock.calls[0][1]).toBe("1234");
-        expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-08-24T16:00:00.000Z");
+        expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-01-24T17:00:00.000Z");
         expect(mockPipeline.hset.mock.calls[1][0]).toBe("Test Course:testApp:sessions:data");
         expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
         expect(mockPipeline.hset.mock.calls[1][2]).toBe("{\"value\":\"test\"}");

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -18,7 +18,7 @@ describe("Sessionstore", () => {
     } as any;
 
     it("can save session", async () => {
-        const data = { value: "test" };
+        const data = "testSession";
         const sut = new SessionStore(mockRedis, "Test Course", "testApp");
         await sut.saveSession("1234", data);
 
@@ -29,7 +29,7 @@ describe("Sessionstore", () => {
         expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-01-24T17:00:00.000Z");
         expect(mockPipeline.hset.mock.calls[1][0]).toBe("Test Course:testApp:sessions:data");
         expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
-        expect(mockPipeline.hset.mock.calls[1][2]).toBe("{\"value\":\"test\"}");
+        expect(mockPipeline.hset.mock.calls[1][2]).toBe("testSession");
         expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -1,0 +1,26 @@
+import {flushRedis, expectRedisValue, post} from "./utils";
+
+describe("Session integration", () => {
+    afterEach(() => {
+        flushRedis();
+    });
+
+    it("can post new session", async () => {
+        const data = {test: "value"};
+        const response = await post(`apps/day1/sessions/1234`, data);
+        expect(response.status).toBe(200);
+        await expectRedisValue("WODIN Example:day1:sessions:data", "1234", data);
+        // TODO: test time
+    });
+
+    it("can update session", async () => {
+        const oldData = {test: "oldValue"};
+        const url = `apps/day1/sessions/1234`;
+        await post(url, oldData);
+
+        const newData = {test: "newValue"};
+        const response = await post(url, newData);
+        expect(response.status).toBe(200);
+        await expectRedisValue("WODIN Example:day1:sessions:data", "1234", newData);
+    });
+});

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -1,4 +1,6 @@
-import {flushRedis, getRedisValue, expectRedisJSONValue, post} from "./utils";
+import {
+    flushRedis, getRedisValue, expectRedisJSONValue, post
+} from "./utils";
 
 describe("Session integration", () => {
     afterEach(() => {
@@ -9,7 +11,7 @@ describe("Session integration", () => {
     const sessionId = "1234";
 
     it("can post new session", async () => {
-        const data = {test: "value"};
+        const data = { test: "value" };
         const response = await post(`apps/day1/sessions/${sessionId}`, data);
         expect(response.status).toBe(200);
         await expectRedisJSONValue(`${redisKeyPrefix}:data`, "1234", data);
@@ -19,12 +21,12 @@ describe("Session integration", () => {
     });
 
     it("can update session", async () => {
-        const oldData = {test: "oldValue"};
-        const url = `apps/day1/sessions/1234`;
+        const oldData = { test: "oldValue" };
+        const url = "apps/day1/sessions/1234";
         await post(url, oldData);
         const oldTime = await getRedisValue("WODIN Example:day1:sessions:time", "1234");
 
-        const newData = {test: "newValue"};
+        const newData = { test: "newValue" };
         const response = await post(url, newData);
         expect(response.status).toBe(200);
         await expectRedisJSONValue("WODIN Example:day1:sessions:data", "1234", newData);

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -1,26 +1,35 @@
-import {flushRedis, expectRedisValue, post} from "./utils";
+import {flushRedis, getRedisValue, expectRedisJSONValue, post} from "./utils";
 
 describe("Session integration", () => {
     afterEach(() => {
         flushRedis();
     });
 
+    const redisKeyPrefix = "WODIN Example:day1:sessions:";
+    const sessionId = "1234";
+
     it("can post new session", async () => {
         const data = {test: "value"};
-        const response = await post(`apps/day1/sessions/1234`, data);
+        const response = await post(`apps/day1/sessions/${sessionId}`, data);
         expect(response.status).toBe(200);
-        await expectRedisValue("WODIN Example:day1:sessions:data", "1234", data);
-        // TODO: test time
+        await expectRedisJSONValue(`${redisKeyPrefix}:data`, "1234", data);
+        const time = await getRedisValue(`${redisKeyPrefix}:data`, "1234");
+        const date = Date.parse(time!);
+        expect(Date.now() - date).toBeLessThan(1000); // expect saved time to be in last second
     });
 
     it("can update session", async () => {
         const oldData = {test: "oldValue"};
         const url = `apps/day1/sessions/1234`;
         await post(url, oldData);
+        const oldTime = await getRedisValue("WODIN Example:day1:sessions:time", "1234");
 
         const newData = {test: "newValue"};
         const response = await post(url, newData);
         expect(response.status).toBe(200);
-        await expectRedisValue("WODIN Example:day1:sessions:data", "1234", newData);
+        await expectRedisJSONValue("WODIN Example:day1:sessions:data", "1234", newData);
+
+        const newTime = await getRedisValue("WODIN Example:day1:sessions:time", "1234");
+        expect(Date.parse(newTime!)).toBeGreaterThan(Date.parse(oldTime!));
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -7,7 +7,7 @@ describe("Session integration", () => {
         await flushRedis();
     });
 
-    const redisKeyPrefix = "WODIN Example:day1:sessions:";
+    const redisKeyPrefix = "example:day1:sessions:";
     const sessionId = "1234";
     const url = `apps/day1/sessions/${sessionId}`;
 

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -3,35 +3,35 @@ import {
 } from "./utils";
 
 describe("Session integration", () => {
-    afterEach(() => {
-        flushRedis();
+    afterEach(async () => {
+        await flushRedis();
     });
 
     const redisKeyPrefix = "WODIN Example:day1:sessions:";
     const sessionId = "1234";
+    const url = `apps/day1/sessions/${sessionId}`;
 
     it("can post new session", async () => {
         const data = { test: "value" };
-        const response = await post(`apps/day1/sessions/${sessionId}`, data);
+        const response = await post(url, data);
         expect(response.status).toBe(200);
-        await expectRedisJSONValue(`${redisKeyPrefix}:data`, "1234", data);
-        const time = await getRedisValue(`${redisKeyPrefix}:data`, "1234");
+        await expectRedisJSONValue(`${redisKeyPrefix}data`, sessionId, data);
+        const time = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
         const date = Date.parse(time!);
         expect(Date.now() - date).toBeLessThan(1000); // expect saved time to be in last second
     });
 
     it("can update session", async () => {
         const oldData = { test: "oldValue" };
-        const url = "apps/day1/sessions/1234";
         await post(url, oldData);
-        const oldTime = await getRedisValue("WODIN Example:day1:sessions:time", "1234");
+        const oldTime = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
 
         const newData = { test: "newValue" };
         const response = await post(url, newData);
         expect(response.status).toBe(200);
-        await expectRedisJSONValue("WODIN Example:day1:sessions:data", "1234", newData);
+        await expectRedisJSONValue(`${redisKeyPrefix}data`, sessionId, newData);
 
-        const newTime = await getRedisValue("WODIN Example:day1:sessions:time", "1234");
+        const newTime = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
         expect(Date.parse(newTime!)).toBeGreaterThan(Date.parse(oldTime!));
     });
 });

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -4,9 +4,9 @@ import Redis from "ioredis";
 const fullUrl = (url: string) => `http://localhost:3000/${url}`;
 const redisUrl = "redis://localhost:6379";
 
-export const post =  async (url: string, body: any) => {
-    const headers = {"Content-Type": "application/json"};
-    const response = await axios.post(fullUrl(url), body, {headers});
+export const post = async (url: string, body: any) => {
+    const headers = { "Content-Type": "application/json" };
+    const response = await axios.post(fullUrl(url), body, { headers });
     return response;
 };
 

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -10,14 +10,14 @@ export const post =  async (url: string, body: any) => {
     return response;
 };
 
-export const expectRedisValue = async (key: string, field: string, expectedValue: any) => {
+export const getRedisValue = async (key: string, field: string) => {
     const redis = new Redis(redisUrl);
-    const value = await redis.hget(key, field);
-    if (expectedValue === null) {
-        expect(value).toBe(null);
-    } else {
-        expect(JSON.parse(value!)).toStrictEqual(expectedValue);
-    }
+    return redis.hget(key, field);
+};
+
+export const expectRedisJSONValue = async (key: string, field: string, expectedValue: any) => {
+    const value = await getRedisValue(key, field);
+    expect(JSON.parse(value!)).toStrictEqual(expectedValue);
 };
 
 export const flushRedis = async () => {

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -12,7 +12,9 @@ export const post = async (url: string, body: any) => {
 
 export const getRedisValue = async (key: string, field: string) => {
     const redis = new Redis(redisUrl);
-    return redis.hget(key, field);
+    const value = await redis.hget(key, field);
+    redis.disconnect();
+    return value;
 };
 
 export const expectRedisJSONValue = async (key: string, field: string, expectedValue: any) => {
@@ -23,4 +25,5 @@ export const expectRedisJSONValue = async (key: string, field: string, expectedV
 export const flushRedis = async () => {
     const redis = new Redis(redisUrl);
     await redis.flushdb();
+    redis.disconnect();
 };

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+import Redis from "ioredis";
+
+const fullUrl = (url: string) => `http://localhost:3000/${url}`;
+const redisUrl = "redis://localhost:6379";
+
+export const post =  async (url: string, body: any) => {
+    const headers = {"Content-Type": "application/json"};
+    const response = await axios.post(fullUrl(url), body, {headers});
+    return response;
+};
+
+export const expectRedisValue = async (key: string, field: string, expectedValue: any) => {
+    const redis = new Redis(redisUrl);
+    const value = await redis.hget(key, field);
+    if (expectedValue === null) {
+        expect(value).toBe(null);
+    } else {
+        expect(JSON.parse(value!)).toStrictEqual(expectedValue);
+    }
+};
+
+export const flushRedis = async () => {
+    const redis = new Redis(redisUrl);
+    await redis.flushdb();
+};

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -26,7 +26,6 @@ export const getRedisValue = async (key: string, field: string) => {
 
 export const expectRedisJSONValue = async (key: string, field: string, expectedValue: any) => {
     const value = await getRedisValue(key, field);
-    console.log(`Value is: ${value}`);
     expect(JSON.parse(value!)).toStrictEqual(expectedValue);
 };
 

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -26,6 +26,7 @@ export const getRedisValue = async (key: string, field: string) => {
 
 export const expectRedisJSONValue = async (key: string, field: string, expectedValue: any) => {
     const value = await getRedisValue(key, field);
+    console.log(`Value is: ${value}`);
     expect(JSON.parse(value!)).toStrictEqual(expectedValue);
 };
 

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -6,8 +6,7 @@ const redisUrl = "redis://localhost:6379";
 
 export const post = async (url: string, body: any) => {
     const headers = { "Content-Type": "application/json" };
-    const response = await axios.post(fullUrl(url), body, { headers });
-    return response;
+    return axios.post(fullUrl(url), body, { headers });
 };
 
 const withRedis = async (func: (redis: Redis) => any) => {

--- a/app/server/tests/routes/apps.test.ts
+++ b/app/server/tests/routes/apps.test.ts
@@ -3,12 +3,15 @@ import { SessionsController } from "../../src/controllers/sessionsController";
 
 describe("odin routes", () => {
     const express = require("express");
+    const bodyParser = require("body-parser");
 
     const mockRouter = {
         get: jest.fn(),
         post: jest.fn()
     };
     const realRouter = express.Router;
+
+    const spyText = jest.spyOn(bodyParser, "text");
 
     beforeAll(() => {
         express.Router = () => mockRouter;
@@ -25,6 +28,7 @@ describe("odin routes", () => {
         expect(mockRouter.get.mock.calls[0][0]).toBe("/:appName");
         expect(mockRouter.get.mock.calls[0][1]).toBe(AppsController.getApp);
         expect(mockRouter.post.mock.calls[0][0]).toBe("/:appName/sessions/:id");
-        expect(mockRouter.post.mock.calls[0][1]).toBe(SessionsController.postSession);
+        expect(mockRouter.post.mock.calls[0][2]).toBe(SessionsController.postSession);
+        expect(spyText).toHaveBeenCalledWith({ type: "application/json" });
     });
 });

--- a/app/server/tests/routes/apps.test.ts
+++ b/app/server/tests/routes/apps.test.ts
@@ -1,10 +1,12 @@
 import { AppsController } from "../../src/controllers/appsController";
+import { SessionsController } from "../../src/controllers/sessionsController";
 
 describe("odin routes", () => {
     const express = require("express");
 
     const mockRouter = {
-        get: jest.fn()
+        get: jest.fn(),
+        post: jest.fn()
     };
     const realRouter = express.Router;
 
@@ -22,5 +24,7 @@ describe("odin routes", () => {
         expect(mockRouter.get).toBeCalledTimes(1);
         expect(mockRouter.get.mock.calls[0][0]).toBe("/:appName");
         expect(mockRouter.get.mock.calls[0][1]).toBe(AppsController.getApp);
+        expect(mockRouter.post.mock.calls[0][0]).toBe("/:appName/sessions/:id");
+        expect(mockRouter.post.mock.calls[0][1]).toBe(SessionsController.postSession);
     });
 });

--- a/app/server/tests/routes/odin.test.ts
+++ b/app/server/tests/routes/odin.test.ts
@@ -2,6 +2,7 @@ import { OdinController } from "../../src/controllers/odinController";
 
 describe("odin routes", () => {
     const express = require("express");
+    const bodyParser = require("body-parser");
 
     const mockRouter = {
         get: jest.fn(),
@@ -9,12 +10,15 @@ describe("odin routes", () => {
     };
     const realRouter = express.Router;
 
+    const spyJson = jest.spyOn(bodyParser, "json");
+
     beforeAll(() => {
         express.Router = () => mockRouter;
     });
 
     afterAll(() => {
         express.Router = realRouter;
+        jest.clearAllMocks();
     });
 
     it("registers expected routes", async () => {
@@ -25,6 +29,8 @@ describe("odin routes", () => {
         expect(mockRouter.get.mock.calls[0][1]).toBe(OdinController.getRunner);
         expect(mockRouter.post).toBeCalledTimes(1);
         expect(mockRouter.post.mock.calls[0][0]).toBe("/model");
-        expect(mockRouter.post.mock.calls[0][1]).toBe(OdinController.postModel);
+        expect(mockRouter.post.mock.calls[0][2]).toBe(OdinController.postModel);
+
+        expect(spyJson).toHaveBeenCalledTimes(1);
     });
 });

--- a/config/wodin.config.json
+++ b/config/wodin.config.json
@@ -1,5 +1,6 @@
 {
     "courseTitle": "WODIN Example",
+    "savePrefix": "example",
     "port": 3000,
     "appsPath": "apps",
     "odinAPI": "http://localhost:8001",


### PR DESCRIPTION
This branch adds an endpoint to store session data to redis. The url is `POST /:appName/sessions/:id` where `id` is a unique id for the sessions, which will be generated in the front end. Data is stored into redis at a key which includes the app name as well as the full course title (maybe course title isn't quite right though - that's intended to be human readable. It should be unique but we have no real way of enforcing that.) We also store the timestamp when session data was last updated.