### PR TITLE
mrc-3470: More actionable error messages if fit impossible

### DIFF
--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -32,6 +32,7 @@ import { ModelFitGetter, fitRequirementsExplanation } from "../../store/modelFit
 import userMessages from "../../userMessages";
 import LoadingSpinner from "../LoadingSpinner.vue";
 import { ModelFitMutation } from "../../store/modelFit/mutations";
+import { allTrue } from "../../utils";
 
 export default {
     name: "FitTab",
@@ -45,11 +46,12 @@ export default {
         const store = useStore();
         const namespace = "modelFit";
 
-        const canFitModel = computed(() => store.getters[`${namespace}/${ModelFitGetter.canRunFit}`]);
+        const fitRequirements = computed(() => store.getters[`${namespace}/${ModelFitGetter.fitRequirements}`]);
+        const canFitModel = computed(() => allTrue(fitRequirements.value));
         const compileRequired = computed(() => store.state.model.compileRequired);
         const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
-        const fitRequirements = computed(() => store.getters[`${namespace}/${ModelFitGetter.fitRequirements}`]);
+
         const cancelFit = () => store.commit(`${namespace}/${ModelFitMutation.SetFitting}`, false);
 
         const iterations = computed(() => store.state.modelFit.iterations);
@@ -59,7 +61,7 @@ export default {
         const sumOfSquares = computed(() => store.state.modelFit.sumOfSquares);
 
         const actionRequiredMessage = computed(() => {
-            if (!fitRequirements.value.hasEverything) {
+            if (!allTrue(fitRequirements.value)) {
                 return fitRequirementsExplanation(fitRequirements.value);
             }
             if (compileRequired.value) {

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -28,7 +28,7 @@ import VueFeather from "vue-feather";
 import FitPlot from "./FitPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { ModelFitAction } from "../../store/modelFit/actions";
-import { ModelFitGetter } from "../../store/modelFit/getters";
+import { ModelFitGetter, fitRequirementsExplanation } from "../../store/modelFit/getters";
 import userMessages from "../../userMessages";
 import LoadingSpinner from "../LoadingSpinner.vue";
 import { ModelFitMutation } from "../../store/modelFit/mutations";
@@ -49,6 +49,7 @@ export default {
         const compileRequired = computed(() => store.state.model.compileRequired);
         const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
+        const fitRequirements = computed(() => store.getters[`${namespace}/${ModelFitGetter.fitRequirements}`]);
         const cancelFit = () => store.commit(`${namespace}/${ModelFitMutation.SetFitting}`, false);
 
         const iterations = computed(() => store.state.modelFit.iterations);
@@ -58,8 +59,8 @@ export default {
         const sumOfSquares = computed(() => store.state.modelFit.sumOfSquares);
 
         const actionRequiredMessage = computed(() => {
-            if (!canFitModel.value) {
-                return userMessages.modelFit.cannotFit;
+            if (!fitRequirements.value.hasEverything) {
+                return fitRequirementsExplanation(fitRequirements.value);
             }
             if (compileRequired.value) {
                 return userMessages.modelFit.compileRequired;

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -28,10 +28,11 @@ import VueFeather from "vue-feather";
 import FitPlot from "./FitPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { ModelFitAction } from "../../store/modelFit/actions";
-import { ModelFitGetter, fitRequirementsExplanation } from "../../store/modelFit/getters";
+import { ModelFitGetter } from "../../store/modelFit/getters";
 import userMessages from "../../userMessages";
 import LoadingSpinner from "../LoadingSpinner.vue";
 import { ModelFitMutation } from "../../store/modelFit/mutations";
+import { fitRequirementsExplanation } from "./support";
 import { allTrue } from "../../utils";
 
 export default {

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -1,0 +1,31 @@
+import { ModelFitRequirements } from "../../store/modelFit/state";
+import userMessages from "../../userMessages";
+import { joinStringsSentence } from "../../utils";
+
+export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
+    const reasons: string[] = [];
+    const appendIf = (test: boolean, value: string) => {
+        if (test) {
+            reasons.push(value);
+        }
+    };
+    const help = userMessages.modelFit.fitRequirements;
+    appendIf(!reqs.hasModel, help.needsModel);
+    appendIf(!reqs.hasData, help.needsData);
+    // Can only tell the user to set a time variable if we have data
+    appendIf(reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
+    // Can only tell the user to link variables if they have model and data
+    appendIf(reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
+    // Can only tell the user to set a target if we have all of the
+    // above (checking hasLinkedVariables is sufficient)
+    appendIf(reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
+    // Can only tell the user to change parameters if we have a
+    // model. This shold be announced last as it's on the tab they are
+    // looking at
+    appendIf(reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
+
+    // Fallback reason if something unexpected has happened.
+    appendIf(reasons.length === 0, help.unknown);
+
+    return `${help.prefix} ${joinStringsSentence(reasons)}.`;
+};

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -5,6 +5,7 @@ import { ModelFitMutation } from "./mutations";
 import { RunMutation } from "../run/mutations";
 import { ModelFitGetter } from "./getters";
 import { FitDataGetter } from "../fitData/getters";
+import { allTrue } from "../../utils";
 
 export enum ModelFitAction {
     FitModel = "FitModel",
@@ -18,7 +19,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             commit, dispatch, state, rootState, getters, rootGetters
         } = context;
 
-        if (getters[ModelFitGetter.canRunFit]) { // todo fix this to use hasEverything
+        if (allTrue(getters[ModelFitGetter.fitRequirements])) {
             commit(ModelFitMutation.SetFitting, true);
 
             const { odin, odinRunner } = rootState.model;

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -18,7 +18,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             commit, dispatch, state, rootState, getters, rootGetters
         } = context;
 
-        if (getters[ModelFitGetter.canRunFit]) {
+        if (getters[ModelFitGetter.canRunFit]) { // todo fix this to use hasEverything
             commit(ModelFitMutation.SetFitting, true);
 
             const { odin, odinRunner } = rootState.model;

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -12,38 +12,6 @@ export interface ModelFitGetters {
     [ModelFitGetter.fitRequirements]: Getter<ModelFitState, FitState>
 }
 
-// I've put this here for want of a better place. Within userMessages
-// feels possible but that would break the default import. Putting it
-// directly in the component makes testing feel much harder. There are
-// tests within getters.test.ts that need moving if this moves.
-export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
-    const reasons: string[] = [];
-    const appendIf = (test: boolean, value: string) => {
-        if (test) {
-            reasons.push(value);
-        }
-    };
-    const help = userMessages.modelFit.fitRequirements;
-    appendIf(!reqs.hasModel, help.needsModel);
-    appendIf(!reqs.hasData, help.needsData);
-    // Can only tell the user to set a time variable if we have data
-    appendIf(reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
-    // Can only tell the user to link variables if they have model and data
-    appendIf(reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
-    // Can only tell the user to set a target if we have all of the
-    // above (checking hasLinkedVariables is sufficient)
-    appendIf(reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
-    // Can only tell the user to change parameters if we have a
-    // model. This shold be announced last as it's on the tab they are
-    // looking at
-    appendIf(reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
-
-    // Fallback reason if something unexpected has happened.
-    appendIf(reasons.length === 0, help.unknown);
-
-    return `${help.prefix} ${joinStringsSentence(reasons)}.`;
-};
-
 export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
     [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters,
         rootState: FitState): ModelFitRequirements => {

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -13,7 +13,9 @@ export interface ModelFitGetters {
 }
 
 // I've put this here for want of a better place. Within userMessages
-// feels possible but that would break the default import.
+// feels possible but that would break the default import. Putting it
+// directly in the component makes testing feel much harder. There are
+// tests within getters.test.ts that need moving if this moves.
 export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
     const reasons: string[] = [];
     const appendIf = (test: boolean, value: string) => {
@@ -33,6 +35,9 @@ export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string =
     // model. This shold be announced last as it's on the tab they are
     // looking at
     appendIf(reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
+
+    // Fallback reason if something unexpected has happened.
+    appendIf(reasons.length === 0, help.unknown);
 
     return `${help.prefix} ${joinStringsSentence(reasons)}.`;
 };

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -28,9 +28,11 @@ export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string =
     appendIf(!reqs.hasData, help.needsData);
     // Can only tell the user to set a time variable if we have data
     appendIf(reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
-    // Can only tell the user to set a target if we have both a model
-    // and data
-    appendIf(reqs.hasModel && reqs.hasData && !reqs.hasTarget, help.needsTarget);
+    // Can only tell the user to link variables if they have model and data
+    appendIf(reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
+    // Can only tell the user to set a target if we have all of the
+    // above (checking hasLinkedVariables is sufficient)
+    appendIf(reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
     // Can only tell the user to change parameters if we have a
     // model. This shold be announced last as it's on the tab they are
     // looking at
@@ -45,10 +47,14 @@ export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string =
 export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
     [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters,
         rootState: FitState): ModelFitRequirements => {
+        const linkedVariables = rootState.fitData?.linkedVariables;
+        const hasLinkedVariables = linkedVariables !== null &&
+            Object.values(linkedVariables).some((el: string | null) => el !== null);
         const checklist = {
             hasModel: !!rootState.model.odin,
             hasData: !!rootState.fitData.data,
             hasTimeVariable: !!rootState.fitData.timeVariable,
+            hasLinkedVariables,
             hasTarget: !!rootState.fitData.columnToFit,
             hasParamsToVary: !!state.paramsToVary.length
         };

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -1,8 +1,6 @@
 import { Getter, GetterTree } from "vuex";
 import { ModelFitState, ModelFitRequirements } from "./state";
 import { FitState } from "../fit/state";
-import userMessages from "../../userMessages";
-import { joinStringsSentence } from "../../utils";
 
 export enum ModelFitGetter {
     fitRequirements = "fitRequirements"
@@ -16,8 +14,8 @@ export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
     [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters,
         rootState: FitState): ModelFitRequirements => {
         const linkedVariables = rootState.fitData?.linkedVariables;
-        const hasLinkedVariables = linkedVariables !== null &&
-            Object.values(linkedVariables).some((el: string | null) => el !== null);
+        const hasLinkedVariables = linkedVariables !== null
+            && Object.values(linkedVariables).some((el: string | null) => el !== null);
         const checklist = {
             hasModel: !!rootState.model.odin,
             hasData: !!rootState.fitData.data,

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -20,7 +20,7 @@ export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string =
         if (test) {
             reasons.push(value);
         }
-    }
+    };
     const help = userMessages.modelFit.fitRequirements;
     appendIf(!reqs.hasModel, help.needsModel);
     appendIf(!reqs.hasData, help.needsData);
@@ -35,10 +35,11 @@ export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string =
     appendIf(reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
 
     return `${help.prefix} ${joinStringsSentence(reasons)}.`;
-}
+};
 
 export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
-    [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters, rootState: FitState): ModelFitRequirements => {
+    [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters,
+        rootState: FitState): ModelFitRequirements => {
         const checklist = {
             hasModel: !!rootState.model.odin,
             hasData: !!rootState.fitData.data,

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -1,18 +1,53 @@
 import { Getter, GetterTree } from "vuex";
-import { ModelFitState } from "./state";
+import { ModelFitState, ModelFitRequirements } from "./state";
 import { FitState } from "../fit/state";
+import userMessages from "../../userMessages";
+import { joinStringsSentence } from "../../utils";
 
 export enum ModelFitGetter {
-    canRunFit = "canRunFit"
+    canRunFit = "canRunFit",
+    fitRequirements = "fitRequirements"
 }
 
 export interface ModelFitGetters {
     [ModelFitGetter.canRunFit]: Getter<ModelFitState, FitState>
 }
 
+// I've put this here for want of a better place. Within userMessages
+// feels possible but that would break the default import.
+export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
+    const reasons: string[] = [];
+    const appendIf = (test: boolean, value: string) => {
+        if (test) {
+            reasons.push(value);
+        }
+    }
+    const help = userMessages.modelFit.fitRequirements;
+    appendIf(!reqs.hasModel, help.needsModel);
+    appendIf(!reqs.hasData, help.needsData);
+    appendIf(reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
+    appendIf(!reqs.hasTarget, help.needsTarget);
+    appendIf(!reqs.hasParamsToVary, help.needsParamsToVary);
+
+    return `${help.prefix} ${joinStringsSentence(reasons)}.`;
+}
+
 export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
     [ModelFitGetter.canRunFit]: (state: ModelFitState, _: ModelFitGetters, rootState: FitState) => {
         return !!(rootState.model.odin && rootState.model.odinRunner && rootState.fitData.data
             && rootState.fitData.timeVariable && rootState.fitData.columnToFit && state.paramsToVary.length);
+    },
+
+    [ModelFitGetter.fitRequirements]: (state: ModelFitState, _: ModelFitGetters, rootState: FitState): ModelFitRequirements => {
+        const checklist = {
+            hasModel: !!rootState.model.odin,
+            hasData: !!rootState.fitData.data,
+            hasTimeVariable: !!rootState.fitData.timeVariable,
+            hasTarget: !!rootState.fitData.columnToFit,
+            hasParamsToVary: !!state.paramsToVary.length,
+            hasEverything: true
+        };
+        checklist.hasEverything = Object.values(checklist).every((x: boolean) => x);
+        return checklist;
     }
 };

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -24,5 +24,4 @@ export interface ModelFitRequirements {
     hasTimeVariable: boolean;
     hasTarget: boolean;
     hasParamsToVary: boolean;
-    hasEverything: boolean;
 }

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -22,6 +22,7 @@ export interface ModelFitRequirements {
     hasModel: boolean;
     hasData: boolean;
     hasTimeVariable: boolean;
+    hasLinkedVariables: boolean;
     hasTarget: boolean;
     hasParamsToVary: boolean;
 }

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -17,3 +17,12 @@ export interface ModelFitState {
     inputs: ModelFitInputs | null, // all inputs except parameters, which vary
     result: OdinFitResult | null, // full solution for current best fit,
 }
+
+export interface ModelFitRequirements {
+    hasModel: boolean;
+    hasData: boolean;
+    hasTimeVariable: boolean;
+    hasTarget: boolean;
+    hasParamsToVary: boolean;
+    hasEverything: boolean;
+}

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -30,8 +30,6 @@ export default {
     },
     modelFit: {
         cancelled: "Model fit was cancelled before converging",
-        cannotFit: "Cannot fit model. Please provide valid data and code, link at least one variable "
-            + "and select parameters to vary.",
         notFittedYet: "Model has not been fitted.",
         selectParamToVary: "Please select at least one parameter to vary during model fit.",
         compileRequired: "Model code has been updated. Compile code and Fit Model for updated best fit.",

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -36,7 +36,15 @@ export default {
         selectParamToVary: "Please select at least one parameter to vary during model fit.",
         compileRequired: "Model code has been updated. Compile code and Fit Model for updated best fit.",
         fitRequired: "Model code has been recompiled, or options or data have been updated. "
-            + "Fit Model for updated best fit."
+            + "Fit Model for updated best fit.",
+        fitRequirements: {
+            prefix: "Cannot fit model. Please",
+            needsModel: "compile a model (code tab)",
+            needsData: "upload a data set (data tab)",
+            needsTimeVariable: "select a time variable for the data (data tab)", // only if !needsModel though!
+            needsTarget: "select a target to fit (options tab)",
+            needsParamsToVary: "select at least one parameter to vary (options tab)"
+        }
     },
     sensitivity: {
         compileRequiredForOptions: "Please compile a valid model in order to set sensitivity options.",

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -39,6 +39,7 @@ export default {
             + "Fit Model for updated best fit.",
         fitRequirements: {
             prefix: "Cannot fit model. Please",
+            unknown: "contact the administrator, as this is unexpected",
             needsModel: "compile a model (code tab)",
             needsData: "upload a data set (data tab)",
             needsTimeVariable: "select a time variable for the data (data tab)", // only if !needsModel though!

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -40,7 +40,8 @@ export default {
             unknown: "contact the administrator, as this is unexpected",
             needsModel: "compile a model (Code tab)",
             needsData: "upload a data set (Data tab)",
-            needsTimeVariable: "select a time variable for the data (Data tab)", // only if !needsModel though!
+            needsTimeVariable: "select a time variable for the data (Data tab)",
+            needsLinkedVariables: "link your model and data (Options tab)",
             needsTarget: "select a target to fit (Options tab)",
             needsParamsToVary: "select at least one parameter to vary (Options tab)"
         }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -40,11 +40,11 @@ export default {
         fitRequirements: {
             prefix: "Cannot fit model. Please",
             unknown: "contact the administrator, as this is unexpected",
-            needsModel: "compile a model (code tab)",
-            needsData: "upload a data set (data tab)",
-            needsTimeVariable: "select a time variable for the data (data tab)", // only if !needsModel though!
-            needsTarget: "select a target to fit (options tab)",
-            needsParamsToVary: "select at least one parameter to vary (options tab)"
+            needsModel: "compile a model (Code tab)",
+            needsData: "upload a data set (Data tab)",
+            needsTimeVariable: "select a time variable for the data (Data tab)", // only if !needsModel though!
+            needsTarget: "select a target to fit (Options tab)",
+            needsParamsToVary: "select at least one parameter to vary (Options tab)"
         }
     },
     sensitivity: {

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -176,19 +176,18 @@ export function generateBatchPars(
     };
 }
 
-export const joinStringsSentence = (strings: string[], last: string = " and ", sep: string = ", ") => {
+export const joinStringsSentence = (strings: string[], last = " and ", sep = ", "): string => {
     const n = strings.length;
     if (n === 0) {
         return "";
-    } else if (n === 1) {
+    } if (n === 1) {
         return strings[0];
-    } else {
-        return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
     }
-}
+    return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
+};
 
-export const newSessionId = () => uid(32);
+export const newSessionId = (): string => uid(32);
 
-export const allTrue = (x: Dict<boolean>) => {
+export const allTrue = (x: Dict<boolean>): boolean => {
     return Object.values(x).every((el: boolean) => el);
-}
+};

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -188,3 +188,7 @@ export const joinStringsSentence = (strings: string[], last: string = " and ", s
 }
 
 export const newSessionId = () => uid(32);
+
+export const allTrue = (x: Dict<boolean>) => {
+    return Object.values(x).every((el: boolean) => el);
+}

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -176,4 +176,15 @@ export function generateBatchPars(
     };
 }
 
+export const joinStringsSentence = (strings: string[], last: string = " and ", sep: string = ", ") => {
+    const n = strings.length;
+    if (n === 0) {
+        return "";
+    } else if (n === 1) {
+        return strings[0];
+    } else {
+        return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
+    }
+}
+
 export const newSessionId = () => uid(32);

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -176,6 +176,8 @@ export function generateBatchPars(
     };
 }
 
+export const newSessionId = (): string => uid(32);
+
 export const joinStringsSentence = (strings: string[], last = " and ", sep = ", "): string => {
     const n = strings.length;
     if (n === 0) {
@@ -185,8 +187,6 @@ export const joinStringsSentence = (strings: string[], last = " and ", sep = ", 
     }
     return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
 };
-
-export const newSessionId = (): string => uid(32);
 
 export const allTrue = (x: Dict<boolean>): boolean => {
     return Object.values(x).every((el: boolean) => el);

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -18,6 +18,7 @@ import DataTab from "../../../../src/app/components/data/DataTab.vue";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
 import { VisualisationTab } from "../../../../src/app/store/appState/state";
 import { AppStateMutation } from "../../../../src/app/store/appState/mutations";
+import { ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
 
 describe("FitApp", () => {
     const getWrapper = (mockSetOpenVisualisationTab = jest.fn()) => {
@@ -47,7 +48,10 @@ describe("FitApp", () => {
                 },
                 modelFit: {
                     namespaced: true,
-                    state: mockModelFitState()
+                    state: mockModelFitState(),
+                    getters: {
+                        [ModelFitGetter.fitRequirements]: () => ({})
+                    }
                 },
                 sensitivity: {
                     namespaced: true,

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -130,7 +130,7 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe( "Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
+            .toBe("Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(true);
         expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -130,7 +130,7 @@ describe("Fit Tab", () => {
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
+            .toBe("Cannot fit model. Please compile a model (Code tab) and upload a data set (Data tab).");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(true);
         expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -14,7 +14,7 @@ import { mockFitState } from "../../../mocks";
 
 describe("Fit Tab", () => {
     const getWrapper = (
-        canRunFit = true,
+        fitRequirements = {}, // ends up being true
         compileRequired = false,
         fitUpdateRequired = false,
         iterations: number | null = 10,
@@ -44,7 +44,7 @@ describe("Fit Tab", () => {
 
                     } as any,
                     getters: {
-                        canRunFit: () => canRunFit
+                        fitRequirements: () => fitRequirements
                     } as any,
                     actions: {
                         FitModel: mockFitModel
@@ -79,7 +79,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when fit is running", () => {
-        const wrapper = getWrapper(true, false, false, 5, false, true, 123.45);
+        const wrapper = getWrapper({}, false, false, 5, false, true, 123.45);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
@@ -93,7 +93,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected before fit runs", () => {
-        const wrapper = getWrapper(true, false, false, null, null, false, null);
+        const wrapper = getWrapper({}, false, false, null, null, false, null);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
@@ -106,7 +106,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when fit has been cancelled", () => {
-        const wrapper = getWrapper(true, false, false, 1, false, false, 121.2);
+        const wrapper = getWrapper({}, false, false, 1, false, false, 121.2);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
@@ -122,12 +122,15 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when cannot run fit", () => {
-        const wrapper = getWrapper(false, false, false, null, null, false, null);
+        const fitRequirements = {
+            hasModel: false,
+            hasData: false
+        };
+        const wrapper = getWrapper(fitRequirements, false, false, null, null, false, null);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect((wrapper.find("#cancel-fit-btn").element as HTMLButtonElement).disabled).toBe(true);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Cannot fit model. Please provide valid data and code, link at least one variable and "
-                + "select parameters to vary.");
+            .toBe( "Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(true);
         expect(fitPlot.findComponent(VueFeather).exists()).toBe(false);
@@ -137,7 +140,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when compile is required", () => {
-        const wrapper = getWrapper(true, true, false);
+        const wrapper = getWrapper({}, true, false);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
             .toBe("Model code has been updated. Compile code and Fit Model for updated best fit.");
@@ -149,7 +152,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when fit update is required", () => {
-        const wrapper = getWrapper(true, false, true);
+        const wrapper = getWrapper({}, false, true);
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
             .toBe("Model code has been recompiled, or options or data have been updated. "
@@ -163,14 +166,14 @@ describe("Fit Tab", () => {
 
     it("dispatches fit action on click button", async () => {
         const mockFitModel = jest.fn();
-        const wrapper = getWrapper(true, false, false, null, null, false, null, mockFitModel);
+        const wrapper = getWrapper({}, false, false, null, null, false, null, mockFitModel);
         await wrapper.find("#fit-btn").trigger("click");
         expect(mockFitModel).toHaveBeenCalledTimes(1);
     });
 
     it("cancel button sets fitting to false", async () => {
         const mockSetFitting = jest.fn();
-        const wrapper = getWrapper(true, false, false, 1, false, true, 25.6, jest.fn(), mockSetFitting);
+        const wrapper = getWrapper({}, false, false, 1, false, true, 25.6, jest.fn(), mockSetFitting);
         await wrapper.find("#cancel-fit-btn").trigger("click");
         expect(mockSetFitting).toHaveBeenCalledTimes(1);
         expect(mockSetFitting.mock.calls[0][1]).toBe(false);

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -1,0 +1,52 @@
+import { fitRequirementsExplanation } from "../../../../src/app/components/fit/support";
+
+describe("construct actionable error messages from requirements", () => {
+    const reqsTrue = {
+        hasData: true,
+        hasModel: true,
+        hasTimeVariable: true,
+        hasLinkedVariables: true,
+        hasTarget: true,
+        hasParamsToVary: true
+    };
+    const reqsFalse = {
+        hasData: false,
+        hasModel: false,
+        hasTimeVariable: false,
+        hasLinkedVariables: false,
+        hasTarget: false,
+        hasParamsToVary: false
+    };
+
+    it("shows fallback when no reason can be found", () => {
+        expect(fitRequirementsExplanation(reqsTrue))
+            .toBe("Cannot fit model. Please contact the administrator, as this is unexpected.");
+    });
+
+    it("tells the user to get started when nothing present", () => {
+        expect(fitRequirementsExplanation(reqsFalse))
+            .toBe("Cannot fit model. Please compile a model (Code tab) and upload a data set (Data tab).");
+    });
+
+    it("tells the user to set dependent things when model and data present", () => {
+        const reqs = {
+            ...reqsFalse,
+            hasData: true,
+            hasModel: true
+        };
+        expect(fitRequirementsExplanation(reqs))
+            .toBe("Cannot fit model. Please select a time variable for the data (Data tab), "
+                  + "link your model and data (Options tab) and select at least one parameter to vary (Options tab).");
+    });
+
+    it("gives specific messages when the user is close", () => {
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasParamsToVary: false }))
+            .toBe("Cannot fit model. Please select at least one parameter to vary (Options tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
+            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTimeVariable: false }))
+            .toBe("Cannot fit model. Please select a time variable for the data (Data tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
+            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
+    });
+});

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -47,7 +47,7 @@ describe("ModelFit actions", () => {
     });
 
     it("FitModel calls wodinFit and dispatches FitModelStep action", () => {
-        const getters = { canRunFit: true };
+        const getters = { fitRequirements: {} };
         const link = { time: "t", data: "v", model: "S" };
         const rootGetters = {
             "fitData/link": link,
@@ -93,7 +93,7 @@ describe("ModelFit actions", () => {
     });
 
     it("FitModel does nothing if cannot fit model", () => {
-        const getters = { canRunFit: false };
+        const getters = { fitRequirements: { hasData: false } };
         const commit = jest.fn();
         const dispatch = jest.fn();
 

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -1,5 +1,5 @@
 import { mockModelFitState } from "../../../mocks";
-import { getters, fitRequirementsExplanation, ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
+import { getters, ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
 
 describe("ModelFit getters", () => {
     const model = {
@@ -17,7 +17,7 @@ describe("ModelFit getters", () => {
     const state = mockModelFitState({ paramsToVary: ["p1"] });
 
     const expectedTrue = {
-        hasData: true,
+       hasData: true,
         hasModel: true,
         hasTimeVariable: true,
         hasTarget: true,
@@ -97,55 +97,5 @@ describe("ModelFit getters", () => {
             hasParamsToVary: false
         };
         expect((getters[ModelFitGetter.fitRequirements] as any)(mockModelFitState(), {}, rootState)).toEqual(expected);
-    });
-});
-
-describe("construct actionable error messages from requirements", () => {
-    const reqsTrue = {
-        hasData: true,
-        hasModel: true,
-        hasTimeVariable: true,
-        hasLinkedVariables: true,
-        hasTarget: true,
-        hasParamsToVary: true
-    };
-    const reqsFalse = {
-        hasData: false,
-        hasModel: false,
-        hasTimeVariable: false,
-        hasLinkedVariables: false,
-        hasTarget: false,
-        hasParamsToVary: false
-    };
-    it("shows fallback when no reason can be found", () => {
-        expect(fitRequirementsExplanation(reqsTrue))
-            .toBe("Cannot fit model. Please contact the administrator, as this is unexpected.");
-    });
-
-    it("tells the user to get started when nothing present", () => {
-        expect(fitRequirementsExplanation(reqsFalse))
-            .toBe("Cannot fit model. Please compile a model (Code tab) and upload a data set (Data tab).");
-    });
-
-    it("tells the user to set dependent things when model and data present", () => {
-        const reqs = {
-            ...reqsFalse,
-            hasData: true,
-            hasModel: true
-        };
-        expect(fitRequirementsExplanation(reqs))
-            .toBe("Cannot fit model. Please select a time variable for the data (Data tab), "
-                  + "link your model and data (Options tab) and select at least one parameter to vary (Options tab).");
-    });
-
-    it("gives specific messages when the user is close", () => {
-        expect(fitRequirementsExplanation({ ...reqsTrue, hasParamsToVary: false }))
-            .toBe("Cannot fit model. Please select at least one parameter to vary (Options tab).");
-        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
-            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
-        expect(fitRequirementsExplanation({ ...reqsTrue, hasTimeVariable: false }))
-            .toBe("Cannot fit model. Please select a time variable for the data (Data tab).");
-        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
-            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
     });
 });

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -1,5 +1,5 @@
 import { mockModelFitState } from "../../../mocks";
-import { getters, ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
+import { getters, fitRequirementsExplanation, ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
 
 describe("ModelFit getters", () => {
     const model = {
@@ -83,5 +83,51 @@ describe("ModelFit getters", () => {
             hasParamsToVary: false
         };
         expect((getters[ModelFitGetter.fitRequirements] as any)(mockModelFitState(), {}, rootState)).toEqual(expected);
+    });
+});
+
+describe("construct actionable error messages from requirements", () => {
+    const reqsTrue = {
+        hasData: true,
+        hasModel: true,
+        hasTimeVariable: true,
+        hasTarget: true,
+        hasParamsToVary: true
+    };
+    const reqsFalse = {
+        hasData: false,
+        hasModel: false,
+        hasTimeVariable: false,
+        hasTarget: false,
+        hasParamsToVary: false
+    };
+    it("shows fallback when no reason can be found", () => {
+        expect(fitRequirementsExplanation(reqsTrue))
+            .toBe("Cannot fit model. Please contact the administrator, as this is unexpected.");
+    });
+
+    it("tells the user to get started when nothing present", () => {
+        expect(fitRequirementsExplanation(reqsFalse))
+            .toBe("Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
+    });
+
+    it("tells the user to set dependent things when model and data present", () => {
+        const reqs = {
+            ...reqsFalse,
+            hasData: true,
+            hasModel: true
+        };
+        expect(fitRequirementsExplanation(reqs))
+            .toBe("Cannot fit model. Please select a time variable for the data (data tab), "
+                  + "select a target to fit (options tab) and select at least one parameter to vary (options tab).");
+    });
+
+    it("gives specific messages when the user is close", () => {
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasParamsToVary: false }))
+            .toBe("Cannot fit model. Please select at least one parameter to vary (options tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
+            .toBe("Cannot fit model. Please select a target to fit (options tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTimeVariable: false }))
+            .toBe("Cannot fit model. Please select a time variable for the data (data tab).");
     });
 });

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -10,7 +10,8 @@ describe("ModelFit getters", () => {
     const fitData = {
         data: [{ t: 1, v: 2 }],
         timeVariable: "t",
-        columnToFit: "v"
+        columnToFit: "v",
+        linkedVariables: { v: "y" }
     };
 
     const state = mockModelFitState({ paramsToVary: ["p1"] });
@@ -20,6 +21,7 @@ describe("ModelFit getters", () => {
         hasModel: true,
         hasTimeVariable: true,
         hasTarget: true,
+        hasLinkedVariables: true,
         hasParamsToVary: true
     };
 
@@ -64,6 +66,18 @@ describe("ModelFit getters", () => {
         expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
     });
 
+    it("fitRequirements is false when no linked variables", () => {
+        const rootState = {
+            model,
+            fitData: { ...fitData, linkedVariables: { "v": null } }
+        };
+        const expected = {
+            ...expectedTrue,
+            hasLinkedVariables: false
+        };
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
+    });
+
     it("fitRequirements is false when columnToFit is not set", () => {
         const rootState = {
             model,
@@ -91,6 +105,7 @@ describe("construct actionable error messages from requirements", () => {
         hasData: true,
         hasModel: true,
         hasTimeVariable: true,
+        hasLinkedVariables: true,
         hasTarget: true,
         hasParamsToVary: true
     };
@@ -98,6 +113,7 @@ describe("construct actionable error messages from requirements", () => {
         hasData: false,
         hasModel: false,
         hasTimeVariable: false,
+        hasLinkedVariables: false,
         hasTarget: false,
         hasParamsToVary: false
     };
@@ -119,7 +135,7 @@ describe("construct actionable error messages from requirements", () => {
         };
         expect(fitRequirementsExplanation(reqs))
             .toBe("Cannot fit model. Please select a time variable for the data (Data tab), "
-                  + "select a target to fit (Options tab) and select at least one parameter to vary (Options tab).");
+                  + "link your model and data (Options tab) and select at least one parameter to vary (Options tab).");
     });
 
     it("gives specific messages when the user is close", () => {
@@ -129,5 +145,7 @@ describe("construct actionable error messages from requirements", () => {
             .toBe("Cannot fit model. Please select a target to fit (Options tab).");
         expect(fitRequirementsExplanation({ ...reqsTrue, hasTimeVariable: false }))
             .toBe("Cannot fit model. Please select a time variable for the data (Data tab).");
+        expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
+            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
     });
 });

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -108,7 +108,7 @@ describe("construct actionable error messages from requirements", () => {
 
     it("tells the user to get started when nothing present", () => {
         expect(fitRequirementsExplanation(reqsFalse))
-            .toBe("Cannot fit model. Please compile a model (code tab) and upload a data set (data tab).");
+            .toBe("Cannot fit model. Please compile a model (Code tab) and upload a data set (Data tab).");
     });
 
     it("tells the user to set dependent things when model and data present", () => {
@@ -118,16 +118,16 @@ describe("construct actionable error messages from requirements", () => {
             hasModel: true
         };
         expect(fitRequirementsExplanation(reqs))
-            .toBe("Cannot fit model. Please select a time variable for the data (data tab), "
-                  + "select a target to fit (options tab) and select at least one parameter to vary (options tab).");
+            .toBe("Cannot fit model. Please select a time variable for the data (Data tab), "
+                  + "select a target to fit (Options tab) and select at least one parameter to vary (Options tab).");
     });
 
     it("gives specific messages when the user is close", () => {
         expect(fitRequirementsExplanation({ ...reqsTrue, hasParamsToVary: false }))
-            .toBe("Cannot fit model. Please select at least one parameter to vary (options tab).");
+            .toBe("Cannot fit model. Please select at least one parameter to vary (Options tab).");
         expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
-            .toBe("Cannot fit model. Please select a target to fit (options tab).");
+            .toBe("Cannot fit model. Please select a target to fit (Options tab).");
         expect(fitRequirementsExplanation({ ...reqsTrue, hasTimeVariable: false }))
-            .toBe("Cannot fit model. Please select a time variable for the data (data tab).");
+            .toBe("Cannot fit model. Please select a time variable for the data (Data tab).");
     });
 });

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -15,53 +15,73 @@ describe("ModelFit getters", () => {
 
     const state = mockModelFitState({ paramsToVary: ["p1"] });
 
-    it("canRunFit is true when all prerequisites are met", () => {
+    const expectedTrue = {
+        hasData: true,
+        hasModel: true,
+        hasTimeVariable: true,
+        hasTarget: true,
+        hasParamsToVary: true
+    };
+
+    it("fitRequirements is all true when all prerequisites are met", () => {
         const rootState = { model, fitData };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(true);
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expectedTrue);
     });
 
-    it("canRunFit is false when odin is not set", () => {
+    it("fitRequirements is false when odin is not set", () => {
         const rootState = {
             model: { ...model, odin: null },
             fitData
         };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(false);
-    });
-
-    it("canRunFit is false when odinRunner is not set", () => {
-        const rootState = {
-            model: { ...model, odinRunner: null },
-            fitData
+        const expected = {
+            ...expectedTrue,
+            hasModel: false
         };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(false);
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
     });
 
-    it("canRunFit is false when data is not set", () => {
+    it("fitRequirements is false when data is not set", () => {
         const rootState = {
             model,
             fitData: { ...fitData, data: null }
         };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(false);
+        const expected = {
+            ...expectedTrue,
+            hasData: false
+        };
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
     });
 
-    it("canRunFit is false when timeVariable is not set", () => {
+    it("fitRequirements is false when timeVariable is not set", () => {
         const rootState = {
             model,
             fitData: { ...fitData, timeVariable: null }
         };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(false);
+        const expected = {
+            ...expectedTrue,
+            hasTimeVariable: false
+        };
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
     });
 
-    it("canRunFit is false when columnToFit is not set", () => {
+    it("fitRequirements is false when columnToFit is not set", () => {
         const rootState = {
             model,
             fitData: { ...fitData, columnToFit: null }
         };
-        expect((getters[ModelFitGetter.canRunFit] as any)(state, {}, rootState)).toBe(false);
+        const expected = {
+            ...expectedTrue,
+            hasTarget: false
+        };
+        expect((getters[ModelFitGetter.fitRequirements] as any)(state, {}, rootState)).toEqual(expected);
     });
 
-    it("canRunFit is false when paramsToVary is empty", () => {
+    it("fitRequirements is false when paramsToVary is empty", () => {
         const rootState = { model, fitData };
-        expect((getters[ModelFitGetter.canRunFit] as any)(mockModelFitState(), {}, rootState)).toBe(false);
+        const expected = {
+            ...expectedTrue,
+            hasParamsToVary: false
+        };
+        expect((getters[ModelFitGetter.fitRequirements] as any)(mockModelFitState(), {}, rootState)).toEqual(expected);
     });
 });

--- a/app/static/tests/unit/store/modelFit/getters.test.ts
+++ b/app/static/tests/unit/store/modelFit/getters.test.ts
@@ -17,7 +17,7 @@ describe("ModelFit getters", () => {
     const state = mockModelFitState({ paramsToVary: ["p1"] });
 
     const expectedTrue = {
-       hasData: true,
+        hasData: true,
         hasModel: true,
         hasTimeVariable: true,
         hasTarget: true,
@@ -69,7 +69,7 @@ describe("ModelFit getters", () => {
     it("fitRequirements is false when no linked variables", () => {
         const rootState = {
             model,
-            fitData: { ...fitData, linkedVariables: { "v": null } }
+            fitData: { ...fitData, linkedVariables: { v: null } }
         };
         const expected = {
             ...expectedTrue,

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -1,5 +1,5 @@
 import {
-    evaluateScript, freezer, generateBatchPars, getCodeErrorFromResponse, processFitData, newSessionId
+    evaluateScript, freezer, generateBatchPars, getCodeErrorFromResponse, processFitData, newSessionId, joinStringsSentence
 } from "../../src/app/utils";
 import { SensitivityScaleType, SensitivityVariationType } from "../../src/app/store/sensitivity/state";
 import { mockBatchParsDisplace, mockBatchParsRange } from "../mocks";
@@ -405,5 +405,20 @@ describe("newSesionId", () => {
     it("generates expected id format", () => {
         const id = newSessionId();
         expect(id).toMatch(/^[a-z0-9]{32}$/);
+    });
+});
+
+describe("join strings", () => {
+    it("handles empty corner case", () => {
+        expect(joinStringsSentence([])).toBe("");
+    });
+    it("handles single corner case", () => {
+        expect(joinStringsSentence(["x"])).toBe("x");
+    });
+    it("handles pair", () => {
+        expect(joinStringsSentence(["x", "y"])).toBe("x and y");
+    });
+    it("handles longer list", () => {
+        expect(joinStringsSentence(["a", "b", "c", "d"], ", and ")).toBe("a, b, c, and d");
     });
 });

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -1,5 +1,6 @@
 import {
-    evaluateScript, freezer, generateBatchPars, getCodeErrorFromResponse, processFitData, newSessionId, joinStringsSentence
+    evaluateScript, freezer, generateBatchPars, getCodeErrorFromResponse,
+    processFitData, newSessionId, joinStringsSentence
 } from "../../src/app/utils";
 import { SensitivityScaleType, SensitivityVariationType } from "../../src/app/store/sensitivity/state";
 import { mockBatchParsDisplace, mockBatchParsRange } from "../mocks";


### PR DESCRIPTION
This PR breaks up our omnibus error message when we can't fit "Cannot fit model. Please provide valid data and code, link at least one variable and select parameters to vary." - watching science users with the app this was a bit of a stopper.

I've replaced the current getter with one that returns a Dict of booleans corresponding to different requirements. When constructing an error message with these there's also a bit of a graph there (no point telling the user to set a time variable if there is no data, or no point telling the user to select variable parameters if there is no model).

I've put the the message construction into the getter file which does not feel right but I wasn't sure where was better. It's fairly tied to the state in that part of the program.

For the rest of the app we just check that all requirements are set, I've added a small utility to check this