### PR TITLE
In the fit app, take end time from data when available

### DIFF
--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -5,9 +5,12 @@
         <label class="col-form-label">End time</label>
       </div>
       <div class="col-6">
-        <numeric-input :value="endTime"
+        <numeric-input
+                       v-if="endTimeData === 0"
+                       :value="endTime"
                        :allow-negative="false"
                        @update="updateEndTime"></numeric-input>
+        <label v-if="endTimeData > 0" class="col-form-label">{{ endTimeData }} (from data)</label>
       </div>
     </div>
   </div>
@@ -18,6 +21,7 @@ import { defineComponent, computed } from "vue";
 import { useStore } from "vuex";
 import { RunMutation } from "../../store/run/mutations";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
+import { FitDataGetter } from "../../store/fitData/getters";
 import NumericInput from "./NumericInput.vue";
 
 export default defineComponent({
@@ -27,6 +31,7 @@ export default defineComponent({
     },
     setup() {
         const store = useStore();
+        const endTimeData = computed(() => store.getters[`fitData/${FitDataGetter.dataEnd}`]);
         const endTime = computed(() => store.state.run.endTime);
 
         const updateEndTime = (newValue: number) => {
@@ -36,6 +41,7 @@ export default defineComponent({
 
         return {
             endTime,
+            endTimeData,
             updateEndTime
         };
     }

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -10,7 +10,7 @@
                        :value="endTime"
                        :allow-negative="false"
                        @update="updateEndTime"></numeric-input>
-        <label v-if="endTimeData > 0" class="col-form-label">{{ endTimeData }} (from data)</label>
+        <label v-else class="col-form-label">{{ endTimeData }} (from data)</label>
       </div>
     </div>
   </div>

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -31,7 +31,12 @@ export default defineComponent({
     },
     setup() {
         const store = useStore();
-        const endTimeData = computed(() => store.getters[`fitData/${FitDataGetter.dataEnd}`]);
+        const endTimeData = computed(() => {
+            // The fitData getter won't be defined in the basic app,
+            // so make sure that we return something sensible.
+            const dataEnd = store.getters[`fitData/${FitDataGetter.dataEnd}`];
+            return dataEnd === undefined ? 0 : dataEnd;
+        });
         const endTime = computed(() => store.state.run.endTime);
 
         const updateEndTime = (newValue: number) => {

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -38,21 +38,18 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
 };
 
 const updateTimeVariable = (context: ActionContext<FitDataState, FitState>) => {
-    const {
-        commit, state, rootState, getters
-    } = context;
+    const { commit, state } = context;
     const { timeVariable, data } = state;
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
-        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true});
+        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
     }
-}
+};
 
 export const actions: ActionTree<FitDataState, FitState> = {
     [FitDataAction.Upload](context, file) {
-        const { commit } = context;
         csvUpload(context)
             .withSuccess(FitDataMutation.SetData)
             .withError(FitDataMutation.SetError)
@@ -64,7 +61,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
     },
 
     [FitDataAction.UpdateTimeVariable](context, timeVariable) {
-        const { commit, state } = context;
+        const { commit } = context;
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
         updateTimeVariable(context);

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -37,13 +37,14 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     commit(FitDataMutation.SetLinkedVariables, newLinks);
 };
 
-const updateTimeVariable = (context: ActionContext<FitDataState, FitState>) => {
+// Runs after a change to the time variable, updating things that depend on it
+const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitState>) => {
     const { commit, state } = context;
     const { timeVariable, data } = state;
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root true });
         commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
     }
 };
@@ -55,7 +56,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
             .withError(FitDataMutation.SetError)
             .then(() => {
                 updateLinkedVariables(context);
-                updateTimeVariable(context);
+                respondUpdatedTimeVariable(context);
             })
             .upload(file);
     },
@@ -64,7 +65,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
         const { commit } = context;
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
-        updateTimeVariable(context);
+        respondUpdatedTimeVariable(context);
     },
 
     [FitDataAction.UpdateLinkedVariables](context) {

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -44,7 +44,7 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
         commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
     }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -35,6 +35,7 @@ export const mutations: MutationTree<RunState> = {
 
     [RunMutation.SetEndTime](state: RunState, payload: number) {
         state.endTime = payload;
-        state.runRequired = true;
+        const prevEndTime = state.result?.inputs?.endTime ? state.result.inputs.endTime : -1;
+        state.runRequired = payload > prevEndTime;
     }
 };

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -7,7 +7,7 @@ import NumericInput from "../../../../src/app/components/options/NumericInput.vu
 
 describe("RunOptions", () => {
     const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn(),
-                        mockDataEnd = 0) => {
+        mockDataEnd = 0) => {
         const store = new Vuex.Store<BasicState>({
             state: {} as any,
             modules: {

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -7,32 +7,35 @@ import NumericInput from "../../../../src/app/components/options/NumericInput.vu
 
 describe("RunOptions", () => {
     const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn(),
-        mockDataEnd = 0) => {
-        const store = new Vuex.Store<BasicState>({
-            state: {} as any,
-            modules: {
-                run: {
-                    namespaced: true,
-                    state: {
-                        endTime: 99
-                    },
-                    mutations: {
-                        SetEndTime: mockSetEndTime
-                    }
+        mockDataEnd: number | null = 0) => {
+        const modules = {
+            run: {
+                namespaced: true,
+                state: {
+                    endTime: 99
                 },
-                fitData: {
-                    namespaced: true,
-                    getters: {
-                        [FitDataGetter.dataEnd]: () => mockDataEnd
-                    }
-                },
-                sensitivity: {
-                    namespaced: true,
-                    mutations: {
-                        SetUpdateRequired: mockSetSensitivityUpdateRequired
-                    }
+                mutations: {
+                    SetEndTime: mockSetEndTime
+                }
+            },
+            sensitivity: {
+                namespaced: true,
+                mutations: {
+                    SetUpdateRequired: mockSetSensitivityUpdateRequired
                 }
             }
+        } as any;
+        if (mockDataEnd !== null) {
+            modules.fitData = {
+                namespaced: true,
+                getters: {
+                    [FitDataGetter.dataEnd]: () => mockDataEnd
+                }
+            };
+        }
+        const store = new Vuex.Store<BasicState>({
+            state: {} as any,
+            modules
         });
         return shallowMount(RunOptions, {
             global: {
@@ -55,6 +58,14 @@ describe("RunOptions", () => {
         expect(labels.length).toBe(2);
         expect(labels[0].text()).toBe("End time");
         expect(labels[1].text()).toBe("10 (from data)");
+    });
+
+    it("renders as expected when no fitData module present", () => {
+        const wrapper = getWrapper(jest.fn(), jest.fn(), null);
+        expect(wrapper.find("label").text()).toBe("End time");
+        const input = wrapper.findComponent(NumericInput);
+        expect(input.props("value")).toBe(99);
+        expect(input.props("allowNegative")).toBe(false);
     });
 
     it("commits end time change", () => {

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -1,11 +1,13 @@
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import { BasicState } from "../../../../src/app/store/basic/state";
+import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
 describe("RunOptions", () => {
-    const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn()) => {
+    const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn(),
+                        mockDataEnd = 0) => {
         const store = new Vuex.Store<BasicState>({
             state: {} as any,
             modules: {
@@ -16,6 +18,12 @@ describe("RunOptions", () => {
                     },
                     mutations: {
                         SetEndTime: mockSetEndTime
+                    }
+                },
+                fitData: {
+                    namespaced: true,
+                    getters: {
+                        [FitDataGetter.dataEnd]: () => mockDataEnd
                     }
                 },
                 sensitivity: {
@@ -33,12 +41,20 @@ describe("RunOptions", () => {
         });
     };
 
-    it("renders as expected", () => {
+    it("renders as expected when no data present", () => {
         const wrapper = getWrapper();
         expect(wrapper.find("label").text()).toBe("End time");
         const input = wrapper.findComponent(NumericInput);
         expect(input.props("value")).toBe(99);
         expect(input.props("allowNegative")).toBe(false);
+    });
+
+    it("renders as expected when data present", () => {
+        const wrapper = getWrapper(jest.fn(), jest.fn(), 10);
+        const labels = wrapper.findAll("label");
+        expect(labels.length).toBe(2);
+        expect(labels[0].text()).toBe("End time");
+        expect(labels[1].text()).toBe("10 (from data)");
     });
 
     it("commits end time change", () => {

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -78,7 +78,7 @@ describe("Fit Data actions", () => {
             const expectedSetDataPayload = {
                 data: mockData,
                 columns: ["a", "b"],
-                timeVariableCandidates: ["a"],
+                timeVariableCandidates: ["a"]
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedSetDataPayload);
             expect(commit.mock.calls[1][0]).toBe(FitDataMutation.SetLinkedVariables);

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -4,6 +4,8 @@ import resetAllMocks = jest.resetAllMocks;
 import { mockFitDataState } from "../../../mocks";
 import { fileTimeout } from "../../../testUtils";
 import { ModelFitMutation } from "../../../../src/app/store/modelFit/mutations";
+import { RunMutation } from "../../../../src/app/store/run/mutations";
+import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 
 describe("Fit Data actions", () => {
     const file = { name: "testFile" } as any;
@@ -34,7 +36,7 @@ describe("Fit Data actions", () => {
     };
 
     it("Upload commits data and updates linked variables on success", (done) => {
-        const mockFileReader = getMockFileReader("a,b\n1,2\n3,4\n5,6\n7,8\n9,10");
+        const mockFileReader = getMockFileReader("a,b\n1,2\n3,4\n5,6\n7,8\n9,1");
         const mockGetters = {
             nonTimeColumns: ["a"]
         };
@@ -48,8 +50,17 @@ describe("Fit Data actions", () => {
                 }
             }
         };
+        const mockData = [
+            { a: 1, b: 2 },
+            { a: 3, b: 4 },
+            { a: 5, b: 6 },
+            { a: 7, b: 8 },
+            { a: 9, b: 1 }
+        ];
         const mockState = {
-            linkedVariables: { a: "X", b: "Y" }
+            linkedVariables: { a: "X", b: "Y" },
+            data: mockData,
+            timeVariable: "a"
         };
 
         const commit = jest.fn();
@@ -62,25 +73,25 @@ describe("Fit Data actions", () => {
         (actions[FitDataAction.Upload] as any)(context, file);
         expectFileRead(mockFileReader);
         setTimeout(() => {
-            expect(commit).toHaveBeenCalledTimes(3);
+            expect(commit).toHaveBeenCalledTimes(5);
             expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetData);
             const expectedSetDataPayload = {
-                data: [
-                    { a: 1, b: 2 },
-                    { a: 3, b: 4 },
-                    { a: 5, b: 6 },
-                    { a: 7, b: 8 },
-                    { a: 9, b: 10 }
-                ],
+                data: mockData,
                 columns: ["a", "b"],
-                timeVariableCandidates: ["a", "b"]
+                timeVariableCandidates: ["a"],
             };
             expect(commit.mock.calls[0][1]).toStrictEqual(expectedSetDataPayload);
             expect(commit.mock.calls[1][0]).toBe(FitDataMutation.SetLinkedVariables);
             expect(commit.mock.calls[1][1]).toStrictEqual({ a: "X" });
-            expect(commit.mock.calls[2][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-            expect(commit.mock.calls[2][1]).toBe(true);
+            expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetEndTime}`);
+            expect(commit.mock.calls[2][1]).toBe(9);
             expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
+            expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
+            expect(commit.mock.calls[3][1]).toBe(true);
+            expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
+            expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
+            expect(commit.mock.calls[4][1]).toBe(true);
+            expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
             done();
         }, fileTimeout);
     });
@@ -216,13 +227,22 @@ describe("Fit Data actions", () => {
     });
 
     it("Update time variable commits new time variable and updates linked variables", () => {
+        const mockData = [
+            { Day1: 1, Day2: 2, Cases: 10 },
+            { Day1: 3, Day2: 4, Cases: 11 },
+            { Day1: 5, Day2: 6, Cases: 12 },
+            { Day1: 7, Day2: 8, Cases: 13 },
+            { Day1: 9, Day2: 10, Cases: 14 }
+        ];
+
         const testState = {
-            timeVariable: "Day1",
+            timeVariable: "Day2",
             columns: ["Day1", "Day2", "Cases"],
             linkedVariables: {
                 Day2: "A",
                 Cases: "B"
-            }
+            },
+            data: mockData
         };
 
         const rootState = {
@@ -249,14 +269,20 @@ describe("Fit Data actions", () => {
         (actions[FitDataAction.UpdateTimeVariable] as any)({
             commit, state: testState, rootState, getters: testGetters
         }, "Day2");
-        expect(commit).toHaveBeenCalledTimes(3);
+        expect(commit).toHaveBeenCalledTimes(5);
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetTimeVariable);
         expect(commit.mock.calls[0][1]).toBe("Day2");
         expect(commit.mock.calls[1][0]).toBe(FitDataMutation.SetLinkedVariables);
         expect(commit.mock.calls[1][1]).toStrictEqual({ Day1: null, Cases: "B" });
-        expect(commit.mock.calls[2][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[2][1]).toBe(true);
+        expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetEndTime}`);
+        expect(commit.mock.calls[2][1]).toBe(10);
         expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
+        expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
+        expect(commit.mock.calls[3][1]).toBe(true);
+        expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
+        expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
+        expect(commit.mock.calls[4][1]).toBe(true);
+        expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
     });
 
     it("UpdateLinkedVariable sets link and sets fitUpdate required if column is columnToFit", () => {

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -50,6 +50,30 @@ describe("Run mutations", () => {
         expect(state.runRequired).toBe(true);
     });
 
+    it("sets end time does not require run if it shrinks", () => {
+        const state = mockRunState({
+            endTime: 100,
+            runRequired: false,
+            result: {
+                inputs: {
+                    endTime: 100
+                }
+            } as any
+        });
+        // shrinking is fine
+        mutations.SetEndTime(state, 50);
+        expect(state.endTime).toBe(50);
+        expect(state.runRequired).toBe(false);
+        // increasing, even right up to the original limit, is fine
+        mutations.SetEndTime(state, 100);
+        expect(state.endTime).toBe(100);
+        expect(state.runRequired).toBe(false);
+        // but any additional time requires a rerun
+        mutations.SetEndTime(state, 101);
+        expect(state.endTime).toBe(101);
+        expect(state.runRequired).toBe(true);
+    });
+
     it("sets odinRunnerResponseError", () => {
         const state = mockRunState();
         const result = {


### PR DESCRIPTION
This PR makes the wodin interface match the existing shiny behaviour of taking the run end time from the data when possible. It's better than the shiny version though because you can run the model before uploading data.

Once data has been uploaded, end time becomes non-editable - I've changed it to a label but can do something else if there's another pattern. I made the label have "(from data)" added to it so that it's somewhat obvious where that number comes from

This PR also fixes mrc-3543 (don't rerun model if end time shrinks). Now that we have inputs it's pretty easy because we can just see if endTime is greater than the original endTime - if it's not then there's no need to rerun anything because we already have the solution to acceptable accuracy over that range.