### PR TITLE
Remove use of Map

### DIFF
--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -142,7 +142,7 @@ export default defineComponent({
         const settingsInternal = reactive({} as SensitivityParameterSettings);
 
         const paramNames = computed(() => {
-            return store.state.run.parameterValues ? Array.from(store.state.run.parameterValues.keys()) : [];
+            return store.state.run.parameterValues ? Object.keys(store.state.run.parameterValues) : [];
         });
 
         const scaleValues = Object.keys(SensitivityScaleType);
@@ -158,7 +158,7 @@ export default defineComponent({
             }
         });
 
-        const centralValue = computed(() => store.state.run.parameterValues.get(settingsInternal.parameterToVary));
+        const centralValue = computed(() => store.state.run.parameterValues[settingsInternal.parameterToVary!]);
 
         const batchParsResult = computed(() => generateBatchPars(store.state, settingsInternal));
         const batchPars = computed(() => batchParsResult.value.batchPars);

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -43,22 +43,15 @@ export default defineComponent({
     },
     setup() {
         const store = useStore();
-        const paramValuesMap = computed(() => store.state.run.parameterValues);
-        const paramNames = computed(
-            () => (paramValuesMap.value ? Array.from(paramValuesMap.value.keys()) as string[] : [])
-        );
 
         const paramsToVary = computed<string[]>(() => {
             return store.state.appType === AppType.Fit ? store.state.modelFit.paramsToVary : [];
         });
 
-        const paramValues = computed(() => {
-            return paramNames.value.reduce((values: Dict<number>, key: string) => {
-                // eslint-disable-next-line no-param-reassign
-                values[key] = paramValuesMap.value.get(key)!;
-                return values;
-            }, {} as Dict<number>);
-        });
+        const paramValues = computed(() => store.state.run.parameterValues);
+        const paramNames = computed(
+            () => (paramValues.value ? Object.keys(paramValues.value) : [])
+        );
 
         const paramVaryFlags = computed(() => {
             return paramNames.value.reduce((values: Dict<boolean>, key: string) => {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -3,7 +3,7 @@ import { ModelState } from "./state";
 import { api } from "../../apiService";
 import { ModelMutation } from "./mutations";
 import { AppState, AppType } from "../appState/state";
-import { Odin, OdinModelResponse, OdinParameter } from "../../types/responseTypes";
+import { Odin, OdinModelResponse, OdinParameter, OdinUserType } from "../../types/responseTypes";
 import { evaluateScript } from "../../utils";
 import { FitDataAction } from "../fitData/actions";
 import { ModelFitAction } from "../modelFit/actions";
@@ -47,10 +47,10 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
         commit(ModelMutation.SetOdin, odin);
 
         // Overwrite any existing parameter values in the model
-        const newValues = new Map<string, number>();
+        const newValues: OdinUserType = {};
         parameters.forEach((param: OdinParameter) => {
             const value = param.default;
-            newValues.set(param.name, value === null ? 0 : value);
+            newValues[param.name] = value === null ? 0 : value;
         });
         commit(`run/${RunMutation.SetParameterValues}`, newValues, { root: true });
 
@@ -65,7 +65,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         // set or update selected sensitivity variable
         const { paramSettings } = rootState.sensitivity;
-        const paramNames = Array.from(newValues.keys());
+        const paramNames = Object.keys(newValues);
         if (!paramSettings.parameterToVary || !paramNames.includes(paramSettings.parameterToVary)) {
             const newParamToVary = paramNames.length ? parameters[0].name : null;
             commit(`sensitivity/${SensitivityMutation.SetParameterToVary}`, newParamToVary, { root: true });

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -68,7 +68,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
     [ModelFitAction.UpdateParamsToVary](context) {
         const { rootState, state, commit } = context;
         const paramValues = rootState.run.parameterValues;
-        const newParams = paramValues ? Array.from(paramValues.keys()) : [];
+        const newParams = paramValues ? Object.keys(paramValues) : [];
         // Retain selected values if we can
         const newParamsToVary = state.paramsToVary.filter((param) => newParams.includes(param));
         commit(ModelFitMutation.SetParamsToVary, newParamsToVary);

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -1,6 +1,6 @@
 import { MutationTree } from "vuex";
 import { RunState } from "./state";
-import { OdinSolution, WodinError } from "../../types/responseTypes";
+import { OdinSolution, OdinUserType, WodinError } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
 
 export enum RunMutation {
@@ -22,14 +22,14 @@ export const mutations: MutationTree<RunState> = {
         state.runRequired = payload;
     },
 
-    [RunMutation.SetParameterValues](state: RunState, payload: Map<string, number>) {
+    [RunMutation.SetParameterValues](state: RunState, payload: OdinUserType) {
         state.parameterValues = payload;
     },
 
-    [RunMutation.UpdateParameterValues](state: RunState, payload: Dict<number>) {
+    [RunMutation.UpdateParameterValues](state: RunState, payload: OdinUserType) {
         if (state.parameterValues) {
             Object.keys(payload).forEach((key) => {
-                state.parameterValues!.set(key, payload[key]);
+                state.parameterValues![key] = payload[key];
             });
             state.runRequired = true;
         }

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -1,9 +1,9 @@
-import { OdinSolution, WodinError } from "../../types/responseTypes";
+import { OdinSolution, OdinUserType, WodinError } from "../../types/responseTypes";
 
 export interface RunState {
     runRequired: boolean
     solution: null | OdinSolution
-    parameterValues: null | Map<string, number>
+    parameterValues: null | OdinUserType
     endTime: number,
     error: WodinError | null
 }

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -79,8 +79,15 @@ export interface OdinFitData {
     value: number[]
 }
 
+// This is strictly a little more restrictive than what odin supports,
+// but wodin does not support fancy user variables yet and we can sort
+// that out later (odin allows the union of number, number[], and a
+// tensor type - the latter two will be a challenge to expose nicely
+// in the interface).
+export type OdinUserType = Dict<number>;
+
 export interface OdinFitParameters {
-    base: Map<string, number>,
+    base: OdinUserType,
     vary: string[]
 }
 
@@ -92,7 +99,7 @@ export interface SimplexResult {
     data: {
         names: string[],
         solution: OdinSolution,
-        pars: Map<string, number>
+        pars: OdinUserType
     }
 }
 
@@ -102,7 +109,7 @@ export interface Simplex {
 }
 
 export interface BatchPars {
-    base: Map<string, number>;
+    base: OdinUserType;
     name: string;
     values: number[];
 }
@@ -117,7 +124,7 @@ export interface Batch {
 
 export interface OdinRunner {
     wodinRun: (odin: Odin,
-               pars: Map<string, number>,
+               pars: OdinUserType,
                tStart: number,
                tEnd: number,
                control: OdeControl) => OdinSolution;
@@ -129,14 +136,14 @@ export interface OdinRunner {
                odeParams: OdeControl,
                simplexParams: Dict<unknown>) => Simplex;
 
-    batchParsRange: (base: Map<string, number>,
+    batchParsRange: (base: OdinUserType,
                      name: string,
                      count: number,
                      logarithmic: boolean,
                      min: number,
                      max: number) => BatchPars;
 
-    batchParsDisplace: (base: Map<string, number>,
+    batchParsDisplace: (base: OdinUserType,
                         name: string,
                         count: number,
                         logarithmic: boolean,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -4,7 +4,7 @@ import { BasicState } from "../src/app/store/basic/state";
 import { FitState } from "../src/app/store/fit/state";
 import { StochasticState } from "../src/app/store/stochastic/state";
 import {
-    BatchPars, ResponseFailure, ResponseSuccess, WodinError
+    BatchPars, OdinUserType, ResponseFailure, ResponseSuccess, WodinError
 } from "../src/app/types/responseTypes";
 import { ModelState } from "../src/app/store/model/state";
 import { RunState } from "../src/app/store/run/state";
@@ -178,7 +178,7 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
     };
 };
 
-export const mockBatchParsRange = (base: Map<string, number>, name: string, count: number,
+export const mockBatchParsRange = (base: OdinUserType, name: string, count: number,
     logarithmic: boolean,
     min: number, max: number): BatchPars => {
     if (count < 2) {
@@ -202,10 +202,10 @@ export const mockBatchParsRange = (base: Map<string, number>, name: string, coun
     return { base, name, values };
 };
 
-export const mockBatchParsDisplace = (base: Map<string, number>, name: string, count: number,
+export const mockBatchParsDisplace = (base: OdinUserType, name: string, count: number,
     logarithmic: boolean,
     displace: number): BatchPars => {
-    const paramValue = base.get(name)!;
+    const paramValue = base[name]!;
     const max = paramValue * (1 + (displace / 100));
     const min = paramValue * (1 - (displace / 100));
     return mockBatchParsRange(base, name, count, logarithmic, min, max);

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -41,9 +41,7 @@ describe("EditParamSettings", () => {
         batchParsRange: mockBatchParsRange
     } as any;
 
-    const parameterValues = new Map<string, number>();
-    parameterValues.set("A", 1);
-    parameterValues.set("B", 2);
+    const parameterValues = { A: 1, B: 2};
 
     const getWrapper = async (paramSettings: SensitivityParameterSettings, open = true,
         mockSetParamSettings = jest.fn()) => {

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -26,7 +26,7 @@ describe("OptionsTab", () => {
         model: {
         },
         run: {
-            parameterValues: new Map<string, number>()
+            parameterValues: {}
         },
         modelFit: {
             paramsToVary: []
@@ -64,7 +64,7 @@ describe("OptionsTab", () => {
                 appType: AppType.Fit,
                 openVisualisationTab: VisualisationTab.Fit,
                 run: {
-                    parameterValues: new Map<string, number>()
+                    parameterValues: {}
                 },
                 model: {
                 },

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -34,7 +34,7 @@ describe("ParameterValues", () => {
                 run: {
                     namespaced: true,
                     state: mockRunState({
-                        parameterValues: new Map([["param1", 1], ["param2", 2.2]])
+                        parameterValues: { param1: 1, param2: 2.2 }
                     }),
                     mutations: storeMutations
                 },

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -38,7 +38,7 @@ describe("SensitivityOptions", () => {
                 run: {
                     namespaced: true,
                     state: {
-                        parameterValues: new Map<string, number>()
+                        parameterValues: {}
                     }
                 }
             } as any

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -30,11 +30,7 @@ describe("Model actions", () => {
         },
         run: {
             runRequired: false,
-            parameterValues: new Map([
-                ["p1", 1],
-                ["p2", 2],
-                ["p3", 3]
-            ])
+            parameterValues: { p1: 1, p2: 2, p3: 3 }
         }
     };
 
@@ -113,7 +109,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
-        const expectedParams = new Map([["p2", 20], ["p3", 30], ["p4", 40]]);
+        const expectedParams = { p2: 20, p3: 30, p4: 40 };
         expect(commit.mock.calls[1][1]).toStrictEqual(expectedParams);
         expect(commit.mock.calls[2][0]).toBe(ModelMutation.SetPaletteModel);
         expect(commit.mock.calls[2][1]).toStrictEqual({ x: "#2e5cb8", y: "#cc0044" });
@@ -191,10 +187,7 @@ describe("Model actions", () => {
             },
             compileRequired: true,
             runRequired: false,
-            parameterValues: new Map([
-                ["p2", 1],
-                ["p3", 2]
-            ])
+            parameterValues: { p2: 1, p3: 2 }
         };
 
         const commit = jest.fn();
@@ -236,7 +229,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
         expect(commit.mock.calls[0][1]).toBe(3);
         expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
-        expect(commit.mock.calls[1][1]).toStrictEqual(new Map());
+        expect(commit.mock.calls[1][1]).toStrictEqual({});
         expect(commit.mock.calls[3][0]).toBe(`sensitivity/${SensitivityMutation.SetParameterToVary}`);
         expect(commit.mock.calls[3][1]).toBe(null);
     });
@@ -316,7 +309,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[2][0]).toBe(`model/${ModelMutation.SetOdin}`);
         expect(commit.mock.calls[2][1]).toBe(3); // evaluated value of test model
         expect(commit.mock.calls[3][0]).toBe(`run/${RunMutation.SetParameterValues}`);
-        expect(commit.mock.calls[3][1]).toStrictEqual(new Map([["p1", 1]]));
+        expect(commit.mock.calls[3][1]).toStrictEqual({ p1: 1 });
 
         expect(commit.mock.calls[4][0]).toBe(`model/${ModelMutation.SetPaletteModel}`);
         expect(commit.mock.calls[4][1]).toStrictEqual({ x: "#2e5cb8", y: "#cc0044" });
@@ -336,7 +329,7 @@ describe("Model actions", () => {
         // runs
         const run = runner.wodinRun;
         expect(run.mock.calls[0][0]).toBe(3);
-        expect(run.mock.calls[0][1]).toStrictEqual(new Map([["p1", 1]]));
+        expect(run.mock.calls[0][1]).toStrictEqual({ p1: 1 });
         expect(run.mock.calls[0][2]).toBe(0); // start
         expect(run.mock.calls[0][3]).toBe(99); // end
 

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -14,9 +14,7 @@ describe("ModelFit actions", () => {
         wodinFit: mockWodinFit
     } as any;
     const mockOdin = {} as any;
-    const parameterValues = new Map<string, number>();
-    parameterValues.set("p1", 1.1);
-    parameterValues.set("p2", 2.2);
+    const parameterValues = { p1: 1.1, p2: 2.2 };
     const modelState = mockModelState({
         odin: mockOdin,
         odinRunner: mockOdinRunner
@@ -99,7 +97,7 @@ describe("ModelFit actions", () => {
         const result = {
             converged: false,
             data: {
-                pars: new Map<string, number>()
+                pars: {}
             }
         };
         const simplex = {
@@ -133,7 +131,7 @@ describe("ModelFit actions", () => {
         const result = {
             converged: true,
             data: {
-                pars: new Map<string, number>()
+                pars: {}
             }
         };
         const simplex = {

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -8,7 +8,7 @@ describe("Run actions", () => {
     it("runs model and updates required action", () => {
         const mockOdin = {} as any;
 
-        const parameterValues = new Map([["p1", 1], ["p2", 2]]);
+        const parameterValues = { p1: 1, p2: 2 };
         const runner = mockRunner();
         const modelState = mockModelState({
             odinRunner: runner,
@@ -50,7 +50,7 @@ describe("Run actions", () => {
         const rootState = { model: modelState } as any;
         const state = mockRunState({
             runRequired: false,
-            parameterValues: new Map()
+            parameterValues: {}
         });
         const commit = jest.fn();
 
@@ -106,7 +106,7 @@ describe("Run actions", () => {
             } as any;
         };
 
-        const parameterValues = new Map([["p1", 1], ["p2", 2]]);
+        const parameterValues = { p1: 1, p2: 2 };
         const runner = mockRunnerWithThrownException();
         const modelState = mockModelState({
             odinRunner: runner,

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -27,11 +27,11 @@ describe("Run mutations", () => {
 
     it("updates parameter values and sets runRequired to true", () => {
         const state = mockRunState({
-            parameterValues: new Map([["p1", 1], ["p2", 2]]),
+            parameterValues: { p1: 1, p2: 2 },
             runRequired: true
         });
         mutations.UpdateParameterValues(state, { p1: 10, p3: 30 });
-        expect(state.parameterValues).toStrictEqual(new Map([["p1", 10], ["p2", 2], ["p3", 30]]));
+        expect(state.parameterValues).toStrictEqual({ p1: 10, p2: 2, p3: 30 });
         expect(state.runRequired).toBe(true);
     });
 

--- a/app/static/tests/unit/store/sensitivity/getters.test.ts
+++ b/app/static/tests/unit/store/sensitivity/getters.test.ts
@@ -4,8 +4,7 @@ import { SensitivityScaleType, SensitivityVariationType } from "../../../../src/
 
 describe("Sensitivity getters", () => {
     it("generates batchPars", () => {
-        const parameterValues = new Map<string, number>();
-        parameterValues.set("A", 2);
+        const parameterValues = { A: 2 };
         const odinRunner = {
             batchParsDisplace: mockBatchParsDisplace
         };

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -271,9 +271,7 @@ describe("processFitData", () => {
 });
 
 describe("generateBatchPars", () => {
-    const parameterValues = new Map<string, number>();
-    parameterValues.set("A", 1);
-    parameterValues.set("B", 2);
+    const parameterValues = { A: 1, B: 2};
 
     const rootState = {
         model: {

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=main
+ODIN_API_BRANCH=mrc-3562
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH


### PR DESCRIPTION
change the branch pin used in the dependencies script before merging.

This is a fairly mechanical replacement of Map with objects for parameters