### PR TITLE
Pin node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 16.16.0
       - name: Install dependencies
         run: npm install -g typescript codecov
       - name: Build


### PR DESCRIPTION
It would appear that node v16.17.0 broke the backend test by setting `_dirname` differently to v16.16.0 (to /tmp..) and then config file was not accessible from this location - not sure if this is a bug or deliberate but pinning to the previous version seems to have fixed the issue for now!