### PR TITLE
mrc-3525 Save session state

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Each app config file should contain the following settings:
 - `appType`: "basic", "fit" or "stochastic"
 - `title`: the app title which will be visible to the user
 - `readOnlyCode`: boolean indicating whether default code should not be editable by the user
+- `stateUploadIntervalMillis` (optional): number of milliseconds to wait after front end state changes before state will be 
+saved to the server. Increase this value if too frequent requests are causing issues. Default is 2000.
 
 ### /defaultCode/*.R
 

--- a/app/static/src/app/apiService.ts
+++ b/app/static/src/app/apiService.ts
@@ -45,6 +45,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     }
 
     private _ignoreErrors = false;
+
     private _ignoreSuccess = false;
 
     private _freezeResponse = false;

--- a/app/static/src/app/apiService.ts
+++ b/app/static/src/app/apiService.ts
@@ -27,6 +27,7 @@ export interface API<S, E> {
     withError: (type: E, root: boolean) => API<S, E>
     withSuccess: (type: S, root: boolean) => API<S, E>
     ignoreErrors: () => API<S, E>
+    ignoreSuccess: () => API<S, E>
 
     get<T>(url: string): Promise<void | ResponseWithType<T>>
 }
@@ -44,6 +45,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
     }
 
     private _ignoreErrors = false;
+    private _ignoreSuccess = false;
 
     private _freezeResponse = false;
 
@@ -80,6 +82,11 @@ export class APIService<S extends string, E extends string> implements API<S, E>
 
     ignoreErrors = () => {
         this._ignoreErrors = true;
+        return this;
+    };
+
+    ignoreSuccess = () => {
+        this._ignoreSuccess = true;
         return this;
     };
 
@@ -129,7 +136,7 @@ export class APIService<S extends string, E extends string> implements API<S, E>
         if (this._onError == null && !this._ignoreErrors) {
             console.warn(`No error handler registered for request ${url}.`);
         }
-        if (this._onSuccess == null) {
+        if (this._onSuccess == null && !this._ignoreSuccess) {
             console.warn(`No success handler registered for request ${url}.`);
         }
     }

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -6,6 +6,7 @@ import { RunState } from "./store/run/state";
 import { SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
+import {OdinFitResult, OdinRunResult} from "./types/wrapperTypes";
 
 function serialiseCode(code: CodeState) {
     return {
@@ -22,16 +23,20 @@ function serialiseModel(model: ModelState) {
     };
 }
 
+function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null) {
+    return result ? {
+        inputs: result.inputs,
+        hasResult: !!result.solution,
+        error: result.error
+    } : null;
+}
+
 function serialiseRun(run: RunState) {
     return {
         runRequired: run.runRequired,
         parameterValues: run.parameterValues,
         endTime: run.endTime,
-        result: run.result ? {
-            inputs: run.result.inputs,
-            hasResult: !!run.result.solution,
-            error: run.result.error
-        } : null
+        result: serialiseSolutionResult(run.result)
     };
 }
 
@@ -67,11 +72,7 @@ function serialiseModelFit(modelFit: ModelFitState) {
         converged: modelFit.converged,
         sumOfSquares: modelFit.sumOfSquares,
         paramsToVary: modelFit.paramsToVary,
-        result: modelFit.result ? {
-            inputs: modelFit.result.inputs,
-            hasResult: !!modelFit.result.solution,
-            error: modelFit.result.error
-        } : null
+        result: serialiseSolutionResult(modelFit.result)
     };
 }
 

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,0 +1,5 @@
+import { AppState } from "./store/appState/state";
+
+export const serialiseState = (state: AppState) => {
+    return JSON.stringify({value: "PLACEHOLDER"});
+};

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -81,9 +81,14 @@ export const serialiseState = (state: AppState) => {
         code: serialiseCode(state.code),
         model: serialiseModel(state.model),
         run: serialiseRun(state.run),
-        sensitivity: serialiseSensitivity(state.sensitivity),
-        fitData: (state.appType === AppType.Fit) ?  serialiseFitData((state as FitState).fitData) : undefined,
-        modelFit: (state.appType === AppType.Fit) ? serialiseModelFit((state as FitState).modelFit) : undefined
-    };
+        sensitivity: serialiseSensitivity(state.sensitivity)
+    } as any; //TODO: generate type from schema
+
+    if (state.appType === AppType.Fit) {
+        const fitState = state as FitState;
+        result.fitData = serialiseFitData(fitState.fitData);
+        result.modelFit = serialiseModelFit(fitState.modelFit);
+    }
+
     return JSON.stringify(result);
 };

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -6,7 +6,7 @@ import { RunState } from "./store/run/state";
 import { SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
-import {OdinFitResult, OdinRunResult} from "./types/wrapperTypes";
+import { OdinFitResult, OdinRunResult } from "./types/wrapperTypes";
 
 function serialiseCode(code: CodeState) {
     return {

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,11 +1,11 @@
-import {AppState, AppType} from "./store/appState/state";
-import {FitState} from "./store/fit/state";
-import {CodeState} from "./store/code/state";
-import {ModelState} from "./store/model/state";
-import {RunState} from "./store/run/state";
-import {SensitivityState} from "./store/sensitivity/state";
-import {FitDataState} from "./store/fitData/state";
-import {ModelFitState} from "./store/modelFit/state";
+import { AppState, AppType } from "./store/appState/state";
+import { FitState } from "./store/fit/state";
+import { CodeState } from "./store/code/state";
+import { ModelState } from "./store/model/state";
+import { RunState } from "./store/run/state";
+import { SensitivityState } from "./store/sensitivity/state";
+import { FitDataState } from "./store/fitData/state";
+import { ModelFitState } from "./store/modelFit/state";
 
 function serialiseCode(code: CodeState) {
     return {
@@ -82,7 +82,7 @@ export const serialiseState = (state: AppState) => {
         model: serialiseModel(state.model),
         run: serialiseRun(state.run),
         sensitivity: serialiseSensitivity(state.sensitivity)
-    } as any; //TODO: generate type from schema
+    } as any; // TODO: generate type from schema
 
     if (state.appType === AppType.Fit) {
         const fitState = state as FitState;

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,5 +1,89 @@
-import { AppState } from "./store/appState/state";
+import {AppState, AppType} from "./store/appState/state";
+import {FitState} from "./store/fit/state";
+import {CodeState} from "./store/code/state";
+import {ModelState} from "./store/model/state";
+import {RunState} from "./store/run/state";
+import {SensitivityState} from "./store/sensitivity/state";
+import {FitDataState} from "./store/fitData/state";
+import {ModelFitState} from "./store/modelFit/state";
+
+function serialiseCode(code: CodeState) {
+    return {
+        currentCode: code.currentCode
+    };
+}
+
+function serialiseModel(model: ModelState) {
+    return {
+        compileRequired: model.compileRequired,
+        odinModelResponse: model.odinModelResponse,
+        hasOdin: !!model.odin,
+        odinModelCodeError: model.odinModelCodeError
+    };
+}
+
+function serialiseRun(run: RunState) {
+    return {
+        runRequired: run.runRequired,
+        parameterValues: run.parameterValues,
+        endTime: run.endTime,
+        result: run.result ? {
+            inputs: run.result.inputs,
+            hasResult: !!run.result.solution,
+            error: run.result.error
+        } : null
+    };
+}
+
+function serialiseSensitivity(sensitivity: SensitivityState) {
+    return {
+        paramSettings: sensitivity.paramSettings,
+        sensitivityUpdateRequired: sensitivity.sensitivityUpdateRequired,
+        plotSettings: sensitivity.plotSettings,
+        result: sensitivity.result ? {
+            inputs: sensitivity.result.inputs,
+            hasResult: !!sensitivity.result.batch,
+            error: sensitivity.result.error
+        } : null
+    };
+}
+
+function serialiseFitData(fitData: FitDataState) {
+    return {
+        data: fitData.data,
+        columns: fitData.columns,
+        timeVariableCandidates: fitData.timeVariableCandidates,
+        timeVariable: fitData.timeVariable,
+        linkedVariables: fitData.linkedVariables,
+        columnToFit: fitData.columnToFit,
+        error: fitData.error
+    };
+}
+
+function serialiseModelFit(modelFit: ModelFitState) {
+    return {
+        fitUpdateRequired: modelFit.fitUpdateRequired,
+        iterations: modelFit.iterations,
+        converged: modelFit.converged,
+        sumOfSquares: modelFit.sumOfSquares,
+        paramsToVary: modelFit.paramsToVary,
+        result: modelFit.result ? {
+            inputs: modelFit.result.inputs,
+            hasResult: !!modelFit.result.solution,
+            error: modelFit.result.error
+        } : null
+    };
+}
 
 export const serialiseState = (state: AppState) => {
-    return JSON.stringify({value: "PLACEHOLDER"});
+    const result = {
+        openVisualisationTab: state.openVisualisationTab,
+        code: serialiseCode(state.code),
+        model: serialiseModel(state.model),
+        run: serialiseRun(state.run),
+        sensitivity: serialiseSensitivity(state.sensitivity),
+        fitData: (state.appType === AppType.Fit) ?  serialiseFitData((state as FitState).fitData) : undefined,
+        modelFit: (state.appType === AppType.Fit) ? serialiseModelFit((state as FitState).modelFit) : undefined
+    };
+    return JSON.stringify(result);
 };

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -26,6 +26,8 @@ async function immediateUploadState(context: ActionContext<AppState, AppState>) 
     commit(AppStateMutation.SetStateUploadInProgress, false);
 }
 
+const getStateUploadInterval = (state: AppState) => state.config?.stateUploadIntervalMillis || 2000;
+
 export const appStateActions: ActionTree<AppState, AppState> = {
     async [AppStateAction.FetchConfig](context, appName) {
         const { commit, state, dispatch } = context;
@@ -62,7 +64,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                     commit(AppStateMutation.ClearQueuedStateUpload);
                     immediateUploadState(context);
                 }
-            }, 2000);
+            }, getStateUploadInterval(state));
 
             // record the newly queued upload
             commit(AppStateMutation.SetQueuedStateUpload, queuedId);

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -1,14 +1,16 @@
-import { ActionTree } from "vuex";
-import { api } from "../../apiService";
-import { ErrorsMutation } from "../errors/mutations";
-import { AppConfig } from "../../types/responseTypes";
-import { CodeMutation } from "../code/mutations";
-import { ModelAction } from "../model/actions";
-import { AppState } from "./state";
-import { AppStateMutation } from "./mutations";
+import {ActionContext, ActionTree} from "vuex";
+import {api} from "../../apiService";
+import {ErrorsMutation} from "../errors/mutations";
+import {AppConfig} from "../../types/responseTypes";
+import {CodeMutation} from "../code/mutations";
+import {ModelAction} from "../model/actions";
+import {AppState} from "./state";
+import {AppStateMutation} from "./mutations";
+import {serialiseState} from "../../serialise";
 
 export enum AppStateAction {
-    FetchConfig = "FetchConfig"
+    FetchConfig = "FetchConfig",
+    QueueStateUpload = "QueueStateUpload"
 }
 
 export const appStateActions: ActionTree<AppState, AppState> = {
@@ -29,5 +31,38 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                 await dispatch(`model/${ModelAction.DefaultModel}`);
             }
         }
+    },
+
+    async [AppStateAction.QueueStateUpload](context) {
+        const {state, dispatch, commit} = context;
+        // Do not queue uploads while fitting is true
+        if (!(state as any).modelFit?.fitting) {
+            // remove any existing queued upload, as this request should supersede it
+            commit(AppStateMutation.ClearQueuedStateUpload);
+
+            const queuedId: number = window.setInterval(() => {
+                // wait for any ongoing uploads to finish before starting a new one
+                // and do not actually upload while fitting is true
+                if (!state.stateUploadInProgress && !(state as any).modelFit?.fitting) {
+                    commit(AppStateMutation.ClearQueuedStateUpload);
+                    immediateUploadState(context);
+                }
+            }, 2000);
+
+            // record the newly queued upload
+            commit(AppStateMutation.SetQueuedStateUpload, queuedId);
+        }
     }
 };
+
+async function immediateUploadState(context: ActionContext<AppState, AppState>) {
+    const {commit, state} = context;
+    const {appName, sessionId} = state;
+
+    commit(AppStateMutation.SetStateUploadInProgress, true);
+    await api<AppStateMutation, ErrorsMutation>(context)
+        .ignoreSuccess()
+        .withError(ErrorsMutation.AddError)
+        .post(`/apps/${appName}/sessions/${sessionId}`, serialiseState(state));
+    commit(AppStateMutation.SetStateUploadInProgress, false);
+}

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -5,8 +5,17 @@ import { AppConfig } from "../../types/responseTypes";
 export enum AppStateMutation {
     SetAppName = "SetAppName",
     SetConfig = "SetConfig",
-    SetOpenVisualisationTab = "SetOpenVisualisationTab"
+    SetOpenVisualisationTab = "SetOpenVisualisationTab",
+    ClearQueuedStateUpload = "ClearQueuedStateUpload",
+    SetQueuedStateUpload = "SetQueuedStateUpload",
+    SetStateUploadInProgress = "SetStateUploadInProgress"
 }
+
+export const StateUploadMutations = [
+    AppStateMutation.ClearQueuedStateUpload,
+    AppStateMutation.SetQueuedStateUpload,
+    AppStateMutation.SetStateUploadInProgress
+] as string[];
 
 export const appStateMutations: MutationTree<AppState> = {
     [AppStateMutation.SetAppName](state: AppState, payload: string) {
@@ -19,5 +28,18 @@ export const appStateMutations: MutationTree<AppState> = {
 
     [AppStateMutation.SetOpenVisualisationTab](state: AppState, payload: VisualisationTab) {
         state.openVisualisationTab = payload;
+    },
+
+    [AppStateMutation.ClearQueuedStateUpload](state: AppState) {
+        window.clearInterval(state.queuedStateUploadIntervalId);
+        state.queuedStateUploadIntervalId = -1;
+    },
+
+    [AppStateMutation.SetQueuedStateUpload](state: AppState, payload: number) {
+        state.queuedStateUploadIntervalId = payload;
+    },
+
+    [AppStateMutation.SetStateUploadInProgress](state: AppState, payload: boolean) {
+        state.stateUploadInProgress = payload;
     }
 };

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -22,6 +22,8 @@ export interface AppState {
     appName: null | string,
     appType: AppType
     openVisualisationTab: VisualisationTab
+    queuedStateUploadIntervalId: number
+    stateUploadInProgress: boolean
     code: CodeState
     model: ModelState
     run: RunState

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -7,7 +7,7 @@ import { model } from "../model/model";
 import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
-import { logMutations } from "../plugins";
+import { logMutations, persistState } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
 
@@ -18,7 +18,9 @@ const defaultState: () => any = () => {
         appType: AppType.Basic,
         openVisualisationTab: VisualisationTab.Run,
         appName: null,
-        config: null
+        config: null,
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false
     };
 };
 
@@ -34,6 +36,7 @@ export const storeOptions: StoreOptions<BasicState> = {
         sensitivity
     },
     plugins: [
-        logMutations
+        logMutations,
+        persistState
     ]
 };

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -10,7 +10,7 @@ import { sensitivity } from "../sensitivity/sensitivity";
 import { fitData } from "../fitData/fitData";
 import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
-import { logMutations } from "../plugins";
+import { logMutations, persistState } from "../plugins";
 import { newSessionId } from "../../utils";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -20,7 +20,9 @@ const defaultState: () => any = () => {
         appType: AppType.Fit,
         openVisualisationTab: VisualisationTab.Run,
         appName: null,
-        config: null
+        config: null,
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false
     };
 };
 
@@ -38,6 +40,7 @@ export const storeOptions: StoreOptions<FitState> = {
         sensitivity
     },
     plugins: [
-        logMutations
+        logMutations,
+        persistState
     ]
 };

--- a/app/static/src/app/store/fit/state.ts
+++ b/app/static/src/app/store/fit/state.ts
@@ -2,9 +2,11 @@ import { AppState } from "../appState/state";
 import { FitConfig } from "../../types/responseTypes";
 import { FitDataState } from "../fitData/state";
 import { ModelState } from "../model/state";
+import {ModelFitState} from "../modelFit/state";
 
 export interface FitState extends AppState {
     config: null | FitConfig,
     fitData: FitDataState,
-    model: ModelState
+    model: ModelState,
+    modelFit: ModelFitState
 }

--- a/app/static/src/app/store/fit/state.ts
+++ b/app/static/src/app/store/fit/state.ts
@@ -2,7 +2,7 @@ import { AppState } from "../appState/state";
 import { FitConfig } from "../../types/responseTypes";
 import { FitDataState } from "../fitData/state";
 import { ModelState } from "../model/state";
-import {ModelFitState} from "../modelFit/state";
+import { ModelFitState } from "../modelFit/state";
 
 export interface FitState extends AppState {
     config: null | FitConfig,

--- a/app/static/src/app/store/plugins.ts
+++ b/app/static/src/app/store/plugins.ts
@@ -1,6 +1,6 @@
 import { MutationPayload, Store } from "vuex";
 import { AppState } from "./appState/state";
-import {StateUploadMutations} from "./appState/mutations";
+import { StateUploadMutations } from "./appState/mutations";
 
 export const logMutations = (store: Store<AppState>): void => {
     store.subscribe((mutation: MutationPayload) => {
@@ -11,7 +11,7 @@ export const logMutations = (store: Store<AppState>): void => {
 export const persistState = (store: Store<AppState>): void => {
     store.subscribe((mutation: MutationPayload) => {
         if (!StateUploadMutations.includes(mutation.type) && !mutation.type.startsWith("errors")) {
-            const {dispatch} = store;
+            const { dispatch } = store;
             dispatch("QueueStateUpload");
         }
     });

--- a/app/static/src/app/store/plugins.ts
+++ b/app/static/src/app/store/plugins.ts
@@ -1,8 +1,18 @@
 import { MutationPayload, Store } from "vuex";
 import { AppState } from "./appState/state";
+import {StateUploadMutations} from "./appState/mutations";
 
 export const logMutations = (store: Store<AppState>): void => {
     store.subscribe((mutation: MutationPayload) => {
         console.log(mutation.type);
+    });
+};
+
+export const persistState = (store: Store<AppState>): void => {
+    store.subscribe((mutation: MutationPayload) => {
+        if (!StateUploadMutations.includes(mutation.type) && !mutation.type.startsWith("errors")) {
+            const {dispatch} = store;
+            dispatch("QueueStateUpload");
+        }
     });
 };

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -9,6 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
+import {logMutations, persistState} from "../plugins";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
@@ -17,7 +18,9 @@ const defaultState: () => any = () => {
         appType: AppType.Stochastic,
         openVisualisationTab: VisualisationTab.Run,
         appName: null,
-        config: null
+        config: null,
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false
     };
 };
 
@@ -31,5 +34,9 @@ export const storeOptions: StoreOptions<StochasticState> = {
         model,
         run,
         sensitivity
-    }
+    },
+    plugins: [
+        logMutations,
+        persistState
+    ]
 };

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -9,7 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
-import {logMutations, persistState} from "../plugins";
+import { logMutations, persistState } from "../plugins";
 import { localStorageManager } from "../../localStorageManager";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -19,7 +19,8 @@ export interface ResponseSuccess {
 
 export interface AppConfig {
     defaultCode: string[],
-    readOnlyCode: boolean
+    readOnlyCode: boolean,
+    stateUploadIntervalMillis?: number | null
 }
 
 export interface BasicConfig extends AppConfig {

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -117,6 +117,8 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
         appType: AppType.Basic,
         openVisualisationTab: VisualisationTab.Run,
         appName: "",
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false,
         config: {
             basicProp: "",
             ...mockAppConfig
@@ -149,6 +151,8 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         appType: AppType.Fit,
         openVisualisationTab: VisualisationTab.Run,
         appName: "",
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false,
         config: {
             fitProp: "",
             ...mockAppConfig
@@ -158,6 +162,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         run: mockRunState(),
         fitData: mockFitDataState(),
         sensitivity: mockSensitivityState(),
+        modelFit: mockModelFitState(),
         ...state
     };
 };
@@ -168,6 +173,8 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
         appType: AppType.Stochastic,
         openVisualisationTab: VisualisationTab.Run,
         appName: "",
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false,
         config: {
             stochasticProp: "",
             ...mockAppConfig

--- a/app/static/tests/unit/apiService.test.ts
+++ b/app/static/tests/unit/apiService.test.ts
@@ -371,7 +371,19 @@ describe("ApiService", () => {
         expect(commit.mock.calls.length).toBe(0);
     });
 
-    it("warns if error and success handlers are not set", async () => {
+    it("does not warn that no success handler if ignoring success", async () => {
+        mockAxios.onGet(TEST_ROUTE)
+            .reply(200, mockSuccess(true));
+
+        await api({ commit: jest.fn(), rootState } as any)
+            .ignoreSuccess()
+            .withError("whatever")
+            .get(TEST_ROUTE);
+
+        expect((console.warn as jest.Mock).mock.calls.length).toBe(0);
+    });
+
+    it("warns if error and success handlers are not set if not ignoring", async () => {
         mockAxios.onGet(TEST_ROUTE)
             .reply(200, mockSuccess(true));
 

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -1,11 +1,236 @@
+import {BasicState} from "../../src/app/store/basic/state";
+import {AppType, VisualisationTab} from "../../src/app/store/appState/state";
+import {
+    SensitivityPlotExtreme,
+    SensitivityPlotType,
+    SensitivityScaleType,
+    SensitivityVariationType
+} from "../../src/app/store/sensitivity/state";
+import {serialiseState} from "../../src/app/serialise";
+import {FitState} from "../../src/app/store/fit/state";
+
 describe("serialise", () => {
 
+    const codeState = {
+        currentCode: ["some code"]
+    };
 
-    const expectCode = (state: BasicState) => {
-      expect();
+    const modelState = {
+        compileRequired: true,
+        odinRunner: {
+            wodinRun: jest.fn(),
+            wodinFit: jest.fn(),
+            batchParsRange: jest.fn(),
+            batchParsDisplace: jest.fn(),
+            batchRun: jest.fn()
+        },
+        odinModelResponse: {
+            valid: true,
+            metadata: {
+                variables: ["S", "I", "R"],
+                parameters: [
+                    {name: "alpha", default: 1, min: 0, max: 2, is_integer: true, rank: 0},
+                    {name: "beta", default: 0.1, min: -1, max: 10.5, is_integer: false, rank: 1}
+                ],
+                messages: ["a test message"]
+            },
+            model: "a test model",
+            error: {line: ["test error line 1"], message: "test model error"}
+        },
+        odin: jest.fn(),
+        paletteModel: {S: "#f00", I: "#0f0", R: "#00f"},
+        odinModelCodeError: {error: "odin error", detail: "test odin error"}
+    };
+
+    const runState = {
+        runRequired: true,
+        parameterValues: {alpha: 1, beta: 1.1},
+        endTime: 20,
+        result: {
+            inputs: {
+                parameterValues: {alpha: 0, beta: 2.2},
+                endTime: 10
+            },
+            solution: jest.fn(),
+            error: {error: "run error", detail: "run error detail"}
+        }
+    };
+
+    const sensitivityBatchPars = {
+        base: {alpha: 1, beta: 1.1},
+        name: "alpha",
+        values: [0.5, 0.75, 1, 1.25, 1.5]
+    };
+    const sensitivityState = {
+        paramSettings: {
+            parameterToVary: "alpha",
+            scaleType: SensitivityScaleType.Arithmetic,
+            variationType: SensitivityVariationType.Percentage,
+            variationPercentage: 50,
+            rangeFrom: 0,
+            rangeTo: 1,
+            numberOfRuns: 5
+        },
+        sensitivityUpdateRequired: false,
+        plotSettings: {
+            plotType: SensitivityPlotType.ValueAtTime,
+            extreme: SensitivityPlotExtreme.Min,
+            time: 5
+        },
+        result: {
+            inputs: {
+                endTime: 10,
+                pars: sensitivityBatchPars
+            },
+            batch: {
+                pars: sensitivityBatchPars,
+                solutions: [jest.fn(), jest.fn()],
+                valueAtTime: jest.fn()
+            },
+            error: {error: "sensitivity error", detail: "sensitivity error detail"}
+        }
+    };
+
+    const fitDataState = {
+        data: [{time: 0, cases: 0}, {time: 1, cases: 2}],
+        columns: ["time", "cases"],
+        timeVariableCandidates: ["time"],
+        timeVariable: "time",
+        linkedVariables: {cases: "I"},
+        columnToFit: "cases",
+        error: {error: "fit error", detail: "fit error detail"}
+    };
+
+    const modelFitState = {
+        fitting: false,
+        fitUpdateRequired: true,
+        iterations: 28,
+        converged: true,
+        sumOfSquares: 21.43,
+        paramsToVary: ["beta"],
+        inputs: {
+            data: [{t: 0, cases: 1}, {t: 1, cases: 3}],
+            endTime: 5,
+            link: {time: "t", data: "cases", model: "S"}
+        },
+        result: {
+            inputs: {
+                parameterValues: {alpha: 0, beta: 3.2},
+                endTime: 15,
+                data: [{t: 0, cases: 2}, {t: 2, cases: 4}],
+                link: {time: "t", data: "cases", model: "R"}
+            },
+            solution: jest.fn(),
+            error: {error: "fit error", detail: "fit error detail"}
+        }
+    };
+
+    const basicState: BasicState = {
+        sessionId: "1234",
+        config: null,
+        appName: "test app",
+        appType: AppType.Basic,
+        openVisualisationTab: VisualisationTab.Sensitivity,
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false,
+        code: codeState,
+        model: modelState,
+        run: runState,
+        sensitivity: sensitivityState
+    };
+
+    const fitState: FitState = {
+        sessionId: "5678",
+        config: null,
+        appName: "test fit app",
+        appType: AppType.Fit,
+        openVisualisationTab: VisualisationTab.Fit,
+        queuedStateUploadIntervalId: -1,
+        stateUploadInProgress: false,
+        code: codeState,
+        model: modelState,
+        run: runState,
+        sensitivity: sensitivityState,
+        fitData: fitDataState,
+        modelFit: modelFitState
+    };
+
+    const expectedCode = {currentCode: ["some code"]};
+    const expectedModel = {
+        compileRequired: true,
+        odinModelResponse: modelState.odinModelResponse,
+        hasOdin: true,
+        odinModelCodeError: modelState.odinModelCodeError
+    };
+    const expectedRun = {
+        runRequired: true,
+        parameterValues: runState.parameterValues,
+        endTime: 20,
+        result: {
+            inputs: runState.result.inputs,
+            hasResult: true,
+            error: runState.result.error
+        }
+    };
+    const expectedSensitivity = {
+        paramSettings: sensitivityState.paramSettings,
+        sensitivityUpdateRequired: false,
+        plotSettings: sensitivityState.plotSettings,
+        result: {
+            inputs: sensitivityState.result.inputs,
+            hasResult: true,
+            error: sensitivityState.result.error
+        }
+    };
+
+    const expectedFitData = {
+        data: fitDataState.data,
+        columns: ["time", "cases"],
+        timeVariableCandidates: ["time"],
+        timeVariable: "time",
+        linkedVariables: {cases: "I"},
+        columnToFit: "cases",
+        error: fitDataState.error
+    };
+
+    const expectedModelFit = {
+        fitUpdateRequired: true,
+        iterations: 28,
+        converged: true,
+        sumOfSquares: 21.43,
+        paramsToVary: ["beta"],
+        result: {
+            inputs: modelFitState.result.inputs,
+            hasResult: true,
+            error: modelFitState.result.error
+        }
     };
 
     it("serialises BasicState as expected", () => {
-
+        const serialised = serialiseState(basicState);
+        const expected = {
+            openVisualisationTab: VisualisationTab.Sensitivity,
+            code: expectedCode,
+            model: expectedModel,
+            run: expectedRun,
+            sensitivity: expectedSensitivity
+        };
+        expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
+
+    it("serialises FitState as expected", () => {
+        const serialised = serialiseState(fitState);
+        const expected = {
+            openVisualisationTab: VisualisationTab.Fit,
+            code: expectedCode,
+            model: expectedModel,
+            run: expectedRun,
+            sensitivity: expectedSensitivity,
+            fitData: expectedFitData,
+            modelFit: expectedModelFit
+        };
+        expect(JSON.parse(serialised)).toStrictEqual(expected);
+    });
+
+    //it("serialises as expected when no solutions or model");
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -232,5 +232,73 @@ describe("serialise", () => {
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
 
-    //it("serialises as expected when no solutions or model");
+    it("serialises as expected when no solutions", () => {
+        const state = {
+            ...fitState,
+            run: {
+                ...runState,
+                result: {
+                    ...runState.result,
+                    solution: null
+                }
+            },
+            sensitivity: {
+                ...sensitivityState,
+                result: {
+                    ...sensitivityState.result,
+                    batch: null
+                }
+            },
+            modelFit: {
+                ...modelFitState,
+                result: {
+                    ...modelFitState.result,
+                    solution: null
+                }
+            }
+        };
+        const serialised = serialiseState(state);
+
+        const expected = {
+            openVisualisationTab: VisualisationTab.Fit,
+            code: expectedCode,
+            model: expectedModel,
+            run: {
+                ...expectedRun,
+                result: {...expectedRun.result, hasResult: false}
+            },
+            sensitivity: {
+                ...expectedSensitivity,
+                result: {...expectedSensitivity.result, hasResult: false}
+            },
+            fitData: expectedFitData,
+            modelFit: {
+                ...expectedModelFit,
+                result: {...expectedModelFit.result, hasResult: false}
+            }
+        };
+        expect(JSON.parse(serialised)).toStrictEqual(expected);
+    });
+
+    it("serialises as expected when no model or results", () => {
+        const state = {
+            ...fitState,
+            model: {...modelState, odin: null},
+            run: {...runState, result: null},
+            sensitivity: {...sensitivityState, result: null},
+            modelFit: {...modelFitState, result: null}
+        };
+        const serialised = serialiseState(state);
+
+        const expected = {
+            openVisualisationTab: VisualisationTab.Fit,
+            code: expectedCode,
+            model: {...expectedModel, hasOdin: false},
+            run: {...expectedRun, result: null },
+            sensitivity: {...expectedSensitivity, result: null},
+            fitData: expectedFitData,
+            modelFit: {...expectedModelFit, result: null}
+        };
+        expect(JSON.parse(serialised)).toStrictEqual(expected);
+    });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -1,0 +1,11 @@
+describe("serialise", () => {
+
+
+    const expectCode = (state: BasicState) => {
+      expect();
+    };
+
+    it("serialises BasicState as expected", () => {
+
+    });
+});

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -1,16 +1,15 @@
-import {BasicState} from "../../src/app/store/basic/state";
-import {AppType, VisualisationTab} from "../../src/app/store/appState/state";
+import { BasicState } from "../../src/app/store/basic/state";
+import { AppType, VisualisationTab } from "../../src/app/store/appState/state";
 import {
     SensitivityPlotExtreme,
     SensitivityPlotType,
     SensitivityScaleType,
     SensitivityVariationType
 } from "../../src/app/store/sensitivity/state";
-import {serialiseState} from "../../src/app/serialise";
-import {FitState} from "../../src/app/store/fit/state";
+import { serialiseState } from "../../src/app/serialise";
+import { FitState } from "../../src/app/store/fit/state";
 
 describe("serialise", () => {
-
     const codeState = {
         currentCode: ["some code"]
     };
@@ -29,35 +28,39 @@ describe("serialise", () => {
             metadata: {
                 variables: ["S", "I", "R"],
                 parameters: [
-                    {name: "alpha", default: 1, min: 0, max: 2, is_integer: true, rank: 0},
-                    {name: "beta", default: 0.1, min: -1, max: 10.5, is_integer: false, rank: 1}
+                    {
+                        name: "alpha", default: 1, min: 0, max: 2, is_integer: true, rank: 0
+                    },
+                    {
+                        name: "beta", default: 0.1, min: -1, max: 10.5, is_integer: false, rank: 1
+                    }
                 ],
                 messages: ["a test message"]
             },
             model: "a test model",
-            error: {line: ["test error line 1"], message: "test model error"}
+            error: { line: ["test error line 1"], message: "test model error" }
         },
         odin: jest.fn(),
-        paletteModel: {S: "#f00", I: "#0f0", R: "#00f"},
-        odinModelCodeError: {error: "odin error", detail: "test odin error"}
+        paletteModel: { S: "#f00", I: "#0f0", R: "#00f" },
+        odinModelCodeError: { error: "odin error", detail: "test odin error" }
     };
 
     const runState = {
         runRequired: true,
-        parameterValues: {alpha: 1, beta: 1.1},
+        parameterValues: { alpha: 1, beta: 1.1 },
         endTime: 20,
         result: {
             inputs: {
-                parameterValues: {alpha: 0, beta: 2.2},
+                parameterValues: { alpha: 0, beta: 2.2 },
                 endTime: 10
             },
             solution: jest.fn(),
-            error: {error: "run error", detail: "run error detail"}
+            error: { error: "run error", detail: "run error detail" }
         }
     };
 
     const sensitivityBatchPars = {
-        base: {alpha: 1, beta: 1.1},
+        base: { alpha: 1, beta: 1.1 },
         name: "alpha",
         values: [0.5, 0.75, 1, 1.25, 1.5]
     };
@@ -87,18 +90,18 @@ describe("serialise", () => {
                 solutions: [jest.fn(), jest.fn()],
                 valueAtTime: jest.fn()
             },
-            error: {error: "sensitivity error", detail: "sensitivity error detail"}
+            error: { error: "sensitivity error", detail: "sensitivity error detail" }
         }
     };
 
     const fitDataState = {
-        data: [{time: 0, cases: 0}, {time: 1, cases: 2}],
+        data: [{ time: 0, cases: 0 }, { time: 1, cases: 2 }],
         columns: ["time", "cases"],
         timeVariableCandidates: ["time"],
         timeVariable: "time",
-        linkedVariables: {cases: "I"},
+        linkedVariables: { cases: "I" },
         columnToFit: "cases",
-        error: {error: "fit error", detail: "fit error detail"}
+        error: { error: "fit error", detail: "fit error detail" }
     };
 
     const modelFitState = {
@@ -109,19 +112,19 @@ describe("serialise", () => {
         sumOfSquares: 21.43,
         paramsToVary: ["beta"],
         inputs: {
-            data: [{t: 0, cases: 1}, {t: 1, cases: 3}],
+            data: [{ t: 0, cases: 1 }, { t: 1, cases: 3 }],
             endTime: 5,
-            link: {time: "t", data: "cases", model: "S"}
+            link: { time: "t", data: "cases", model: "S" }
         },
         result: {
             inputs: {
-                parameterValues: {alpha: 0, beta: 3.2},
+                parameterValues: { alpha: 0, beta: 3.2 },
                 endTime: 15,
-                data: [{t: 0, cases: 2}, {t: 2, cases: 4}],
-                link: {time: "t", data: "cases", model: "R"}
+                data: [{ t: 0, cases: 2 }, { t: 2, cases: 4 }],
+                link: { time: "t", data: "cases", model: "R" }
             },
             solution: jest.fn(),
-            error: {error: "fit error", detail: "fit error detail"}
+            error: { error: "fit error", detail: "fit error detail" }
         }
     };
 
@@ -155,7 +158,7 @@ describe("serialise", () => {
         modelFit: modelFitState
     };
 
-    const expectedCode = {currentCode: ["some code"]};
+    const expectedCode = { currentCode: ["some code"] };
     const expectedModel = {
         compileRequired: true,
         odinModelResponse: modelState.odinModelResponse,
@@ -188,7 +191,7 @@ describe("serialise", () => {
         columns: ["time", "cases"],
         timeVariableCandidates: ["time"],
         timeVariable: "time",
-        linkedVariables: {cases: "I"},
+        linkedVariables: { cases: "I" },
         columnToFit: "cases",
         error: fitDataState.error
     };
@@ -265,16 +268,16 @@ describe("serialise", () => {
             model: expectedModel,
             run: {
                 ...expectedRun,
-                result: {...expectedRun.result, hasResult: false}
+                result: { ...expectedRun.result, hasResult: false }
             },
             sensitivity: {
                 ...expectedSensitivity,
-                result: {...expectedSensitivity.result, hasResult: false}
+                result: { ...expectedSensitivity.result, hasResult: false }
             },
             fitData: expectedFitData,
             modelFit: {
                 ...expectedModelFit,
-                result: {...expectedModelFit.result, hasResult: false}
+                result: { ...expectedModelFit.result, hasResult: false }
             }
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
@@ -283,21 +286,21 @@ describe("serialise", () => {
     it("serialises as expected when no model or results", () => {
         const state = {
             ...fitState,
-            model: {...modelState, odin: null},
-            run: {...runState, result: null},
-            sensitivity: {...sensitivityState, result: null},
-            modelFit: {...modelFitState, result: null}
+            model: { ...modelState, odin: null },
+            run: { ...runState, result: null },
+            sensitivity: { ...sensitivityState, result: null },
+            modelFit: { ...modelFitState, result: null }
         };
         const serialised = serialiseState(state);
 
         const expected = {
             openVisualisationTab: VisualisationTab.Fit,
             code: expectedCode,
-            model: {...expectedModel, hasOdin: false},
-            run: {...expectedRun, result: null },
-            sensitivity: {...expectedSensitivity, result: null},
+            model: { ...expectedModel, hasOdin: false },
+            run: { ...expectedRun, result: null },
+            sensitivity: { ...expectedSensitivity, result: null },
             fitData: expectedFitData,
-            modelFit: {...expectedModelFit, result: null}
+            modelFit: { ...expectedModelFit, result: null }
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -8,7 +8,7 @@ import { ErrorsMutation } from "../../../../src/app/store/errors/mutations";
 import { CodeMutation, mutations as codeMutations } from "../../../../src/app/store/code/mutations";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { ModelAction } from "../../../../src/app/store/model/actions";
-import {serialiseState} from "../../../../src/app/serialise";
+import { serialiseState } from "../../../../src/app/serialise";
 
 describe("AppState actions", () => {
     const getStore = () => {
@@ -113,10 +113,10 @@ describe("AppState actions", () => {
         jest.useFakeTimers();
         const mockSetInterval = jest.spyOn(window, "setInterval");
         const state = mockFitState({
-            modelFit: mockModelFitState({fitting: true})
+            modelFit: mockModelFitState({ fitting: true })
         });
         const commit = jest.fn();
-        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
         expect(commit).not.toHaveBeenCalled();
         expect(mockSetInterval).not.toHaveBeenCalled();
     });
@@ -124,12 +124,12 @@ describe("AppState actions", () => {
     it("QueueStateUpload sets new state upload pending", (done) => {
         jest.useFakeTimers();
         const mockSetInterval = jest.spyOn(window, "setInterval");
-        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const state = mockFitState({ sessionId: "1234", appName: "testApp" });
         const commit = jest.fn();
         mockAxios.onPost("/apps/testApp/sessions/1234")
             .reply(200, "");
 
-        (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe(AppStateMutation.ClearQueuedStateUpload);
         expect(commit.mock.calls[1][0]).toBe(AppStateMutation.SetQueuedStateUpload);
@@ -162,12 +162,12 @@ describe("AppState actions", () => {
     it("QueueStateUpload callback does not upload pending if upload is in progress", async () => {
         jest.useFakeTimers();
         const mockSetInterval = jest.spyOn(window, "setInterval");
-        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const state = mockFitState({ sessionId: "1234", appName: "testApp" });
         const commit = jest.fn();
         mockAxios.onPost("/apps/testApp/sessions/1234")
             .reply(200);
 
-        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(mockSetInterval).toHaveBeenCalledTimes(1);
         expect(mockAxios.history.post.length).toBe(0);
@@ -185,12 +185,12 @@ describe("AppState actions", () => {
     it("QueueStateUpload callback does not upload pending if fitting is in progress", async () => {
         jest.useFakeTimers();
         const mockSetInterval = jest.spyOn(window, "setInterval");
-        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const state = mockFitState({ sessionId: "1234", appName: "testApp" });
         const commit = jest.fn();
         mockAxios.onPost("/apps/testApp/sessions/1234")
             .reply(200);
 
-        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(mockSetInterval).toHaveBeenCalledTimes(1);
         expect(mockAxios.history.post.length).toBe(0);
@@ -207,12 +207,12 @@ describe("AppState actions", () => {
 
     it("QueueStatusUpload callback commits api error", (done) => {
         jest.useFakeTimers();
-        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const state = mockFitState({ sessionId: "1234", appName: "testApp" });
         const commit = jest.fn();
         mockAxios.onPost("/apps/testApp/sessions/1234")
             .reply(500, mockFailure("upload failure"));
 
-        (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
         jest.advanceTimersByTime(2000);
 
         expect(commit).toHaveBeenCalledTimes(4);
@@ -227,7 +227,7 @@ describe("AppState actions", () => {
         setTimeout(() => {
             expect(commit).toHaveBeenCalledTimes(6);
             expect(commit.mock.calls[4][0]).toBe(ErrorsMutation.AddError);
-            expect(commit.mock.calls[4][1]).toStrictEqual({error: "OTHER_ERROR", detail: "upload failure"});
+            expect(commit.mock.calls[4][1]).toStrictEqual({ error: "OTHER_ERROR", detail: "upload failure" });
             expect(commit.mock.calls[5][0]).toBe(AppStateMutation.SetStateUploadInProgress);
             expect(commit.mock.calls[5][1]).toBe(false);
             done();

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -1,6 +1,6 @@
 import Vuex from "vuex";
 import {
-    mockAxios, mockBasicState, mockCodeState, mockFailure, mockSuccess
+    mockAxios, mockBasicState, mockCodeState, mockFailure, mockFitState, mockModelFitState, mockSuccess
 } from "../../../mocks";
 import { AppStateAction, appStateActions } from "../../../../src/app/store/appState/actions";
 import { AppStateMutation, appStateMutations } from "../../../../src/app/store/appState/mutations";
@@ -8,6 +8,7 @@ import { ErrorsMutation } from "../../../../src/app/store/errors/mutations";
 import { CodeMutation, mutations as codeMutations } from "../../../../src/app/store/code/mutations";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { ModelAction } from "../../../../src/app/store/model/actions";
+import {serialiseState} from "../../../../src/app/serialise";
 
 describe("AppState actions", () => {
     const getStore = () => {
@@ -24,6 +25,11 @@ describe("AppState actions", () => {
             }
         });
     };
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        mockAxios.reset();
+    });
 
     it("fetches config and commits result", async () => {
         const config = {
@@ -101,5 +107,130 @@ describe("AppState actions", () => {
         expect((commit.mock.calls[1][1] as any).detail).toBe("Test Error Msg");
 
         expect(dispatch).not.toBeCalled();
+    });
+
+    it("QueueStateUpload does not queue during fitting", async () => {
+        jest.useFakeTimers();
+        const mockSetInterval = jest.spyOn(window, "setInterval");
+        const state = mockFitState({
+            modelFit: mockModelFitState({fitting: true})
+        });
+        const commit = jest.fn();
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        expect(commit).not.toHaveBeenCalled();
+        expect(mockSetInterval).not.toHaveBeenCalled();
+    });
+
+    it("QueueStateUpload sets new state upload pending", (done) => {
+        jest.useFakeTimers();
+        const mockSetInterval = jest.spyOn(window, "setInterval");
+        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const commit = jest.fn();
+        mockAxios.onPost("/apps/testApp/sessions/1234")
+            .reply(200, "");
+
+        (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.ClearQueuedStateUpload);
+        expect(commit.mock.calls[1][0]).toBe(AppStateMutation.SetQueuedStateUpload);
+
+        expect(mockSetInterval).toHaveBeenCalledTimes(1);
+        expect(mockSetInterval.mock.calls[0][1]).toBe(2000);
+
+        expect(mockAxios.history.post.length).toBe(0);
+
+        jest.advanceTimersByTime(2000);
+
+        // The additional commits and axios call for immediateUploadState should now have been called
+        expect(commit).toHaveBeenCalledTimes(4);
+        expect(commit.mock.calls[2][0]).toBe(AppStateMutation.ClearQueuedStateUpload);
+        expect(commit.mock.calls[3][0]).toBe(AppStateMutation.SetStateUploadInProgress);
+        expect(commit.mock.calls[3][1]).toBe(true);
+        expect(mockAxios.history.post.length).toBe(1);
+        expect(mockAxios.history.post[0].data).toBe(serialiseState(state));
+
+        // use a real timer to wait for the final commit after mock axios returns!
+        jest.useRealTimers();
+        setTimeout(() => {
+            expect(commit).toHaveBeenCalledTimes(5);
+            expect(commit.mock.calls[4][0]).toBe(AppStateMutation.SetStateUploadInProgress);
+            expect(commit.mock.calls[4][1]).toBe(false);
+            done();
+        });
+    });
+
+    it("QueueStateUpload callback does not upload pending if upload is in progress", async () => {
+        jest.useFakeTimers();
+        const mockSetInterval = jest.spyOn(window, "setInterval");
+        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const commit = jest.fn();
+        mockAxios.onPost("/apps/testApp/sessions/1234")
+            .reply(200);
+
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(mockSetInterval).toHaveBeenCalledTimes(1);
+        expect(mockAxios.history.post.length).toBe(0);
+
+        // set upload in progress so interval callback will not do upload
+        state.stateUploadInProgress = true;
+
+        jest.advanceTimersByTime(2000);
+
+        // There should be no additional commits or axios calls
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(mockAxios.history.post.length).toBe(0);
+    });
+
+    it("QueueStateUpload callback does not upload pending if fitting is in progress", async () => {
+        jest.useFakeTimers();
+        const mockSetInterval = jest.spyOn(window, "setInterval");
+        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const commit = jest.fn();
+        mockAxios.onPost("/apps/testApp/sessions/1234")
+            .reply(200);
+
+        await (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(mockSetInterval).toHaveBeenCalledTimes(1);
+        expect(mockAxios.history.post.length).toBe(0);
+
+        // set fitting progress so interval callback will not do upload
+        state.modelFit.fitting = true;
+
+        jest.advanceTimersByTime(2000);
+
+        // There should be no additional commits or axios calls
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(mockAxios.history.post.length).toBe(0);
+    });
+
+    it("QueueStatusUpload callback commits api error", (done) => {
+        jest.useFakeTimers();
+        const state = mockFitState({sessionId: "1234", appName: "testApp"});
+        const commit = jest.fn();
+        mockAxios.onPost("/apps/testApp/sessions/1234")
+            .reply(500, mockFailure("upload failure"));
+
+        (appStateActions[AppStateAction.QueueStateUpload] as any)({commit, state});
+        jest.advanceTimersByTime(2000);
+
+        expect(commit).toHaveBeenCalledTimes(4);
+        expect(commit.mock.calls[2][0]).toBe(AppStateMutation.ClearQueuedStateUpload);
+        expect(commit.mock.calls[3][0]).toBe(AppStateMutation.SetStateUploadInProgress);
+        expect(commit.mock.calls[3][1]).toBe(true);
+        expect(mockAxios.history.post.length).toBe(1);
+        expect(mockAxios.history.post[0].data).toBe(serialiseState(state));
+
+        // use a real timer to wait for the final commits after mock axios returns
+        jest.useRealTimers();
+        setTimeout(() => {
+            expect(commit).toHaveBeenCalledTimes(6);
+            expect(commit.mock.calls[4][0]).toBe(ErrorsMutation.AddError);
+            expect(commit.mock.calls[4][1]).toStrictEqual({error: "OTHER_ERROR", detail: "upload failure"});
+            expect(commit.mock.calls[5][0]).toBe(AppStateMutation.SetStateUploadInProgress);
+            expect(commit.mock.calls[5][1]).toBe(false);
+            done();
+        });
     });
 });

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -159,6 +159,26 @@ describe("AppState actions", () => {
         });
     });
 
+    it("Uses state upload interval from config if defined", () => {
+        jest.useFakeTimers();
+        const mockSetInterval = jest.spyOn(window, "setInterval");
+        const state = mockFitState({
+            sessionId: "1234",
+            appName: "testApp",
+            config: {
+                stateUploadIntervalMillis: 1000
+            } as any
+        });
+        const commit = jest.fn();
+        mockAxios.onPost("/apps/testApp/sessions/1234")
+            .reply(200, "");
+
+        (appStateActions[AppStateAction.QueueStateUpload] as any)({ commit, state });
+        expect(commit).toHaveBeenCalledTimes(2);
+
+        expect(mockSetInterval.mock.calls[0][1]).toBe(1000);
+    });
+
     it("QueueStateUpload callback does not upload pending if upload is in progress", async () => {
         jest.useFakeTimers();
         const mockSetInterval = jest.spyOn(window, "setInterval");

--- a/app/static/tests/unit/store/appState/mutations.test.ts
+++ b/app/static/tests/unit/store/appState/mutations.test.ts
@@ -1,5 +1,6 @@
 import { appStateMutations } from "../../../../src/app/store/appState/mutations";
 import { VisualisationTab } from "../../../../src/app/store/appState/state";
+import {mockBasicState} from "../../../mocks";
 
 describe("AppState mutations", () => {
     it("Sets appName", () => {
@@ -19,5 +20,25 @@ describe("AppState mutations", () => {
         const state = { openVisualisationTab: VisualisationTab.Run } as any;
         appStateMutations.SetOpenVisualisationTab(state, VisualisationTab.Sensitivity);
         expect(state.openVisualisationTab).toBe(VisualisationTab.Sensitivity);
+    });
+
+    it("clears queued state upload", () => {
+        const spyClearInterval = jest.spyOn(window, "clearInterval");
+        const state = mockBasicState({queuedStateUploadIntervalId: 99});
+        appStateMutations.ClearQueuedStateUpload(state);
+        expect(state.queuedStateUploadIntervalId).toBe(-1);
+        expect(spyClearInterval).toHaveBeenCalledWith(99);
+    });
+
+    it("sets queued state upload", () => {
+        const state = mockBasicState();
+        appStateMutations.SetQueuedStateUpload(state, 99);
+        expect(state.queuedStateUploadIntervalId).toBe(99);
+    });
+
+    it("sets state upload in progress", () => {
+        const state = mockBasicState();
+        appStateMutations.SetStateUploadInProgress(state, true);
+        expect(state.stateUploadInProgress).toBe(true);
     });
 });

--- a/app/static/tests/unit/store/appState/mutations.test.ts
+++ b/app/static/tests/unit/store/appState/mutations.test.ts
@@ -1,6 +1,6 @@
 import { appStateMutations } from "../../../../src/app/store/appState/mutations";
 import { VisualisationTab } from "../../../../src/app/store/appState/state";
-import {mockBasicState} from "../../../mocks";
+import { mockBasicState } from "../../../mocks";
 
 describe("AppState mutations", () => {
     it("Sets appName", () => {
@@ -24,7 +24,7 @@ describe("AppState mutations", () => {
 
     it("clears queued state upload", () => {
         const spyClearInterval = jest.spyOn(window, "clearInterval");
-        const state = mockBasicState({queuedStateUploadIntervalId: 99});
+        const state = mockBasicState({ queuedStateUploadIntervalId: 99 });
         appStateMutations.ClearQueuedStateUpload(state);
         expect(state.queuedStateUploadIntervalId).toBe(-1);
         expect(spyClearInterval).toHaveBeenCalledWith(99);

--- a/app/static/tests/unit/store/plugins.test.ts
+++ b/app/static/tests/unit/store/plugins.test.ts
@@ -1,8 +1,8 @@
 import Vuex from "vuex";
 import { logMutations, persistState } from "../../../src/app/store/plugins";
 import { AppState } from "../../../src/app/store/appState/state";
-import {AppStateAction} from "../../../src/app/store/appState/actions";
-import {AppStateMutation} from "../../../src/app/store/appState/mutations";
+import { AppStateAction } from "../../../src/app/store/appState/actions";
+import { AppStateMutation } from "../../../src/app/store/appState/mutations";
 
 describe("plugins", () => {
     it("logMutations logs mutations to console", () => {
@@ -49,7 +49,7 @@ describe("plugins", () => {
     it("persistState does not dispatch QueueStateUpload for any StateUploadMutation", () => {
         const store = new Vuex.Store<AppState>({
             mutations: {
-                [AppStateMutation.ClearQueuedStateUpload]:  () => {},
+                [AppStateMutation.ClearQueuedStateUpload]: () => {},
                 [AppStateMutation.SetQueuedStateUpload]: () => {},
                 [AppStateMutation.SetStateUploadInProgress]: () => {}
             }

--- a/config/apps/day1.config.json
+++ b/config/apps/day1.config.json
@@ -2,5 +2,6 @@
   "appType": "basic",
   "title": "Day 1 - Basic Model",
   "basicProp": "day1 basic value",
-  "readOnlyCode": false
+  "readOnlyCode": false,
+  "stateUploadIntervalMillis": 1000
 }

--- a/config/apps/day1.config.json
+++ b/config/apps/day1.config.json
@@ -3,5 +3,5 @@
   "title": "Day 1 - Basic Model",
   "basicProp": "day1 basic value",
   "readOnlyCode": false,
-  "stateUploadIntervalMillis": 1000
+  "stateUploadIntervalMillis": 2000
 }


### PR DESCRIPTION
This branch adds serialising session state and saving it to the session POST endpoint.

We follow a similar pattern to HINT, where each mutation (with some exceptions) cause a pending state save to be queued, and the save to take place two seconds later. This allows us to collect related groups of mutations into a single save request, to minimise traffic. This has some associated state e.g. interval id, and so we need to exclude mutation of these from triggering saves or we end up in an infinite loop!

State serialisation selectively includes the state properties required for later rehydration - e.g.  we do not include the odin solutions themselves. The serialisation takes quite a long-winded 'opt in' approach - each property of each module which we want to include in the serialisation is specified individually so new properties will not be automatically included. However, this does not extend to nested properties - in some cases we do deliberately exclude some nested values e.g. the solutions in the result types. However for brevity some complex properties are included in their entirely e.g. `odinModelResponse` so we should bear this in mind if we add values to these types. An alternative approach would be more opt-out and only exclude what we definitely want to - I'm not completely sure which would be best!

The serialised state should conform to the appState schema specified here: https://github.com/mrc-ide/wodin/blob/main/schema/appState.json

To test, run the app and check the network tab to see requests to the POST session endpoint with serialised state payload when mutations occur. 

I've written up a separate ticket to write a test to validate serialised output against the schema, and also to generate a type fron the schema to use for the serialisation output: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3594/Use-serialisation-schema-in-test-and-for-serialisation-type