### PR TITLE
mrc-3526 Save Session Ids to local storage

### DIFF
--- a/app/static/src/app/localStorageManager.ts
+++ b/app/static/src/app/localStorageManager.ts
@@ -1,0 +1,16 @@
+class LocalStorageManager {
+    static sessionIdsKey = "sessionIds";
+
+    getSessionIds = (): string[] => {
+        const serialised = window.localStorage.getItem(LocalStorageManager.sessionIdsKey);
+        return (serialised ? JSON.parse(serialised) : []) as string[];
+    }
+
+    addSessionId = (sessionId: string) => {
+        const sessionIds = this.getSessionIds();
+        sessionIds.push(sessionId);
+        window.localStorage.setItem(LocalStorageManager.sessionIdsKey, JSON.stringify(sessionIds));
+    }
+}
+
+export const localStorageManager = new LocalStorageManager();

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -10,7 +10,7 @@ import { sensitivity } from "../sensitivity/sensitivity";
 import { logMutations } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
-import {localStorageManager} from "../../localStorageManager";
+import { localStorageManager } from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -10,6 +10,7 @@ import { sensitivity } from "../sensitivity/sensitivity";
 import { logMutations } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
+import {localStorageManager} from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
@@ -37,3 +38,5 @@ export const storeOptions: StoreOptions<BasicState> = {
         logMutations
     ]
 };
+
+localStorageManager.addSessionId((storeOptions.state as BasicState).sessionId);

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -12,6 +12,7 @@ import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
 import { logMutations } from "../plugins";
 import { newSessionId } from "../../utils";
+import {localStorageManager} from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
@@ -41,3 +42,5 @@ export const storeOptions: StoreOptions<FitState> = {
         logMutations
     ]
 };
+
+localStorageManager.addSessionId((storeOptions.state as FitState).sessionId);

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -12,7 +12,7 @@ import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
 import { logMutations } from "../plugins";
 import { newSessionId } from "../../utils";
-import {localStorageManager} from "../../localStorageManager";
+import { localStorageManager } from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -9,7 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
-import {localStorageManager} from "../../localStorageManager";
+import { localStorageManager } from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -9,6 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
+import {localStorageManager} from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
@@ -33,3 +34,5 @@ export const storeOptions: StoreOptions<StochasticState> = {
         sensitivity
     }
 };
+
+localStorageManager.addSessionId((storeOptions.state as StochasticState).sessionId);

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -1,0 +1,25 @@
+import { localStorageManager } from "../../src/app/localStorageManager";
+
+describe("localStorageManager", () => {
+    const spyOnGetItem = jest.spyOn(Storage.prototype, "getItem").mockReturnValue("[\"session1\", \"session2\"]");
+    const spyOnSetItem = jest.spyOn(Storage.prototype, "setItem");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("can get session ids", () => {
+        const sessionIds = localStorageManager.getSessionIds();
+        expect(sessionIds).toStrictEqual(["session1", "session2"]);
+        expect(spyOnGetItem).toHaveBeenCalledTimes(1);
+        expect(spyOnGetItem.mock.calls[0][0]).toBe("sessionIds");
+    });
+
+    it("can add session id", () => {
+        localStorageManager.addSessionId("session3");
+        expect(spyOnGetItem).toHaveBeenCalledTimes(1);
+        expect(spyOnSetItem).toHaveBeenCalledTimes(1);
+        expect(spyOnSetItem.mock.calls[0][0]).toBe("sessionIds");
+        expect(spyOnSetItem.mock.calls[0][1]).toBe(JSON.stringify(["session1", "session2", "session3"]));
+    });
+});

--- a/app/static/tests/unit/store/basic/basic.test.ts
+++ b/app/static/tests/unit/store/basic/basic.test.ts
@@ -1,15 +1,17 @@
+import { localStorageManager } from "../../../../src/app/localStorageManager";
+
 jest.mock("../../../../src/app/utils", () => {
     return {
         newSessionId: jest.fn().mockReturnValue("12345")
     };
 });
-
-/* eslint-disable import/first */
-import { storeOptions } from "../../../../src/app/store/basic/basic";
+const spyAddSessionId = jest.spyOn(localStorageManager, "addSessionId");
 
 describe("basic", () => {
-    it("generates session id as expected", () => {
+    it("generates and saves sessionId", async () => {
+        const { storeOptions } = await import("../../../../src/app/store/basic/basic");
         const state = storeOptions.state as any;
         expect(state.sessionId).toBe("12345");
+        expect(spyAddSessionId).toHaveBeenCalledWith("12345");
     });
 });

--- a/app/static/tests/unit/store/fit/fit.test.ts
+++ b/app/static/tests/unit/store/fit/fit.test.ts
@@ -1,15 +1,17 @@
+import { localStorageManager } from "../../../../src/app/localStorageManager";
+
 jest.mock("../../../../src/app/utils", () => {
     return {
         newSessionId: jest.fn().mockReturnValue("12345")
     };
 });
-
-/* eslint-disable import/first */
-import { storeOptions } from "../../../../src/app/store/fit/fit";
+const spyAddSessionId = jest.spyOn(localStorageManager, "addSessionId");
 
 describe("fit", () => {
-    it("generates session id as expected", () => {
+    it("generates and saves sessionId", async () => {
+        const { storeOptions } = await import("../../../../src/app/store/fit/fit");
         const state = storeOptions.state as any;
         expect(state.sessionId).toBe("12345");
+        expect(spyAddSessionId).toHaveBeenCalledWith("12345");
     });
 });

--- a/app/static/tests/unit/store/stochastic/stochastic.test.ts
+++ b/app/static/tests/unit/store/stochastic/stochastic.test.ts
@@ -1,15 +1,17 @@
+import { localStorageManager } from "../../../../src/app/localStorageManager";
+
 jest.mock("../../../../src/app/utils", () => {
     return {
         newSessionId: jest.fn().mockReturnValue("12345")
     };
 });
+const spyAddSessionId = jest.spyOn(localStorageManager, "addSessionId");
 
-/* eslint-disable import/first */
-import { storeOptions } from "../../../../src/app/store/stochastic/stochastic";
-
-describe("stochastic", () => {
-    it("generates session id as expected", () => {
+describe("basic", () => {
+    it("generates and saves sessionId", async () => {
+        const { storeOptions } = await import("../../../../src/app/store/stochastic/stochastic");
         const state = storeOptions.state as any;
         expect(state.sessionId).toBe("12345");
+        expect(spyAddSessionId).toHaveBeenCalledWith("12345");
     });
 });


### PR DESCRIPTION
This branch adds a `localStorageManager` and uses it to save the ids of new sessions into local storage. All historic session ids are kept as a serialised string array under a single key, `sessionIds`. 

To spy on this class in order to unit test its usage from the top level store modules, I seemed to need to do a dynamic import in the test, or the store modules would be loaded and the save triggered before the spy could be set up. 

To test, load the app, and check local storage in browser devtools (Application tab). You should see a new id added to the `sessionIds` key on each reload. 