### PR TITLE
Plot data on run plot, where available

### DIFF
--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -20,7 +20,6 @@ import {
 import {
     WodinPlotData, fadePlotStyle, margin, config
 } from "../plot";
-import { OdinSolution } from "../types/responseTypes";
 
 export default defineComponent({
     name: "WodinOdePlot",
@@ -38,7 +37,7 @@ export default defineComponent({
         // Only used as an indicator that redraw is required when this changes - the data to display is calculated by
         // plotData function using these solutions
         redrawWatches: {
-            type: Array as PropType<OdinSolution[]>,
+            type: Array as PropType<any[]>,
             required: true
         }
     },

--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -37,7 +37,7 @@ export default defineComponent({
         },
         // Only used as an indicator that redraw is required when this changes - the data to display is calculated by
         // plotData function using these solutions
-        solutions: {
+        redrawWatches: {
             type: Array as PropType<OdinSolution[]>,
             required: true
         }
@@ -86,7 +86,7 @@ export default defineComponent({
         let resizeObserver: null | ResizeObserver = null;
 
         const drawPlot = () => {
-            if (props.solutions.length) {
+            if (props.redrawWatches.length) {
                 baseData.value = props.plotData(startTime, props.endTime, nPoints);
 
                 if (hasPlotData.value) {
@@ -104,7 +104,7 @@ export default defineComponent({
 
         onMounted(drawPlot);
 
-        watch(() => props.solutions, drawPlot);
+        watch(() => props.redrawWatches, drawPlot);
 
         onUnmounted(() => {
             if (resizeObserver) {

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -4,7 +4,7 @@
         :placeholder-message="placeholderMessage"
         :end-time="endTime"
         :plot-data="allPlotData"
-        :solutions="solution ? [solution] : []">
+        :redrawWatches="solution ? [solution] : []">
         <slot></slot>
     </wodin-ode-plot>
 </template>

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -4,7 +4,7 @@
       :placeholder-message="placeholderMessage"
       :end-time="endTime"
       :plot-data="allPlotData"
-      :solutions="solution ? [solution, allFitData] : []">
+      :redrawWatches="solution ? [solution, allFitData] : []">
     <slot></slot>
   </wodin-ode-plot>
 </template>

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -4,7 +4,7 @@
       :placeholder-message="placeholderMessage"
       :end-time="endTime"
       :plot-data="allPlotData"
-      :solutions="solution ? [solution] : []">
+      :solutions="solution ? [solution, allFitData] : []">
     <slot></slot>
   </wodin-ode-plot>
 </template>
@@ -12,8 +12,9 @@
 <script lang="ts">
 import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
+import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
-import { odinToPlotly, WodinPlotData } from "../../plot";
+import { odinToPlotly, allFitDataToPlotly, WodinPlotData } from "../../plot";
 import WodinOdePlot from "../WodinOdePlot.vue";
 
 export default defineComponent({
@@ -35,18 +36,22 @@ export default defineComponent({
 
         const palette = computed(() => store.state.model.paletteModel);
 
+        const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
+
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const result = solution.value && solution.value(start, end, points);
             if (!result) {
                 return [];
             }
-            return [...odinToPlotly(result, palette.value)];
+            return [...odinToPlotly(result, palette.value),
+                ...allFitDataToPlotly(allFitData.value, palette.value, start, end)];
         };
 
         return {
             placeholderMessage,
             endTime,
             solution,
+            allFitData,
             allPlotData
         };
     }

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -4,7 +4,7 @@
       :placeholder-message="placeholderMessage"
       :end-time="endTime"
       :plot-data="allPlotData"
-      :solutions="solutions">
+      :redrawWatches="solutions">
     <slot></slot>
   </wodin-ode-plot>
 </template>

--- a/app/static/src/app/palette.ts
+++ b/app/static/src/app/palette.ts
@@ -49,7 +49,14 @@ export function paletteModel(names: string[]): Palette {
 }
 
 export function paletteData(names: string[]): Palette {
-    const cols = ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00", "#ffff33", "#a65628", "#f781bf"];
+    // This is not a lot of colours, but we don't really expect that
+    // many columns to come in here (if a user is adding more than 3
+    // columns we might want some interface to filter down to
+    // interesting ones, we will also bail on any non-numeric column).
+    //
+    // These are all brownish so that the colours will contrast nicely
+    // with the model series (a rainbow, above)
+    const cols = ["#1c0a00", "#603601", "#cc9544"];
     const ret: Palette = {};
     names.forEach((el: string, index: number) => {
         ret[el] = cols[index];

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,6 +1,6 @@
 import { PlotData } from "plotly.js";
-import { Palette } from "./palette";
-import type { FitData, FitDataLink } from "./store/fitData/state";
+import { paletteData, Palette } from "./palette";
+import type { AllFitData, FitData, FitDataLink } from "./store/fitData/state";
 import { OdinSeriesSet } from "./types/responseTypes";
 import { Dict } from "./types/utilTypes";
 
@@ -77,4 +77,28 @@ export function fitDataToPlotly(data: FitData, link: FitDataLink, palette: Palet
             color: palette[link.model]
         }
     }];
+}
+
+export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: Palette,
+    start: number, end: number): WodinPlotData {
+    if (!allFitData) {
+        return [];
+    }
+    const {
+        data, linkedVariables, timeVariable
+    } = allFitData;
+    const filteredData = data.filter(
+        (row: Dict<number>) => row[timeVariable] >= start && row[timeVariable] <= end
+    );
+    const palette = paletteData(Object.keys(linkedVariables));
+    return Object.keys(linkedVariables).map((name: string) => ({
+        name,
+        x: filteredData.map((row: Dict<number>) => row[timeVariable]),
+        y: filteredData.map((row: Dict<number>) => row[name]),
+        mode: "markers",
+        type: "scatter",
+        marker: {
+            color: linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]
+        }
+    }));
 }

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -28,6 +28,12 @@ export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
     };
 }
 
+function filterData(data: FitData, timeVariable: string, start: number, end: number) {
+    return data.filter(
+        (row: Dict<number>) => row[timeVariable] >= start && row[timeVariable] <= end
+    );
+}
+
 export interface PlotlyOptions {
     includeLegendGroup: boolean,
     lineWidth: number
@@ -64,9 +70,7 @@ export function odinToPlotly(s: OdinSeriesSet, palette: Palette, options: Partia
 
 export function fitDataToPlotly(data: FitData, link: FitDataLink, palette: Palette, start: number,
     end: number): WodinPlotData {
-    const filteredData = data.filter(
-        (row: Dict<number>) => row[link.time] >= start && row[link.time] <= end
-    );
+    const filteredData = filterData(data, link.time, start, end);
     return [{
         name: link.data,
         x: filteredData.map((row: Dict<number>) => row[link.time]),
@@ -87,9 +91,7 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
     const {
         data, linkedVariables, timeVariable
     } = allFitData;
-    const filteredData = data.filter(
-        (row: Dict<number>) => row[timeVariable] >= start && row[timeVariable] <= end
-    );
+    const filteredData = filterData(data, timeVariable, start, end);
     const palette = paletteData(Object.keys(linkedVariables));
     return Object.keys(linkedVariables).map((name: string) => ({
         name,

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -64,7 +64,6 @@ export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
         if (data && timeVariable) {
             result = {
                 data,
-                endTime: data[data.length - 1][timeVariable],
                 linkedVariables,
                 timeVariable
             };

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -73,7 +73,7 @@ export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
         if (data && timeVariable) {
             result = {
                 data,
-                { ...linkedVariables },
+                linkedVariables: { ...linkedVariables },
                 timeVariable
             };
         }

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -1,12 +1,13 @@
 import { GetterTree, Getter } from "vuex";
-import { FitDataLink, FitDataState } from "./state";
+import { FitDataLink, FitDataState, AllFitData } from "./state";
 import { FitState } from "../fit/state";
 
 export enum FitDataGetter {
     nonTimeColumns ="nonTimeColumns",
     dataStart = "dataStart",
     dataEnd = "dataEnd",
-    link = "link"
+    link = "link",
+    allData = "allData"
 }
 
 export interface FitDataGetters {
@@ -51,6 +52,21 @@ export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
                 data: state.columnToFit,
                 // The name of the variable representing the modelled values in the solution
                 model: modelVariableToFit
+            };
+        }
+        return result;
+    },
+
+    [FitDataGetter.allData]: (state: FitDataState): null | AllFitData => {
+        console.log("Triggering allData getter");
+        let result = null;
+        const { data, timeVariable, linkedVariables } = state;
+        if (data && timeVariable) {
+            result = {
+                data,
+                endTime: data[data.length - 1][timeVariable],
+                linkedVariables,
+                timeVariable
             };
         }
         return result;

--- a/app/static/src/app/store/fitData/getters.ts
+++ b/app/static/src/app/store/fitData/getters.ts
@@ -57,14 +57,23 @@ export const getters: FitDataGetters & GetterTree<FitDataState, FitState> = {
         return result;
     },
 
+    // This is used by plots (*except the FitPlot*) that want to
+    // display the data time series. In this case there's no concept
+    // of which data stream is being present, but we do need the time
+    // variable to exist. In the case where no data is present or time
+    // is not known we return null. It's not a problem if no linked
+    // variables are known - we'll use the data palette in that case;
+    // if links exist we'll colour following the model.
+    //
+    // We need to copy the linkedVariables so that a change to them
+    // will trigger replotting.
     [FitDataGetter.allData]: (state: FitDataState): null | AllFitData => {
-        console.log("Triggering allData getter");
         let result = null;
         const { data, timeVariable, linkedVariables } = state;
         if (data && timeVariable) {
             result = {
                 data,
-                linkedVariables,
+                { ...linkedVariables },
                 timeVariable
             };
         }

--- a/app/static/src/app/store/fitData/state.ts
+++ b/app/static/src/app/store/fitData/state.ts
@@ -14,6 +14,13 @@ export interface FitDataLink {
 
 export type FitData = Dict<number>[];
 
+export interface AllFitData {
+    data: FitData;
+    endTime: number;
+    linkedVariables: Dict<string | null>;
+    timeVariable: string;
+}
+
 export interface FitDataState {
     data: FitData | null,
     columns: string[] | null,

--- a/app/static/src/app/store/fitData/state.ts
+++ b/app/static/src/app/store/fitData/state.ts
@@ -16,7 +16,6 @@ export type FitData = Dict<number>[];
 
 export interface AllFitData {
     data: FitData;
-    endTime: number;
     linkedVariables: Dict<string | null>;
     timeVariable: string;
 }

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -98,7 +98,7 @@ describe("FitPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution]);
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
@@ -111,7 +111,7 @@ describe("FitPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("solutions")).toStrictEqual([]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([]);
 
         const plotData = wodinPlot.props("plotData");
         const data = plotData(0, 1, 100);

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -56,7 +56,7 @@ describe("RunPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
-        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution, mockAllFitData]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution, mockAllFitData]);
 
         // Generates expected plot data from model
         const plotData = wodinPlot.props("plotData");
@@ -115,7 +115,7 @@ describe("RunPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
-        expect(wodinPlot.props("solutions")).toStrictEqual([]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([]);
 
         const plotData = wodinPlot.props("plotData");
         const data = plotData(0, 1, 10);
@@ -186,7 +186,7 @@ describe("RunPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
-        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution, mockAllFitData]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution, mockAllFitData]);
 
         // Generates expected plot data from model
         const plotData = wodinPlot.props("plotData");

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -162,7 +162,7 @@ describe("RunPlot", () => {
                 },
                 run: {
                     endTime: 99,
-                    solution: mockSolution
+                    result: mockResult
                 }
             } as any,
             modules: {

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -14,6 +14,7 @@ describe("RunPlot", () => {
         x: [0, 1],
         y: [[3, 4], [5, 6]]
     });
+    const mockAllFitData = undefined;
 
     const paletteModel = {
         S: "#ff0000",
@@ -49,7 +50,7 @@ describe("RunPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
-        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution]);
+        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution, mockAllFitData]);
 
         // Generates expected plot data from model
         const plotData = wodinPlot.props("plotData");

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -7,6 +7,7 @@ import Vuex from "vuex";
 import RunPlot from "../../../../src/app/components/run/RunPlot.vue";
 import WodinOdePlot from "../../../../src/app/components/WodinOdePlot.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
+import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 
 describe("RunPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({
@@ -136,5 +137,92 @@ describe("RunPlot", () => {
         });
         const wodinPlot = wrapper.findComponent(WodinOdePlot);
         expect(wodinPlot.props("fadePlot")).toBe(true);
+    });
+
+    it("adds data when available", () => {
+        const mockFitData = [
+            { t: 0, v: 10 },
+            { t: 1, v: 20 },
+            { t: 2, v: 0 }
+        ];
+        const mockAllFitData = {
+            timeVariable: "t",
+            data: mockFitData,
+            linkedVariables: { v: "S" }
+        }
+        const store = new Vuex.Store<BasicState>({
+            state: {
+                model: {
+                    paletteModel
+                },
+                run: {
+                    endTime: 99,
+                    solution: mockSolution
+                }
+            } as any,
+            modules: {
+                fitData: {
+                    namespaced: true,
+                    getters: {
+                        [FitDataGetter.allData]: () => mockAllFitData
+                    }
+                }
+            }
+        });
+        const wrapper = shallowMount(RunPlot, {
+            props: {
+                fadePlot: false
+            },
+            global: {
+                plugins: [store]
+            }
+        });
+        const wodinPlot = wrapper.findComponent(WodinOdePlot);
+        expect(wodinPlot.props("fadePlot")).toBe(false);
+        expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
+        expect(wodinPlot.props("endTime")).toBe(99);
+        expect(wodinPlot.props("solutions")).toStrictEqual([mockSolution, mockAllFitData]);
+
+        // Generates expected plot data from model
+        const plotData = wodinPlot.props("plotData");
+        const data = plotData(0, 1, 10);
+        expect(data).toStrictEqual([
+            {
+                mode: "lines",
+                line: {
+                    color: "#ff0000",
+                    width: 2
+                },
+                name: "S",
+                x: [0, 1],
+                y: [3, 4],
+                showlegend: true,
+                legendgroup: undefined
+            },
+            {
+                mode: "lines",
+                line: {
+                    color: "#00ff00",
+                    width: 2
+                },
+                name: "I",
+                x: [0, 1],
+                y: [5, 6],
+                showlegend: true,
+                legendgroup: undefined
+            },
+            {
+                mode: "markers",
+                marker: {
+                    color: "#ff0000"
+                },
+                name: "v",
+                type: "scatter",
+                "x": [0, 1],
+                "y": [10, 20]
+            }
+        ]);
+
+        expect(mockSolution).toBeCalledWith(0, 1, 10);
     });
 });

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -15,7 +15,6 @@ describe("RunPlot", () => {
         x: [0, 1],
         y: [[3, 4], [5, 6]]
     });
-    const mockAllFitData = undefined;
 
     const paletteModel = {
         S: "#ff0000",
@@ -48,6 +47,7 @@ describe("RunPlot", () => {
             }
         });
         const wodinPlot = wrapper.findComponent(WodinOdePlot);
+        const mockAllFitData = undefined;
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
@@ -149,7 +149,7 @@ describe("RunPlot", () => {
             timeVariable: "t",
             data: mockFitData,
             linkedVariables: { v: "S" }
-        }
+        };
         const store = new Vuex.Store<BasicState>({
             state: {
                 model: {
@@ -218,8 +218,8 @@ describe("RunPlot", () => {
                 },
                 name: "v",
                 type: "scatter",
-                "x": [0, 1],
-                "y": [10, 20]
+                x: [0, 1],
+                y: [10, 20]
             }
         ]);
 

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -162,7 +162,7 @@ describe("SensitivityTracesPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Sensitivity has not been run.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("solutions")).toStrictEqual(mockSolutions);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual(mockSolutions);
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
@@ -176,7 +176,7 @@ describe("SensitivityTracesPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Sensitivity has not been run.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("solutions")).toStrictEqual([]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([]);
 
         const plotData = wodinPlot.props("plotData");
         const data = plotData(0, 1, 100);

--- a/app/static/tests/unit/components/wodinOdePlot.test.ts
+++ b/app/static/tests/unit/components/wodinOdePlot.test.ts
@@ -30,7 +30,7 @@ describe("WodinOdePlot", () => {
     const defaultProps = {
         fadePlot: false,
         endTime: 99,
-        solutions: [],
+        redrawWatches: [],
         plotData: mockPlotDataFn,
         placeholderMessage: "No data available"
     };
@@ -85,7 +85,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         const mockOn = mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
         expect(mockPlotDataFn.mock.calls[0][0]).toBe(0);
         expect(mockPlotDataFn.mock.calls[0][1]).toBe(99);
@@ -102,7 +102,7 @@ describe("WodinOdePlot", () => {
 
     it("does not draw run plot if base data is null", async () => {
         const wrapper = getWrapper();
-        wrapper.setProps({ solutions: [{} as any], plotData: () => null });
+        wrapper.setProps({ redrawWatches: [{} as any], plotData: () => null });
 
         await nextTick();
         expect(mockPlotlyNewPlot).not.toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         const relayoutEvent = {
@@ -147,7 +147,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         const relayoutEvent = {
@@ -169,7 +169,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         const relayoutEvent = {
@@ -189,7 +189,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         const relayoutEvent = {
@@ -209,7 +209,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         const divElement = wrapper.find("div.plot").element;
@@ -220,7 +220,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         (wrapper.vm as any).resize();
@@ -232,7 +232,7 @@ describe("WodinOdePlot", () => {
         const wrapper = getWrapper();
         mockPlotElementOn(wrapper);
 
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
 
         wrapper.unmount();
@@ -250,7 +250,7 @@ describe("WodinOdePlot", () => {
         expect(wrapper.find(".plot-placeholder").text()).toBe("No data available");
 
         mockPlotElementOn(wrapper);
-        wrapper.setProps({ solutions: [{} as any] });
+        wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
         expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
     });

--- a/app/static/tests/unit/palette.test.ts
+++ b/app/static/tests/unit/palette.test.ts
@@ -58,12 +58,11 @@ describe("create palettes", () => {
     });
 
     it("creates palettes for data", () => {
-        const pal = paletteData(["a", "b", "c", "d"]);
+        const pal = paletteData(["a", "b", "c"]);
         expect(pal).toEqual({
-            a: "#e41a1c",
-            b: "#377eb8",
-            c: "#4daf4a",
-            d: "#984ea3"
+            a: "#1c0a00",
+            b: "#603601",
+            c: "#cc9544"
         });
     });
 

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -1,4 +1,8 @@
-import { odinToPlotly } from "../../src/app/plot";
+import {
+    allFitDataToPlotly,
+    fitDataToPlotly,
+    odinToPlotly
+} from "../../src/app/plot";
 
 describe("odinToPlotly", () => {
     const palette = {
@@ -74,5 +78,130 @@ describe("odinToPlotly", () => {
                 showlegend: false
             }
         ]);
+    });
+});
+
+describe("allFitDataToPlotly", () => {
+    const palette = {
+        A: "#ff0000",
+        B: "#0000ff"
+    };
+    const data = [
+        { t: 0, a: 1, b: 2 },
+        { t: 1, a: 2, b: 4 },
+        { t: 2, a: 3, b: 6 },
+        { t: 3, a: 4, b: 8 },
+        { t: 4, a: 5, b: 10 }
+    ];
+    const allFitData = {
+        data,
+        linkedVariables: { a: null, b: null },
+        timeVariable: "t"
+    };
+
+    it("creates unlinked data", () => {
+        const res = allFitDataToPlotly(allFitData, palette, 0, 4);
+        expect(res).toStrictEqual([
+            {
+                marker: { color: "#e41a1c" }, // first data colour
+                mode: "markers",
+                name: "a",
+                type: "scatter",
+                x: [0, 1, 2, 3, 4],
+                y: [1, 2, 3, 4, 5]
+            },
+            {
+                marker: { color: "#377eb8" }, // second data colour
+                mode: "markers",
+                name: "b",
+                type: "scatter",
+                x: [0, 1, 2, 3, 4],
+                y: [2, 4, 6, 8, 10]
+            }
+        ]);
+    });
+
+    it("returns empty set if data missing", () => {
+        const res = allFitDataToPlotly(null, palette, 0, 4);
+        expect(res).toStrictEqual([]);
+    });
+
+    it("filters data by time", () => {
+        const res = allFitDataToPlotly(allFitData, palette, 1, 3);
+        expect(res).toStrictEqual([
+            {
+                marker: { color: "#e41a1c" },
+                mode: "markers",
+                name: "a",
+                type: "scatter",
+                x: [1, 2, 3],
+                y: [2, 3, 4]
+            },
+            {
+                marker: { color: "#377eb8" },
+                mode: "markers",
+                name: "b",
+                type: "scatter",
+                x: [1, 2, 3],
+                y: [4, 6, 8]
+            }
+        ]);
+    });
+
+    it("adds model colours where possible", () => {
+        const allFitDataLinked = {
+            data,
+            linkedVariables: { a: null, b: "B" },
+            timeVariable: "t"
+        };
+        const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4);
+        expect(res).toStrictEqual([
+            {
+                marker: { color: "#e41a1c" }, // first data colour
+                mode: "markers",
+                name: "a",
+                type: "scatter",
+                x: [0, 1, 2, 3, 4],
+                y: [1, 2, 3, 4, 5]
+            },
+            {
+                marker: { color: "#0000ff" }, // Model colour
+                mode: "markers",
+                name: "b",
+                type: "scatter",
+                x: [0, 1, 2, 3, 4],
+                y: [2, 4, 6, 8, 10]
+            }
+        ]);
+    });
+});
+
+describe("fitDataToPlotly", () => {
+    const palette = {
+        A: "#ff0000",
+        B: "#0000ff"
+    };
+    const data = [
+        { t: 0, a: 1, b: 2 },
+        { t: 1, a: 2, b: 4 },
+        { t: 2, a: 3, b: 6 },
+        { t: 3, a: 4, b: 8 },
+        { t: 4, a: 5, b: 10 }
+    ];
+    const link = {
+        time: "t",
+        data: "a",
+        model: "A"
+    };
+    it("creates series", () => {
+        const res = fitDataToPlotly(data, link, palette, 0, 4);
+        expect(res).toEqual([{
+            marker: { color: "#ff0000" },
+            mode: "markers",
+            name: "a",
+            type: "scatter",
+            x: [0, 1, 2, 3, 4],
+            y: [1, 2, 3, 4, 5]
+        }]);
     });
 });

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -103,7 +103,7 @@ describe("allFitDataToPlotly", () => {
         const res = allFitDataToPlotly(allFitData, palette, 0, 4);
         expect(res).toStrictEqual([
             {
-                marker: { color: "#e41a1c" }, // first data colour
+                marker: { color: "#1c0a00" }, // first data colour
                 mode: "markers",
                 name: "a",
                 type: "scatter",
@@ -111,7 +111,7 @@ describe("allFitDataToPlotly", () => {
                 y: [1, 2, 3, 4, 5]
             },
             {
-                marker: { color: "#377eb8" }, // second data colour
+                marker: { color: "#603601" }, // second data colour
                 mode: "markers",
                 name: "b",
                 type: "scatter",
@@ -130,7 +130,7 @@ describe("allFitDataToPlotly", () => {
         const res = allFitDataToPlotly(allFitData, palette, 1, 3);
         expect(res).toStrictEqual([
             {
-                marker: { color: "#e41a1c" },
+                marker: { color: "#1c0a00" },
                 mode: "markers",
                 name: "a",
                 type: "scatter",
@@ -138,7 +138,7 @@ describe("allFitDataToPlotly", () => {
                 y: [2, 3, 4]
             },
             {
-                marker: { color: "#377eb8" },
+                marker: { color: "#603601" },
                 mode: "markers",
                 name: "b",
                 type: "scatter",
@@ -157,7 +157,7 @@ describe("allFitDataToPlotly", () => {
         const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4);
         expect(res).toStrictEqual([
             {
-                marker: { color: "#e41a1c" }, // first data colour
+                marker: { color: "#1c0a00" }, // first data colour
                 mode: "markers",
                 name: "a",
                 type: "scatter",

--- a/app/static/tests/unit/store/fitData/getters.test.ts
+++ b/app/static/tests/unit/store/fitData/getters.test.ts
@@ -46,4 +46,38 @@ describe("FitDataGetters", () => {
         const state = mockFitDataState();
         expect((getters[FitDataGetter.link] as any)(state)).toBe(null);
     });
+
+    it("gets model data where possible", () => {
+        const allData = {
+            timeVariable: "t",
+            data: [
+                { t: 0, v: 10 },
+                { t: 1, v: 20 },
+                { t: 2, v: 0 }
+            ],
+            linkedVariables: {}
+        };
+
+        const state = mockFitDataState(allData);
+        expect((getters[FitDataGetter.allData] as any)(state)).toStrictEqual(allData);
+    });
+
+    it("model data is null when uninitialised", () => {
+        const state = mockFitDataState();
+        expect((getters[FitDataGetter.allData] as any)(state)).toBe(null);
+    });
+
+    it("gets model data where partially initialised", () => {
+        const allData = {
+            data: [
+                { t: 0, v: 10 },
+                { t: 1, v: 20 },
+                { t: 2, v: 0 }
+            ],
+            linkedVariables: {}
+        };
+
+        const state = mockFitDataState(allData);
+        expect((getters[FitDataGetter.allData] as any)(state)).toBe(null);
+    });
 });


### PR DESCRIPTION
This PR adds data to the run plot if available. Things to note:

* this works in both the basic app (with no data) and the fit app, though some of that is just because of the way that truthiness cascades through (there's no checking to make sure that we should try (or not) and look for this in the basic app for example). I think that this is the same with other apps
* I've added the fit data to the solutions array to trigger a redraw. This works well on upload; after uploading data the plot is redrawn with the data points on it
* the colouring logic for the data is: unlinked data use our built-in data palette, but any linked data take on the colour of the series that they are linked to
* Changing the linked series does not trigger a redraw, rerunning the model does show the new colours correctly though
* There's a plotly issue that I'd like to try and fix on a different ticket where the addition of points that include an x of 0 makes plotly add some additional space to the left of 0, which is a little visually jarring. we have this problem already actually, but it's less apparent when you change tabs