### PR TITLE
Wrap odin result with its inputs

### DIFF
--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.modelFit.notFittedYet;
 
-        const solution = computed(() => store.state.modelFit.solution);
+        const solution = computed(() => store.state.modelFit.result?.result);
 
         const endTime = computed(() => store.getters[`fitData/${FitDataGetter.dataEnd}`]);
 

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.modelFit.notFittedYet;
 
-        const solution = computed(() => store.state.modelFit.result?.result);
+        const solution = computed(() => store.state.modelFit.result?.solution);
 
         const endTime = computed(() => store.getters[`fitData/${FitDataGetter.dataEnd}`]);
 

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -71,7 +71,7 @@ export default defineComponent({
         const timestampParamNames = () => paramNames.value.map((name: string) => name + Date.now());
 
         const paramKeys = ref(timestampParamNames());
-        const odinSolution = computed(() => store.state.run.result?.result);
+        const odinSolution = computed(() => store.state.run.result?.solution);
 
         const updateValue = (newValue: number, paramName: string) => {
             store.commit(`run/${RunMutation.UpdateParameterValues}`, { [paramName]: newValue });

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -71,7 +71,7 @@ export default defineComponent({
         const timestampParamNames = () => paramNames.value.map((name: string) => name + Date.now());
 
         const paramKeys = ref(timestampParamNames());
-        const odinSolution = computed(() => store.state.run.solution);
+        const odinSolution = computed(() => store.state.run.result?.result);
 
         const updateValue = (newValue: number, paramName: string) => {
             store.commit(`run/${RunMutation.UpdateParameterValues}`, { [paramName]: newValue });

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -29,7 +29,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.run.notRunYet;
 
-        const solution = computed(() => (store.state.run.solution));
+        const solution = computed(() => (store.state.run.result?.result));
 
         const endTime = computed(() => store.state.run.endTime);
 

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -29,7 +29,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.run.notRunYet;
 
-        const solution = computed(() => (store.state.run.result?.result));
+        const solution = computed(() => (store.state.run.result?.solution));
 
         const endTime = computed(() => store.state.run.endTime);
 

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -28,7 +28,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
 
-        const error = computed(() => store.state.run.error);
+        const error = computed(() => store.state.run.result?.error);
 
         // Enable run button if model has initialised and compile is not required
         const canRunModel = computed(() => !!store.state.model.odinRunner && !!store.state.model.odin

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -36,7 +36,7 @@ export default defineComponent({
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const batch = computed(() => store.state.sensitivity.result.result);
+        const batch = computed(() => store.state.sensitivity.result.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
 

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -36,7 +36,7 @@ export default defineComponent({
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const batch = computed(() => store.state.sensitivity.batch);
+        const batch = computed(() => store.state.sensitivity.result.result);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
 

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 
         const sensitivityUpdateRequired = computed(() => store.state.sensitivity.sensitivityUpdateRequired);
         const updateMsg = computed(() => {
-            if (store.state.sensitivity.batch?.solutions.length) {
+            if (store.state.sensitivity.result?.result?.solutions.length) {
                 if (store.state.model.compileRequired) {
                     return userMessages.sensitivity.compileRequiredForUpdate;
                 }
@@ -62,7 +62,7 @@ export default defineComponent({
             () => store.state.sensitivity.plotSettings.plotType === SensitivityPlotType.TraceOverTime
         );
 
-        const error = computed(() => store.state.sensitivity.error);
+        const error = computed(() => store.state.sensitivity.result?.error);
 
         return {
             canRunSensitivity,

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -47,7 +47,7 @@ export default defineComponent({
 
         const sensitivityUpdateRequired = computed(() => store.state.sensitivity.sensitivityUpdateRequired);
         const updateMsg = computed(() => {
-            if (store.state.sensitivity.result?.result?.solutions.length) {
+            if (store.state.sensitivity.result?.batch?.solutions.length) {
                 if (store.state.model.compileRequired) {
                     return userMessages.sensitivity.compileRequiredForUpdate;
                 }

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -33,7 +33,7 @@ export default defineComponent({
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
         const solutions = computed(() => (store.state.sensitivity.batch?.solutions || []));
-        const centralSolution = computed(() => (store.state.run.solution));
+        const centralSolution = computed(() => (store.state.run.result?.result));
 
         const endTime = computed(() => store.state.run.endTime);
 

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const solutions = computed(() => (store.state.sensitivity.result?.result?.solutions || []);
+        const solutions = computed(() => (store.state.sensitivity.result?.result?.solutions || []));
         const centralSolution = computed(() => (store.state.run.result?.result));
 
         const endTime = computed(() => store.state.run.endTime);

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const result: Partial<PlotData>[] = [];
             if (solutions.value.length) {
-                const pars = store.state.sensitivity.result!.result!.pars;
+                const { pars } = store.state.sensitivity.result!.result!;
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
                     const data = sln(start, end, points);
                     const plotlyOptions = {

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const solutions = computed(() => (store.state.sensitivity.batch?.solutions || []));
+        const solutions = computed(() => (store.state.sensitivity.result?.result?.solutions || []);
         const centralSolution = computed(() => (store.state.run.result?.result));
 
         const endTime = computed(() => store.state.run.endTime);
@@ -45,10 +45,9 @@ export default defineComponent({
         };
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
-            const { batch } = store.state.sensitivity;
-
             const result: Partial<PlotData>[] = [];
             if (solutions.value.length) {
+                const pars = store.state.sensitivity.result!.result!.pars;
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
                     const data = sln(start, end, points);
                     const plotlyOptions = {
@@ -59,8 +58,8 @@ export default defineComponent({
                     if (data) {
                         const plotData = odinToPlotly(data, palette.value, plotlyOptions);
                         plotData.forEach((plotTrace) => {
-                            updatePlotTraceNameWithParameterValue(plotTrace, batch.pars.name,
-                                batch.pars.values[slnIdx]);
+                            updatePlotTraceNameWithParameterValue(plotTrace, pars.name,
+                                pars.values[slnIdx]);
                         });
 
                         result.push(...plotData);

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -32,8 +32,8 @@ export default defineComponent({
 
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const solutions = computed(() => (store.state.sensitivity.result?.result?.solutions || []));
-        const centralSolution = computed(() => (store.state.run.result?.result));
+        const solutions = computed(() => (store.state.sensitivity.result?.batch?.solutions || []));
+        const centralSolution = computed(() => (store.state.run.result?.solution));
 
         const endTime = computed(() => store.state.run.endTime);
 
@@ -47,7 +47,7 @@ export default defineComponent({
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const result: Partial<PlotData>[] = [];
             if (solutions.value.length) {
-                const { pars } = store.state.sensitivity.result!.result!;
+                const { pars } = store.state.sensitivity.result!.batch!;
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
                     const data = sln(start, end, points);
                     const plotlyOptions = {

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -42,7 +42,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             const inputs = {
                 data,
                 endTime,
-                link,
+                link
             };
 
             commit(ModelFitMutation.SetFitUpdateRequired, false);

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -10,6 +10,7 @@ export const defaultState: ModelFitState = {
     converged: null,
     sumOfSquares: null,
     paramsToVary: [],
+    inputs: null,
     result: null
 };
 

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -9,8 +9,8 @@ export const defaultState: ModelFitState = {
     iterations: null,
     converged: null,
     sumOfSquares: null,
-    solution: null,
-    paramsToVary: []
+    paramsToVary: [],
+    result: null
 };
 
 export const modelFit = {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -18,7 +18,13 @@ export const mutations: MutationTree<ModelFitState> = {
         state.converged = payload.converged;
         state.iterations = payload.iterations;
         state.sumOfSquares = payload.value;
-        state.solution = payload.data.solution;
+        state.result = {
+            inputs: {
+                endTime: payload.data.endTime, parameterValues: payload.data.pars
+            },
+            result: payload.data.solution,
+            error: null
+        };
     },
 
     [ModelFitMutation.SetParamsToVary](state: ModelFitState, payload: string[]) {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -25,7 +25,7 @@ export const mutations: MutationTree<ModelFitState> = {
         };
         state.result = {
             inputs,
-            result: payload.data.solution,
+            solution: payload.data.solution,
             error: null
         };
     },

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -1,10 +1,11 @@
 import { MutationTree } from "vuex";
-import { ModelFitState } from "./state";
+import { ModelFitInputs, ModelFitState } from "./state";
 import { SimplexResult } from "../../types/responseTypes";
 
 export enum ModelFitMutation {
     SetFitting = "SetFitting",
     SetResult = "SetResult",
+    SetInputs = "SetInputs",
     SetParamsToVary = "SetParamsToVary",
     SetFitUpdateRequired = "SetFitUpdateRequired"
 }
@@ -18,13 +19,19 @@ export const mutations: MutationTree<ModelFitState> = {
         state.converged = payload.converged;
         state.iterations = payload.iterations;
         state.sumOfSquares = payload.value;
+        const inputs = {
+            ...state.inputs!,
+            parameterValues: payload.data.pars
+        };
         state.result = {
-            inputs: {
-                endTime: payload.data.endTime, parameterValues: payload.data.pars
-            },
+            inputs,
             result: payload.data.solution,
             error: null
         };
+    },
+
+    [ModelFitMutation.SetInputs](state: ModelFitState, payload: ModelFitInputs) {
+        state.inputs = payload;
     },
 
     [ModelFitMutation.SetParamsToVary](state: ModelFitState, payload: string[]) {

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -1,5 +1,4 @@
-import { OdinSolution } from "../../types/responseTypes";
-import { OdinRunResult } from "../../types/wrapperTypes";
+import { OdinFitResult } from "../../types/wrapperTypes";
 import type { FitData, FitDataLink } from "../fitData/state";
 
 export interface ModelFitInputs {

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -1,4 +1,5 @@
 import { OdinSolution } from "../../types/responseTypes";
+import { OdinRunResult } from "../../types/wrapperTypes";
 
 export interface ModelFitState {
     fitting: boolean,
@@ -6,6 +7,6 @@ export interface ModelFitState {
     iterations: number | null,
     converged: boolean | null,
     sumOfSquares: number | null,
-    solution: OdinSolution | null, // full solution for current best fit
-    paramsToVary: string[]
+    paramsToVary: string[],
+    result: OdinRunResult | null, // full solution for current best fit
 }

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -1,5 +1,12 @@
 import { OdinSolution } from "../../types/responseTypes";
 import { OdinRunResult } from "../../types/wrapperTypes";
+import type { FitData, FitDataLink } from "../fitData/state";
+
+export interface ModelFitInputs {
+    data: FitData;
+    endTime: number;
+    link: FitDataLink;
+}
 
 export interface ModelFitState {
     fitting: boolean,
@@ -8,5 +15,6 @@ export interface ModelFitState {
     converged: boolean | null,
     sumOfSquares: number | null,
     paramsToVary: string[],
-    result: OdinRunResult | null, // full solution for current best fit
+    inputs: ModelFitInputs | null, // all inputs except parameters, which vary
+    result: OdinFitResult | null, // full solution for current best fit,
 }

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -28,7 +28,7 @@ export const actions: ActionTree<RunState, AppState> = {
             } catch (e) {
                 payload.error = {
                     error: userMessages.errors.wodinRunError,
-                    detail: e as string
+                    detail: (e as Error).message
                 };
             }
             commit(RunMutation.SetResult, payload);

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -3,6 +3,7 @@ import { RunState } from "./state";
 import { RunMutation } from "./mutations";
 import { AppState } from "../appState/state";
 import userMessages from "../../userMessages";
+import type { OdinRunResult } from "../../types/wrapperTypes";
 
 export enum RunAction {
     RunModel = "RunModel"
@@ -11,17 +12,25 @@ export enum RunAction {
 export const actions: ActionTree<RunState, AppState> = {
     RunModel(context) {
         const { rootState, state, commit } = context;
-        const parameters = state.parameterValues;
-        if (rootState.model.odinRunner && rootState.model.odin && parameters) {
-            const start = 0;
-            const end = state.endTime;
+        const parameterValues = state.parameterValues;
+        if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
+            const startTime = 0;
+            const endTime = state.endTime;
+            const payload : OdinRunResult = {
+                inputs: { endTime, parameterValues },
+                result: null,
+                error: null
+            };
             try {
-                const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameters, start, end, {});
-                commit(RunMutation.SetSolution, solution);
+                const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues, startTime, endTime, {});
+                payload.result = solution;
             } catch (e) {
-                const wodinRunError = { error: userMessages.errors.wodinRunError, detail: e };
-                commit(RunMutation.SetError, wodinRunError);
+                payload.error = {
+                    error: userMessages.errors.wodinRunError,
+                    detail: e
+                };
             }
+            commit(RunMutation.SetResult, payload);
 
             if (state.runRequired) {
                 commit(RunMutation.SetRunRequired, false);

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -27,7 +27,7 @@ export const actions: ActionTree<RunState, AppState> = {
             } catch (e) {
                 payload.error = {
                     error: userMessages.errors.wodinRunError,
-                    detail: e
+                    detail: e as string
                 };
             }
             commit(RunMutation.SetResult, payload);

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -12,17 +12,18 @@ export enum RunAction {
 export const actions: ActionTree<RunState, AppState> = {
     RunModel(context) {
         const { rootState, state, commit } = context;
-        const parameterValues = state.parameterValues;
+        const { parameterValues } = state;
         if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
             const startTime = 0;
-            const endTime = state.endTime;
+            const { endTime } = state;
             const payload : OdinRunResult = {
                 inputs: { endTime, parameterValues },
                 result: null,
                 error: null
             };
             try {
-                const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues, startTime, endTime, {});
+                const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
+                    startTime, endTime, {});
                 payload.result = solution;
             } catch (e) {
                 payload.error = {

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -18,13 +18,13 @@ export const actions: ActionTree<RunState, AppState> = {
             const { endTime } = state;
             const payload : OdinRunResult = {
                 inputs: { endTime, parameterValues },
-                result: null,
+                solution: null,
                 error: null
             };
             try {
                 const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
                     startTime, endTime, {});
-                payload.result = solution;
+                payload.solution = solution;
             } catch (e) {
                 payload.error = {
                     error: userMessages.errors.wodinRunError,

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -36,5 +36,5 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.SetEndTime](state: RunState, payload: number) {
         state.endTime = payload;
         state.runRequired = true;
-    },
+    }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -1,21 +1,19 @@
 import { MutationTree } from "vuex";
 import { RunState } from "./state";
-import { OdinSolution, WodinError } from "../../types/responseTypes";
+import { OdinRunResult } from "../../types/wrapperTypes";
 import { Dict } from "../../types/utilTypes";
 
 export enum RunMutation {
     SetRunRequired = "SetRunRequired",
-    SetSolution = "SetSolution",
+    SetResult = "SetResult",
     SetParameterValues = "SetParameterValues",
     UpdateParameterValues = "UpdateParameterValues",
-    SetEndTime = "SetEndTime",
-    SetError = "SetError"
+    SetEndTime = "SetEndTime"
 }
 
 export const mutations: MutationTree<RunState> = {
-    [RunMutation.SetSolution](state: RunState, payload: OdinSolution) {
-        state.solution = payload;
-        state.error = null;
+    [RunMutation.SetResult](state: RunState, payload: OdinRunResult) {
+        state.result = payload;
     },
 
     [RunMutation.SetRunRequired](state: RunState, payload: boolean) {
@@ -39,8 +37,4 @@ export const mutations: MutationTree<RunState> = {
         state.endTime = payload;
         state.runRequired = true;
     },
-
-    [RunMutation.SetError](state: RunState, payload: WodinError) {
-        state.error = payload;
-    }
 };

--- a/app/static/src/app/store/run/run.ts
+++ b/app/static/src/app/store/run/run.ts
@@ -4,10 +4,9 @@ import { actions } from "./actions";
 
 export const defaultState: RunState = {
     runRequired: false,
-    solution: null,
     parameterValues: null,
     endTime: 100,
-    error: null
+    result: null
 };
 
 export const run = {

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -10,6 +10,4 @@ export interface RunState {
     endTime: number;
     // The result of running the model, along with its inputs
     result: OdinRunResult | null;
-    // solution: null | OdinSolution
-    // error: WodinError | null
 }

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -1,4 +1,3 @@
-import { OdinSolution, WodinError } from "../../types/responseTypes";
 import { OdinRunResult } from "../../types/wrapperTypes";
 
 export interface RunState {

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -1,9 +1,15 @@
 import { OdinSolution, WodinError } from "../../types/responseTypes";
+import { OdinRunResult } from "../../types/wrapperTypes";
 
 export interface RunState {
-    runRequired: boolean
-    solution: null | OdinSolution
-    parameterValues: null | Map<string, number>
-    endTime: number,
-    error: WodinError | null
+    // Set to true if the stored solution at `result` is out of date
+    runRequired: boolean;
+    // Parameter values to pass into the next solution
+    parameterValues: null | Map<string, number>;
+    // End time for the next solution
+    endTime: number;
+    // The result of running the model, along with its inputs
+    result: OdinRunResult | null;
+    // solution: null | OdinSolution
+    // error: WodinError | null
 }

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -5,6 +5,7 @@ import { SensitivityGetter } from "./getters";
 import { SensitivityMutation } from "./mutations";
 import { RunAction } from "../run/actions";
 import userMessages from "../../userMessages";
+import { OdinSensitivityResult } from "../../types/wrapperTypes";
 
 export enum SensitivityAction {
     RunSensitivity = "RunSensitivity"
@@ -20,18 +21,27 @@ export const actions: ActionTree<SensitivityState, AppState> = {
         const batchPars = getters[SensitivityGetter.batchPars];
 
         if (odinRunner && odin && batchPars) {
+            const payload : OdinSensitivityResult = {
+                inputs: { endTime, pars: batchPars },
+                result: null,
+                error: null
+            };
             try {
                 const batch = odinRunner.batchRun(odin, batchPars, 0, endTime, {});
-                commit(SensitivityMutation.SetBatch, batch);
+                payload.result = batch;
+            } catch (e: unknown) {
+                payload.error = {
+                    error: userMessages.errors.wodinSensitivityError,
+                    detail: (e as Error).message
+                };
+            }
+            commit(SensitivityMutation.SetResult, payload);
+            if (payload.result !== null) {
                 commit(SensitivityMutation.SetUpdateRequired, false);
-
                 // Also re-run model if required so that plotted central traces are correct
                 if (rootState.run.runRequired) {
                     dispatch(`run/${RunAction.RunModel}`, null, { root: true });
                 }
-            } catch (e: unknown) {
-                const wodinError = { error: userMessages.errors.wodinSensitivityError, detail: (e as Error).message };
-                commit(SensitivityMutation.SetError, wodinError);
             }
         }
     }

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -23,12 +23,12 @@ export const actions: ActionTree<SensitivityState, AppState> = {
         if (odinRunner && odin && batchPars) {
             const payload : OdinSensitivityResult = {
                 inputs: { endTime, pars: batchPars },
-                result: null,
+                batch: null,
                 error: null
             };
             try {
                 const batch = odinRunner.batchRun(odin, batchPars, 0, endTime, {});
-                payload.result = batch;
+                payload.batch = batch;
             } catch (e: unknown) {
                 payload.error = {
                     error: userMessages.errors.wodinSensitivityError,
@@ -36,7 +36,7 @@ export const actions: ActionTree<SensitivityState, AppState> = {
                 };
             }
             commit(SensitivityMutation.SetResult, payload);
-            if (payload.result !== null) {
+            if (payload.batch !== null) {
                 commit(SensitivityMutation.SetUpdateRequired, false);
                 // Also re-run model if required so that plotted central traces are correct
                 if (rootState.run.runRequired) {

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -2,17 +2,16 @@ import { MutationTree } from "vuex";
 import {
     SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState
 } from "./state";
-import { Batch, WodinError } from "../../types/responseTypes";
+import { OdinSensitivityResult } from "../../types/wrapperTypes";
 
 export enum SensitivityMutation {
     SetParameterToVary = "SetParameterToVary",
     SetParamSettings = "SetParamSettings",
-    SetBatch = "SetBatch",
+    SetResult = "SetResult",
     SetUpdateRequired = "SetUpdateRequired",
     SetPlotType = "SetPlotType",
     SetPlotExtreme = "SetPlotExtreme",
     SetPlotTime = "SetPlotTime",
-    SetError = "SetError"
 }
 
 export const mutations: MutationTree<SensitivityState> = {
@@ -26,9 +25,8 @@ export const mutations: MutationTree<SensitivityState> = {
         state.sensitivityUpdateRequired = true;
     },
 
-    [SensitivityMutation.SetBatch](state: SensitivityState, payload: Batch) {
-        state.batch = payload;
-        state.error = null;
+    [SensitivityMutation.SetResult](state: SensitivityState, payload: OdinSensitivityResult) {
+        state.result = payload;
     },
 
     [SensitivityMutation.SetUpdateRequired](state: SensitivityState, payload: boolean) {
@@ -45,9 +43,5 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.SetPlotTime](state: SensitivityState, payload: number) {
         state.plotSettings.time = payload;
-    },
-
-    [SensitivityMutation.SetError](state: SensitivityState, payload: WodinError) {
-        state.error = payload;
     }
 };

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -24,9 +24,8 @@ export const defaultState: SensitivityState = {
         extreme: SensitivityPlotExtreme.Max,
         time: null
     },
-    batch: null,
     sensitivityUpdateRequired: false,
-    error: null
+    result: null
 };
 
 export const sensitivity = {

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -1,4 +1,4 @@
-import { Batch, WodinError } from "../../types/responseTypes";
+import { OdinSensitivityResult } from "../../types/wrapperTypes";
 
 export enum SensitivityScaleType {
     Arithmetic = "Arithmetic",
@@ -40,9 +40,8 @@ export interface SensitivityPlotSettings {
 
 export interface SensitivityState {
     paramSettings: SensitivityParameterSettings,
-    batch: Batch | null,
     // Whether sensitivity needs to be re-run because of change to settings or model
     sensitivityUpdateRequired: boolean
     plotSettings: SensitivityPlotSettings,
-    error: WodinError | null
+    result: OdinSensitivityResult | null;
 }

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -90,6 +90,7 @@ export interface SimplexResult {
     converged: boolean;
     value: number;
     data: {
+        endTime: number,
         names: string[],
         solution: OdinSolution,
         pars: Map<string, number>

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -1,0 +1,12 @@
+import { OdinSolution, WodinError } from "./responseTypes";
+
+export interface OdinRunResultInputs {
+    parameterValues: Map<string, number>;
+    endTime: number;
+}
+
+export interface OdinRunResult {
+    inputs: OdinRunResultInputs;
+    result: OdinSolution | null;
+    error: WodinErrr | null;
+}

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -5,18 +5,18 @@ import {
     WodinError
 } from "./responseTypes";
 
-export interface OdinRunResultInputs {
+export interface OdinRunInputs {
     parameterValues: Map<string, number>;
     endTime: number;
 }
 
 export interface OdinRunResult {
-    inputs: OdinRunResultInputs;
+    inputs: OdinRunInputs;
     result: OdinSolution | null;
     error: WodinError | null;
 }
 
-export interface OdinFitResultInputs {
+export interface OdinFitInputs {
     parameterValues: Map<string, number>;
     endTime: number;
     data: FitData;
@@ -24,7 +24,7 @@ export interface OdinFitResultInputs {
 }
 
 export interface OdinFitResult {
-    inputs: OdinFitResultInputs;
+    inputs: OdinFitInputs;
     result: OdinSolution | null;
     error: WodinError | null;
 }

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -8,9 +8,7 @@ export interface OdinRunResultInputs {
 export interface OdinRunResult {
     inputs: OdinRunResultInputs;
     result: OdinSolution | null;
-    // TODO: Fixing this typo causes a different error to appear on
-    // compilation (WodinErrr -> WodinError)
-    error: WodinErrr | null;
+    error: WodinError | null;
 }
 
 export interface OdinFitResultInputs {

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -12,7 +12,7 @@ export interface OdinRunInputs {
 
 export interface OdinRunResult {
     inputs: OdinRunInputs;
-    result: OdinSolution | null;
+    solution: OdinSolution | null;
     error: WodinError | null;
 }
 
@@ -25,7 +25,7 @@ export interface OdinFitInputs {
 
 export interface OdinFitResult {
     inputs: OdinFitInputs;
-    result: OdinSolution | null;
+    solution: OdinSolution | null;
     error: WodinError | null;
 }
 
@@ -36,6 +36,6 @@ export interface OdinSensitivityInputs {
 
 export interface OdinSensitivityResult {
     inputs: OdinSensitivityInputs;
-    result: Batch | null;
+    batch: Batch | null;
     error: WodinError | null;
 }

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -8,5 +8,20 @@ export interface OdinRunResultInputs {
 export interface OdinRunResult {
     inputs: OdinRunResultInputs;
     result: OdinSolution | null;
+    // TODO: Fixing this typo causes a different error to appear on
+    // compilation (WodinErrr -> WodinError)
     error: WodinErrr | null;
+}
+
+export interface OdinFitResultInputs {
+    parameterValues: Map<string, number>;
+    endTime: number;
+    data: FitData;
+    link: FitDataLink;
+}
+
+export interface OdinFitResult {
+    inputs: OdinFitResultInputs;
+    result: OdinSolution | null;
+    error: WodinError | null;
 }

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -1,4 +1,9 @@
-import { OdinSolution, WodinError } from "./responseTypes";
+import {
+    Batch,
+    BatchPars,
+    OdinSolution,
+    WodinError
+} from "./responseTypes";
 
 export interface OdinRunResultInputs {
     parameterValues: Map<string, number>;
@@ -21,5 +26,16 @@ export interface OdinFitResultInputs {
 export interface OdinFitResult {
     inputs: OdinFitResultInputs;
     result: OdinSolution | null;
+    error: WodinError | null;
+}
+
+export interface OdinSensitivityInputs {
+    endTime: number;
+    pars: BatchPars;
+}
+
+export interface OdinSensitivityResult {
+    inputs: OdinSensitivityInputs;
+    result: Batch | null;
     error: WodinError | null;
 }

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -154,6 +154,6 @@ test.describe("Code Tab tests", () => {
         await runBtn.click();
 
         await expect(await page.innerText(".run-tab #error-info"))
-            .toBe("An error occurred while running the model: Error: Integration failure: too many steps at 0");
+            .toBe("An error occurred while running the model: Integration failure: too many steps at 0");
     });
 });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -105,9 +105,8 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
             extreme: SensitivityPlotExtreme.Max,
             time: null
         },
-        batch: null,
         sensitivityUpdateRequired: false,
-        error: null,
+        result: null,
         ...state
     };
 };

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -136,8 +136,9 @@ export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitS
         iterations: null,
         converged: null,
         sumOfSquares: null,
-        solution: null,
         paramsToVary: [],
+        inputs: null,
+        result: null,
         ...state
     };
 };

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -62,10 +62,9 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
 export const mockRunState = (state: Partial<RunState> = {}): RunState => {
     return {
         runRequired: false,
-        solution: null,
         parameterValues: null,
         endTime: 100,
-        error: null,
+        result: null,
         ...state
     };
 };

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -56,7 +56,7 @@ describe("FitPlot", () => {
                 },
                 modelFit: {
                     result: {
-                        result: modelFitHasSolution ? mockSolution : null
+                        solution: modelFitHasSolution ? mockSolution : null
                     }
                 }
             } as any,

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -55,7 +55,9 @@ describe("FitPlot", () => {
                     paletteModel: mockPalette
                 },
                 modelFit: {
-                    solution: modelFitHasSolution ? mockSolution : null
+                    result: {
+                        result: modelFitHasSolution ? mockSolution : null
+                    }
                 }
             } as any,
             modules: {

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -131,7 +131,7 @@ describe("ParameterValues", () => {
         });
         wrapper.findAll("input").at(1)!.setValue("");
 
-        store.commit(`run/${RunMutation.SetResult}`, { result: {} });
+        store.commit(`run/${RunMutation.SetResult}`, { solution: {} });
         await nextTick();
         expect(wrapper.findAllComponents(NumericInput).at(1)!.props("value")).toBe(2.2);
         expect((wrapper.findAll("input").at(1)!.element as HTMLInputElement).value).toBe("2.2");

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -131,7 +131,7 @@ describe("ParameterValues", () => {
         });
         wrapper.findAll("input").at(1)!.setValue("");
 
-        store.commit(`run/${RunMutation.SetSolution}`, {});
+        store.commit(`run/${RunMutation.SetResult}`, { result: {} });
         await nextTick();
         expect(wrapper.findAllComponents(NumericInput).at(1)!.props("value")).toBe(2.2);
         expect((wrapper.findAll("input").at(1)!.element as HTMLInputElement).value).toBe("2.2");

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -16,7 +16,7 @@ describe("RunPlot", () => {
     });
     const mockResult = {
         inputs: {},
-        result: mockSolution,
+        solution: mockSolution,
         error: null
     };
 

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -14,6 +14,11 @@ describe("RunPlot", () => {
         x: [0, 1],
         y: [[3, 4], [5, 6]]
     });
+    const mockResult = {
+        inputs: {},
+        result: mockSolution,
+        error: null
+    };
 
     const paletteModel = {
         S: "#ff0000",
@@ -33,7 +38,7 @@ describe("RunPlot", () => {
                 },
                 run: {
                     endTime: 99,
-                    solution: mockSolution
+                    result: mockResult
                 }
             } as any
         });

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -108,7 +108,12 @@ describe("RunTab", () => {
 
     it("displays error info in run model", () => {
         const odinRunnerError = { error: "model error", detail: "with details" };
-        const wrapper = getWrapper({}, { error: odinRunnerError });
+        const result = {
+            inputs: { endTime: 99, parameterValues: new Map() },
+            error: odinRunnerError,
+            result: null
+        };
+        const wrapper = getWrapper({}, { result });
         expect(wrapper.findComponent(ErrorInfo).exists()).toBe(true);
         expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(odinRunnerError);
     });

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -111,7 +111,7 @@ describe("RunTab", () => {
         const result = {
             inputs: { endTime: 99, parameterValues: new Map() },
             error: odinRunnerError,
-            result: null
+            solution: null
         };
         const wrapper = getWrapper({}, { result });
         expect(wrapper.findComponent(ErrorInfo).exists()).toBe(true);

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -78,7 +78,7 @@ describe("SensitivitySummaryPlot", () => {
                     namespaced: true,
                     state: {
                         result: {
-                            result: hasData ? mockBatch : null
+                            batch: hasData ? mockBatch : null
                         },
                         plotSettings: { ...plotSettings }
                     },

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -77,7 +77,9 @@ describe("SensitivitySummaryPlot", () => {
                 sensitivity: {
                     namespaced: true,
                     state: {
-                        batch: hasData ? mockBatch : null,
+                        result: {
+                            result: hasData ? mockBatch : null
+                        },
                         plotSettings: { ...plotSettings }
                     },
                     mutations: {

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -36,7 +36,7 @@ describe("SensitivityTab", () => {
                         sensitivityUpdateRequired: false,
                         result: {
                             inputs: {},
-                            result: {
+                            batch: {
                                 solutions: []
                             },
                             error: null
@@ -104,7 +104,7 @@ describe("SensitivityTab", () => {
         const sensitivityState = {
             result: {
                 inputs: {} as any,
-                result: null,
+                batch: null,
                 error: testError
             }
         };
@@ -137,7 +137,7 @@ describe("SensitivityTab", () => {
     it("renders expected update message when required action is Compile", () => {
         const sensitivityState = {
             result: {
-                result: { solutions: [{}] }
+                batch: { solutions: [{}] }
             }
         } as any;
         const wrapper = getWrapper({ compileRequired: true }, sensitivityState);
@@ -149,7 +149,7 @@ describe("SensitivityTab", () => {
     it("renders expected update message when sensitivity requires update", () => {
         const sensitivityState = {
             result: {
-                result: { solutions: [{}] }
+                batch: { solutions: [{}] }
             },
             sensitivityUpdateRequired: true
         } as any;
@@ -163,7 +163,7 @@ describe("SensitivityTab", () => {
     it("fades Summary plot when updated required", () => {
         const sensitivityState = {
             result: {
-                result: { solutions: [{}] }
+                batch: { solutions: [{}] }
             },
             plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any,
             sensitivityUpdateRequired: true

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -99,11 +99,14 @@ describe("SensitivityTab", () => {
         expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
     });
 
-    it.skip("renders error", () => {
+    it("renders error", () => {
         const testError = { error: "Test Error", detail: "test error detail" };
         const sensitivityState = {
-            result: null,
-            error: testError
+            result: {
+                inputs: {} as any,
+                result: null,
+                error: testError
+            }
         };
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(testError);

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -34,13 +34,16 @@ describe("SensitivityTab", () => {
                     namespaced: true,
                     state: {
                         sensitivityUpdateRequired: false,
-                        batch: {
-                            solutions: []
+                        result: {
+                            inputs: {},
+                            result: {
+                                solutions: []
+                            },
+                            error: null
                         },
                         plotSettings: {
                             plotType: SensitivityPlotType.TraceOverTime
                         },
-                        error: null,
                         ...sensitivityState
                     },
                     getters: {
@@ -96,9 +99,13 @@ describe("SensitivityTab", () => {
         expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
     });
 
-    it("renders error", () => {
+    it.skip("renders error", () => {
         const testError = { error: "Test Error", detail: "test error detail" };
-        const wrapper = getWrapper({}, { error: testError });
+        const sensitivityState = {
+            result: null,
+            error: testError
+        };
+        const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(testError);
     });
 
@@ -126,7 +133,9 @@ describe("SensitivityTab", () => {
 
     it("renders expected update message when required action is Compile", () => {
         const sensitivityState = {
-            batch: { solutions: [{}] }
+            result: {
+                result: { solutions: [{}] }
+            }
         } as any;
         const wrapper = getWrapper({ compileRequired: true }, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
@@ -136,7 +145,9 @@ describe("SensitivityTab", () => {
 
     it("renders expected update message when sensitivity requires update", () => {
         const sensitivityState = {
-            batch: { solutions: [{}] },
+            result: {
+                result: { solutions: [{}] }
+            },
             sensitivityUpdateRequired: true
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
@@ -148,7 +159,9 @@ describe("SensitivityTab", () => {
 
     it("fades Summary plot when updated required", () => {
         const sensitivityState = {
-            batch: { solutions: [{}] },
+            result: {
+                result: { solutions: [{}] }
+            },
             plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any,
             sensitivityUpdateRequired: true
         } as any;

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -126,13 +126,13 @@ describe("SensitivityTracesPlot", () => {
                 },
                 run: {
                     result: {
-                        result: mockCentralSln
+                        solution: mockCentralSln
                     },
                     endTime: 1
                 },
                 sensitivity: {
                     result: {
-                        result: {
+                        batch: {
                             solutions: sensitivityHasSolutions ? mockSolutions : null,
                             pars: {
                                 name: "alpha",

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -125,7 +125,9 @@ describe("SensitivityTracesPlot", () => {
                     paletteModel: mockPalette
                 },
                 run: {
-                    solution: mockCentralSln,
+                    result: {
+                        result: mockCentralSln
+                    },
                     endTime: 1
                 },
                 sensitivity: {

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -131,11 +131,13 @@ describe("SensitivityTracesPlot", () => {
                     endTime: 1
                 },
                 sensitivity: {
-                    batch: {
-                        solutions: sensitivityHasSolutions ? mockSolutions : null,
-                        pars: {
-                            name: "alpha",
-                            values: [1.11111, 2.22222]
+                    result: {
+                        result: {
+                            solutions: sensitivityHasSolutions ? mockSolutions : null,
+                            pars: {
+                                name: "alpha",
+                                values: [1.11111, 2.22222]
+                            }
                         }
                     }
                 }

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -340,9 +340,13 @@ describe("Model actions", () => {
         expect(run.mock.calls[0][2]).toBe(0); // start
         expect(run.mock.calls[0][3]).toBe(99); // end
 
-        expect(commit.mock.calls[9][0]).toBe(`run/${RunMutation.SetSolution}`);
-        expect(commit.mock.calls[9][1]).toBe("test solution");
+        expect(commit.mock.calls[9][0]).toBe(`run/${RunMutation.SetResult}`);
+        expect(commit.mock.calls[9][1]).toEqual({
+            error: null,
+            inputs: { endTime: 99, parameterValues: new Map([["p1", 1]]) },
+            result: "test solution"
+        });
         expect(commit.mock.calls[10][0]).toBe(`run/${RunMutation.SetRunRequired}`);
-        expect(commit.mock.calls[10][1]).toBe(false);
+        expect(commit.mock.calls[1][1]).toBe(true);
     });
 });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -344,9 +344,9 @@ describe("Model actions", () => {
         expect(commit.mock.calls[9][1]).toEqual({
             error: null,
             inputs: { endTime: 99, parameterValues: new Map([["p1", 1]]) },
-            result: "test solution"
+            solution: "test solution"
         });
         expect(commit.mock.calls[10][0]).toBe(`run/${RunMutation.SetRunRequired}`);
-        expect(commit.mock.calls[1][1]).toBe(true);
+        expect(commit.mock.calls[10][1]).toBe(false);
     });
 });

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -50,7 +50,7 @@ describe("ModelFit actions", () => {
 
     it("FitModel calls wodinFit and dispatches FitModelStep action", () => {
         const getters = { canRunFit: true };
-        const link = {time: "t", data: "v", model: "S" };
+        const link = { time: "t", data: "v", model: "S" };
         const rootGetters = {
             "fitData/link": link,
             "fitData/dataEnd": 100

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -50,18 +50,33 @@ describe("ModelFit actions", () => {
 
     it("FitModel calls wodinFit and dispatches FitModelStep action", () => {
         const getters = { canRunFit: true };
+        const link = {time: "t", data: "v", model: "S" };
+        const rootGetters = {
+            "fitData/link": link,
+            "fitData/dataEnd": 100
+        };
         const commit = jest.fn();
         const dispatch = jest.fn();
+        const expectedData = {
+            time: [0, 1, 2],
+            value: [10, 20, 30]
+        };
 
         (actions[ModelFitAction.FitModel] as any)({
-            commit, dispatch, state, rootState, getters
+            commit, dispatch, state, rootState, rootGetters, getters
         });
 
-        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit).toHaveBeenCalledTimes(3);
         expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetFitting);
         expect(commit.mock.calls[0][1]).toBe(true);
         expect(commit.mock.calls[1][0]).toBe(ModelFitMutation.SetFitUpdateRequired);
         expect(commit.mock.calls[1][1]).toBe(false);
+        expect(commit.mock.calls[2][0]).toBe(ModelFitMutation.SetInputs);
+        expect(commit.mock.calls[2][1]).toEqual({
+            data: expectedData,
+            endTime: 100,
+            link
+        });
 
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(ModelFitAction.FitModelStep);
@@ -69,10 +84,7 @@ describe("ModelFit actions", () => {
 
         expect(mockWodinFit).toHaveBeenCalledTimes(1);
         expect(mockWodinFit.mock.calls[0][0]).toBe(mockOdin);
-        expect(mockWodinFit.mock.calls[0][1]).toStrictEqual({
-            time: [0, 1, 2],
-            value: [10, 20, 30]
-        });
+        expect(mockWodinFit.mock.calls[0][1]).toStrictEqual(expectedData);
         expect(mockWodinFit.mock.calls[0][2]).toStrictEqual({
             base: parameterValues,
             vary: ["p1"]

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -2,16 +2,33 @@ import { mockModelFitState } from "../../../mocks";
 import { mutations } from "../../../../src/app/store/modelFit/mutations";
 
 describe("ModelFit mutations", () => {
+    const mockInputs = {
+        data: [{ a: 1, b: 2 }, { a: 3, b: -4 }],
+        endTime: 100,
+        link: {
+            time: "t",
+            data: "d",
+            model: "m"
+        }
+    };
+
     it("sets fitting", () => {
         const state = mockModelFitState();
         mutations.SetFitting(state, true);
         expect(state.fitting).toBe(true);
     });
 
-    it("sets model fit result", () => {
+    it("sets model fit inputs", () => {
         const state = mockModelFitState();
+        mutations.SetInputs(state, mockInputs);
+        expect(state.inputs).toEqual(mockInputs);
+    });
+
+    it("sets model fit result", () => {
+        const state = mockModelFitState({ inputs: mockInputs });
         const solution = jest.fn();
         const pars = new Map([["x", 1]]);
+
         const payload = {
             converged: false,
             iterations: 2,
@@ -27,7 +44,12 @@ describe("ModelFit mutations", () => {
         expect(state.iterations).toBe(2);
         expect(state.sumOfSquares).toBe(1.2);
         expect(state.result).toEqual({
-            inputs: { endTime: 100, parameterValues: pars },
+            inputs: {
+                data: mockInputs.data,
+                endTime: 100,
+                link: mockInputs.link,
+                parameterValues: pars
+            },
             result: solution,
             error: null
         });

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -1,7 +1,7 @@
 import { mockModelFitState } from "../../../mocks";
 import { mutations } from "../../../../src/app/store/modelFit/mutations";
 
-describe("ModeilFit mutations", () => {
+describe("ModelFit mutations", () => {
     it("sets fitting", () => {
         const state = mockModelFitState();
         mutations.SetFitting(state, true);
@@ -11,11 +11,14 @@ describe("ModeilFit mutations", () => {
     it("sets model fit result", () => {
         const state = mockModelFitState();
         const solution = jest.fn();
+        const pars = new Map([["x", 1]]);
         const payload = {
             converged: false,
             iterations: 2,
             value: 1.2,
             data: {
+                endTime: 100,
+                pars,
                 solution
             }
         };
@@ -23,7 +26,11 @@ describe("ModeilFit mutations", () => {
         expect(state.converged).toBe(false);
         expect(state.iterations).toBe(2);
         expect(state.sumOfSquares).toBe(1.2);
-        expect(state.solution).toBe(solution);
+        expect(state.result).toEqual({
+            inputs: { endTime: 100, parameterValues: pars },
+            result: solution,
+            error: null
+        });
     });
 
     it("sets paramsToVary", () => {

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -50,7 +50,7 @@ describe("ModelFit mutations", () => {
                 link: mockInputs.link,
                 parameterValues: pars
             },
-            result: solution,
+            solution,
             error: null
         });
     });

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -136,7 +136,7 @@ describe("Run actions", () => {
             inputs: { parameterValues, endTime: 99 },
             result: null,
             error: {
-                detail: mockError,
+                detail: mockError.message,
                 error: "An error occurred while running the model"
             }
         });

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -37,7 +37,7 @@ describe("Run actions", () => {
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
         expect(commit.mock.calls[0][1]).toEqual({
             inputs: { parameterValues, endTime: 99 },
-            result: "test solution",
+            solution: "test solution",
             error: null
         });
         expect(commit.mock.calls[1][0]).toBe(RunMutation.SetRunRequired);
@@ -134,7 +134,7 @@ describe("Run actions", () => {
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
         expect(commit.mock.calls[0][1]).toStrictEqual({
             inputs: { parameterValues, endTime: 99 },
-            result: null,
+            solution: null,
             error: {
                 detail: mockError.message,
                 error: "An error occurred while running the model"

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -34,8 +34,12 @@ describe("Run actions", () => {
         expect(run.mock.calls[0][3]).toBe(99); // end time from state
 
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetSolution);
-        expect(commit.mock.calls[0][1]).toBe("test solution");
+        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
+        expect(commit.mock.calls[0][1]).toEqual({
+            inputs: { parameterValues, endTime: 99 },
+            result: "test solution",
+            error: null
+        });
         expect(commit.mock.calls[1][0]).toBe(RunMutation.SetRunRequired);
         expect(commit.mock.calls[1][1]).toBe(false);
     });
@@ -56,7 +60,7 @@ describe("Run actions", () => {
 
         (actions[RunAction.RunModel] as any)({ commit, state, rootState });
         expect(commit.mock.calls.length).toBe(1);
-        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetSolution);
+        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
     });
 
     it("run model does nothing if odin runner is not set", () => {
@@ -127,10 +131,14 @@ describe("Run actions", () => {
 
         expect(runner.wodinRun.mock.calls[0][0]).toBe(mockOdin);
         expect(commit.mock.calls.length).toBe(2);
-        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetError);
+        expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
         expect(commit.mock.calls[0][1]).toStrictEqual({
-            detail: mockError,
-            error: "An error occurred while running the model"
+            inputs: { parameterValues, endTime: 99 },
+            result: null,
+            error: {
+                detail: mockError,
+                error: "An error occurred while running the model"
+            }
         });
     });
 });

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -8,7 +8,7 @@ describe("Run mutations", () => {
         const result = {
             inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
             error: null,
-            result: mockSolution
+            solution: mockSolution
         };
 
         mutations.SetResult(state, result);
@@ -51,12 +51,11 @@ describe("Run mutations", () => {
     });
 
     it("sets odinRunnerResponseError", () => {
-        const mockSolution = () => [{ x: 1, y: 2 }];
         const state = mockRunState();
         const result = {
             inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
             error: { error: "model error", detail: "with details" },
-            result: null
+            solution: null
         };
 
         mutations.SetResult(state, result);

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -9,7 +9,7 @@ describe("Run mutations", () => {
             inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
             error: null,
             result: mockSolution
-        }
+        };
 
         mutations.SetResult(state, result);
         expect(state.result).toBe(result);
@@ -57,7 +57,7 @@ describe("Run mutations", () => {
             inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
             error: { error: "model error", detail: "with details" },
             result: null
-        }
+        };
 
         mutations.SetResult(state, result);
         expect(state.result).toBe(result);

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -5,9 +5,14 @@ describe("Run mutations", () => {
     it("sets odin solution", () => {
         const mockSolution = () => [{ x: 1, y: 2 }];
         const state = mockRunState();
+        const result = {
+            inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
+            error: null,
+            result: mockSolution
+        }
 
-        mutations.SetSolution(state, mockSolution);
-        expect(state.solution).toBe(mockSolution);
+        mutations.SetResult(state, result);
+        expect(state.result).toBe(result);
     });
 
     it("sets run required", () => {
@@ -46,9 +51,15 @@ describe("Run mutations", () => {
     });
 
     it("sets odinRunnerResponseError", () => {
-        const error = { error: "model error", detail: "with details" };
+        const mockSolution = () => [{ x: 1, y: 2 }];
         const state = mockRunState();
-        mutations.SetError(state, error);
-        expect(state.error).toBe(error);
+        const result = {
+            inputs: { endTime: 99, parameterValues: new Map([["a", 1]]) },
+            error: { error: "model error", detail: "with details" },
+            result: null
+        }
+
+        mutations.SetResult(state, result);
+        expect(state.result).toBe(result);
     });
 });

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -40,7 +40,7 @@ describe("Sensitivity actions", () => {
         expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetResult);
         expect(commit.mock.calls[0][1]).toStrictEqual({
             inputs: { endTime: 99, pars: mockBatchPars },
-            result: mockBatch,
+            batch: mockBatch,
             error: null
         });
         expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetUpdateRequired);
@@ -79,7 +79,7 @@ describe("Sensitivity actions", () => {
                 endTime: 99,
                 pars: mockBatchPars
             },
-            result: null,
+            batch: null,
             error: {
                 error: "An error occurred while running sensitivity",
                 detail: "a test error"

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -37,8 +37,12 @@ describe("Sensitivity actions", () => {
         });
 
         expect(commit).toHaveBeenCalledTimes(2);
-        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetBatch);
-        expect(commit.mock.calls[0][1]).toBe(mockBatch);
+        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetResult);
+        expect(commit.mock.calls[0][1]).toStrictEqual({
+            inputs: { endTime: 99, pars: mockBatchPars },
+            result: mockBatch,
+            error: null
+        });
         expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetUpdateRequired);
         expect(commit.mock.calls[1][1]).toBe(false);
 
@@ -69,10 +73,17 @@ describe("Sensitivity actions", () => {
         });
 
         expect(commit).toHaveBeenCalledTimes(1);
-        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetError);
+        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetResult);
         expect(commit.mock.calls[0][1]).toStrictEqual({
-            error: "An error occurred while running sensitivity",
-            detail: "a test error"
+            inputs: {
+                endTime: 99,
+                pars: mockBatchPars
+            },
+            result: null,
+            error: {
+                error: "An error occurred while running sensitivity",
+                detail: "a test error"
+            }
         });
 
         expect(dispatch).not.toHaveBeenCalled();
@@ -145,7 +156,7 @@ describe("Sensitivity actions", () => {
         });
 
         expect(commit).toHaveBeenCalledTimes(2);
-        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetBatch);
+        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetResult);
         expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetUpdateRequired);
 
         expect(mockRunner.batchRun).toHaveBeenCalledWith(rootState.model.odin, mockBatchPars, 0, 99, {});

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -25,13 +25,19 @@ describe("Sensitivity mutations", () => {
 
     it("sets batch", () => {
         const state = {
-            batch: null,
-            error: { error: "TEST ERROR", detail: "test detail" }
+            result: {
+                inputs: null,
+                result: null,
+                error: { error: "TEST ERROR", detail: "test detail" }
+            }
         } as any;
-        const batch = { solutions: [] } as any;
-        mutations[SensitivityMutation.SetBatch](state, batch);
-        expect(state.batch).toBe(batch);
-        expect(state.error).toBe(null);
+        const batch = {
+            inputs: {},
+            result: { solutions: [] },
+            error: null
+        };
+        mutations[SensitivityMutation.SetResult](state, batch);
+        expect(state.result).toBe(batch);
     });
 
     it("sets update required", () => {
@@ -67,9 +73,13 @@ describe("Sensitivity mutations", () => {
     });
 
     it("sets error", () => {
-        const state = { error: null } as any;
-        const error = { error: "TEST ERROR", detail: "test error detail" };
-        mutations[SensitivityMutation.SetError](state, error);
-        expect(state.error).toBe(error);
+        const state = { } as any;
+        const batch = {
+            inputs: {},
+            result: null,
+            error: { error: "TEST ERROR", detail: "test error detail" }
+        };
+        mutations[SensitivityMutation.SetResult](state, batch);
+        expect(state.result).toBe(batch);
     });
 });

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -27,13 +27,13 @@ describe("Sensitivity mutations", () => {
         const state = {
             result: {
                 inputs: null,
-                result: null,
+                batch: null,
                 error: { error: "TEST ERROR", detail: "test detail" }
             }
         } as any;
         const batch = {
             inputs: {},
-            result: { solutions: [] },
+            batch: { solutions: [] },
             error: null
         };
         mutations[SensitivityMutation.SetResult](state, batch);
@@ -76,7 +76,7 @@ describe("Sensitivity mutations", () => {
         const state = { } as any;
         const batch = {
             inputs: {},
-            result: null,
+            batch: null,
             error: { error: "TEST ERROR", detail: "test error detail" }
         };
         mutations[SensitivityMutation.SetResult](state, batch);


### PR DESCRIPTION
This PR updates the run, fit and sensitivity model state to hold a copy of the _original_ inputs used to create them, so that we can serialise these inputs later for ease of rehydration. This means that we should not have to poke about in the store for anything when rebuilding the full store state

Some issues remain:

* We don't correctly use these inputs everywhere, in particular FitPlot.vue needs some light refactoring to use the inputs I think?
* We should apply this to the model compilation too I think