### PR TITLE
Update central solution when fit updates

### DIFF
--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -65,7 +65,21 @@ export const actions: ActionTree<ModelFitState, FitState> = {
         commit(ModelFitMutation.SetResult, result);
         // update model params on every step
         commit(`run/${RunMutation.SetParameterValues}`, result.data.pars, { root: true });
-        commit(`run/${RunMutation.SetResult}`, state.result, { root: true });
+
+        // Recast things slightly (really just the inputs) to get a
+        // suitable bit of data for the run tab and update the central
+        // solution. The assuption here is that the solution does not
+        // fail (error not null) which will be the case if the fit
+        // starts at all.
+        const runResult = {
+            inputs: {
+                parameterValues: result.data.pars,
+                endTime: result.data.endTime
+            },
+            solution: result.data.solution,
+            error: null
+        };
+        commit(`run/${RunMutation.SetResult}`, runResult, { root: true });
 
         if (result.converged) {
             commit(ModelFitMutation.SetFitting, false);

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -64,6 +64,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
         commit(ModelFitMutation.SetResult, result);
         // update model params on every step
         commit(`run/${RunMutation.SetParameterValues}`, result.data.pars, { root: true });
+        commit(`run/${RunMutation.SetResult}`, state.result, { root: true });
 
         if (result.converged) {
             commit(ModelFitMutation.SetFitting, false);

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -32,10 +32,6 @@ export const actions: ActionTree<RunState, AppState> = {
                 };
             }
             commit(RunMutation.SetResult, payload);
-
-            if (state.runRequired) {
-                commit(RunMutation.SetRunRequired, false);
-            }
         }
     }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -14,6 +14,7 @@ export enum RunMutation {
 export const mutations: MutationTree<RunState> = {
     [RunMutation.SetResult](state: RunState, payload: OdinRunResult) {
         state.result = payload;
+        state.runRequired = false;
     },
 
     [RunMutation.SetRunRequired](state: RunState, payload: boolean) {

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -294,7 +294,7 @@ describe("Model actions", () => {
 
         await store.dispatch(`model/${ModelAction.DefaultModel}`);
 
-        expect(commit.mock.calls.length).toBe(11);
+        expect(commit.mock.calls.length).toBe(10);
 
         // fetch
         const postData = JSON.parse(mockAxios.history.post[0].data);
@@ -339,7 +339,5 @@ describe("Model actions", () => {
             inputs: { endTime: 99, parameterValues: { p1: 1 } },
             solution: "test solution"
         });
-        expect(commit.mock.calls[10][0]).toBe(`run/${RunMutation.SetRunRequired}`);
-        expect(commit.mock.calls[10][1]).toBe(false);
     });
 });

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -117,7 +117,13 @@ describe("ModelFit actions", () => {
             result: () => result
         } as any;
 
-        const testState = mockModelFitState({ fitting: true });
+        const testState = mockModelFitState({
+            fitting: true,
+            result: {
+                inputs: {},
+                solution: "solution"
+            } as any
+        });
 
         const commit = jest.fn();
         const dispatch = jest.fn();
@@ -125,12 +131,15 @@ describe("ModelFit actions", () => {
 
         setTimeout(() => {
             expect(simplex.step).toHaveBeenCalledTimes(1);
-            expect(commit).toHaveBeenCalledTimes(2);
+            expect(commit).toHaveBeenCalledTimes(3);
             expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetResult);
             expect(commit.mock.calls[0][1]).toBe(result);
             expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
             expect(commit.mock.calls[1][1]).toBe(result.data.pars);
             expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
+            expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetResult}`);
+            expect(commit.mock.calls[2][1]).toStrictEqual(testState.result);
+            expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
 
             expect(dispatch).toHaveBeenCalledTimes(1);
             expect(dispatch.mock.calls[0][0]).toBe(ModelFitAction.FitModelStep);
@@ -158,11 +167,12 @@ describe("ModelFit actions", () => {
 
         setTimeout(() => {
             expect(simplex.step).toHaveBeenCalledTimes(1);
-            expect(commit).toHaveBeenCalledTimes(3);
+            expect(commit).toHaveBeenCalledTimes(4);
             expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetResult);
             expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
-            expect(commit.mock.calls[2][0]).toBe(ModelFitMutation.SetFitting);
-            expect(commit.mock.calls[2][1]).toBe(false);
+            expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetResult}`);
+            expect(commit.mock.calls[3][0]).toBe(ModelFitMutation.SetFitting);
+            expect(commit.mock.calls[3][1]).toBe(false);
 
             expect(dispatch).not.toHaveBeenCalled();
             done();

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -109,7 +109,9 @@ describe("ModelFit actions", () => {
         const result = {
             converged: false,
             data: {
-                pars: {}
+                pars: {},
+                endTime: 99,
+                solution: "solution"
             }
         };
         const simplex = {
@@ -118,11 +120,7 @@ describe("ModelFit actions", () => {
         } as any;
 
         const testState = mockModelFitState({
-            fitting: true,
-            result: {
-                inputs: {},
-                solution: "solution"
-            } as any
+            fitting: true
         });
 
         const commit = jest.fn();
@@ -138,7 +136,11 @@ describe("ModelFit actions", () => {
             expect(commit.mock.calls[1][1]).toBe(result.data.pars);
             expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetResult}`);
-            expect(commit.mock.calls[2][1]).toStrictEqual(testState.result);
+            expect(commit.mock.calls[2][1]).toStrictEqual({
+                inputs: { endTime: 99, parameterValues: {} },
+                solution: "solution",
+                error: null
+            });
             expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
 
             expect(dispatch).toHaveBeenCalledTimes(1);

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -33,15 +33,13 @@ describe("Run actions", () => {
         expect(run.mock.calls[0][2]).toBe(0); // start
         expect(run.mock.calls[0][3]).toBe(99); // end time from state
 
-        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
         expect(commit.mock.calls[0][1]).toEqual({
             inputs: { parameterValues, endTime: 99 },
             solution: "test solution",
             error: null
         });
-        expect(commit.mock.calls[1][0]).toBe(RunMutation.SetRunRequired);
-        expect(commit.mock.calls[1][1]).toBe(false);
     });
 
     it("run model does not update required action if required action was not run", () => {
@@ -130,7 +128,7 @@ describe("Run actions", () => {
         (actions[RunAction.RunModel] as any)({ commit, state, rootState });
 
         expect(runner.wodinRun.mock.calls[0][0]).toBe(mockOdin);
-        expect(commit.mock.calls.length).toBe(2);
+        expect(commit.mock.calls.length).toBe(1);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResult);
         expect(commit.mock.calls[0][1]).toStrictEqual({
             inputs: { parameterValues, endTime: 99 },

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -4,7 +4,7 @@ import { mockError, mockRunState } from "../../../mocks";
 describe("Run mutations", () => {
     it("sets odin solution", () => {
         const mockSolution = () => [{ x: 1, y: 2 }];
-        const state = mockRunState();
+        const state = mockRunState({ runRequired: true });
         const result = {
             inputs: { endTime: 99, parameterValues: { a: 1 } },
             error: null,
@@ -13,6 +13,7 @@ describe("Run mutations", () => {
 
         mutations.SetResult(state, result);
         expect(state.result).toBe(result);
+        expect(state.runRequired).toBe(false);
     });
 
     it("sets run required", () => {


### PR DESCRIPTION
~This will behave a bit better once #66 is merged as it has the effect of changing the solution end time weirdly, but it is actually independent.~

Currently we update the parameters but do not set the "needs run" flag. This PR updates the central solution directly from he model fit.