### PR TITLE
More detailed reasons for fit update

### DIFF
--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -50,7 +50,6 @@ export default {
         const fitRequirements = computed(() => store.getters[`${namespace}/${ModelFitGetter.fitRequirements}`]);
         const canFitModel = computed(() => allTrue(fitRequirements.value));
         const compileRequired = computed(() => store.state.model.compileRequired);
-        const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
         const fitUpdateRequiredReasons = computed(() => store.state.modelFit.fitUpdateRequiredReasons);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
 

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -50,7 +50,7 @@ export default {
         const fitRequirements = computed(() => store.getters[`${namespace}/${ModelFitGetter.fitRequirements}`]);
         const canFitModel = computed(() => allTrue(fitRequirements.value));
         const compileRequired = computed(() => store.state.model.compileRequired);
-        const fitUpdateRequiredReasons = computed(() => store.state.modelFit.fitUpdateRequiredReasons);
+        const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
 
         const cancelFit = () => store.commit(`${namespace}/${ModelFitMutation.SetFitting}`, false);
@@ -75,8 +75,8 @@ export default {
             if (compileRequired.value) {
                 return userMessages.modelFit.compileRequired;
             }
-            if (anyTrue(fitUpdateRequiredReasons.value)) {
-                return fitUpdateRequiredExplanation(fitUpdateRequiredReasons.value);
+            if (anyTrue(fitUpdateRequired.value)) {
+                return fitUpdateRequiredExplanation(fitUpdateRequired.value);
             }
 
             return "";

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -32,8 +32,8 @@ import { ModelFitGetter } from "../../store/modelFit/getters";
 import userMessages from "../../userMessages";
 import LoadingSpinner from "../LoadingSpinner.vue";
 import { ModelFitMutation } from "../../store/modelFit/mutations";
-import { fitRequirementsExplanation } from "./support";
-import { allTrue } from "../../utils";
+import { fitRequirementsExplanation, fitUpdateRequiredExplanation } from "./support";
+import { allTrue, anyTrue } from "../../utils";
 
 export default {
     name: "FitTab",
@@ -51,6 +51,7 @@ export default {
         const canFitModel = computed(() => allTrue(fitRequirements.value));
         const compileRequired = computed(() => store.state.model.compileRequired);
         const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
+        const fitUpdateRequiredReasons = computed(() => store.state.modelFit.fitUpdateRequiredReasons);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
 
         const cancelFit = () => store.commit(`${namespace}/${ModelFitMutation.SetFitting}`, false);
@@ -65,11 +66,18 @@ export default {
             if (!allTrue(fitRequirements.value)) {
                 return fitRequirementsExplanation(fitRequirements.value);
             }
+            // This is confusing if the user has not run a fit as it
+            // makes it look like some additional action needs
+            // taking. The plot already tells the user that the fit
+            // needs running, so don't add a message.
+            if (!store.state.modelFit.result?.solution) {
+                return "";
+            }
             if (compileRequired.value) {
                 return userMessages.modelFit.compileRequired;
             }
-            if (fitUpdateRequired.value) {
-                return userMessages.modelFit.fitRequired;
+            if (anyTrue(fitUpdateRequiredReasons.value)) {
+                return fitUpdateRequiredExplanation(fitUpdateRequiredReasons.value);
             }
 
             return "";

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -40,4 +40,4 @@ export const fitUpdateRequiredExplanation = (reasons: FitUpdateRequiredReasons):
     // Fallback reason if something unexpected has happened.
     appendIf(explanation, explanation.length === 0, help.unknown);
     return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;
-}
+};

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -1,4 +1,4 @@
-import { ModelFitRequirements, RerunFitReasons } from "../../store/modelFit/state";
+import { ModelFitRequirements, FitUpdateRequiredReasons } from "../../store/modelFit/state";
 import userMessages from "../../userMessages";
 import { joinStringsSentence } from "../../utils";
 
@@ -9,35 +9,35 @@ const appendIf = (container: string[], test: boolean, value: string) => {
 };
 
 export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
-    const reasons: string[] = [];
+    const explanation: string[] = [];
     const help = userMessages.modelFit.fitRequirements;
-    appendIf(reasons, !reqs.hasModel, help.needsModel);
-    appendIf(reasons, !reqs.hasData, help.needsData);
+    appendIf(explanation, !reqs.hasModel, help.needsModel);
+    appendIf(explanation, !reqs.hasData, help.needsData);
     // Can only tell the user to set a time variable if we have data
-    appendIf(reasons, reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
+    appendIf(explanation, reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
     // Can only tell the user to link variables if they have model and data
-    appendIf(reasons, reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
+    appendIf(explanation, reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
     // Can only tell the user to set a target if we have all of the
     // above (checking hasLinkedVariables is sufficient)
-    appendIf(reasons, reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
+    appendIf(explanation, reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
     // Can only tell the user to change parameters if we have a
     // model. This shold be announced last as it's on the tab they are
     // looking at
-    appendIf(reasons, reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
+    appendIf(explanation, reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
 
     // Fallback reason if something unexpected has happened.
-    appendIf(reasons, reasons.length === 0, help.unknown);
+    appendIf(explanation, explanation.length === 0, help.unknown);
 
-    return `${help.prefix} ${joinStringsSentence(reasons)}.`;
+    return `${help.prefix} ${joinStringsSentence(explanation)}.`;
 };
 
-export const fitUpdateRequiredExplanation = (reqs: RerunFitReasons): string => {
-    const reasons: string[] = [];
+export const fitUpdateRequiredExplanation = (reasons: FitUpdateRequiredReasons): string => {
+    const explanation: string[] = [];
     const help = userMessages.modelFit.updateFitReasons;
-    appendIf(reasons, reqs.modelChanged, help.modelChanged);
-    appendIf(reasons, reqs.dataChanged, help.dataChanged);
-    appendIf(reasons, reqs.linkChanged && !reqs.modelChanged && !reqs.dataChanged, help.linkChanged);
+    appendIf(explanation, reasons.modelChanged, help.modelChanged);
+    appendIf(explanation, reasons.dataChanged, help.dataChanged);
+    appendIf(explanation, reasons.linkChanged && !reasons.modelChanged && !reasons.dataChanged, help.linkChanged);
     // Fallback reason if something unexpected has happened.
-    appendIf(reasons, reasons.length === 0, help.unknown);
-    return `${help.prefix} ${joinStringsSentence(reasons)}. ${help.suffix}.`;
+    appendIf(explanation, explanation.length === 0, help.unknown);
+    return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;
 }

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -37,6 +37,7 @@ export const fitUpdateRequiredExplanation = (reasons: FitUpdateRequiredReasons):
     appendIf(explanation, reasons.modelChanged, help.modelChanged);
     appendIf(explanation, reasons.dataChanged, help.dataChanged);
     appendIf(explanation, reasons.linkChanged && !reasons.modelChanged && !reasons.dataChanged, help.linkChanged);
+    appendIf(explanation, reasons.parameterChanged && !reasons.modelChanged, help.parameterChanged);
     // Fallback reason if something unexpected has happened.
     appendIf(explanation, explanation.length === 0, help.unknown);
     return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -37,7 +37,8 @@ export const fitUpdateRequiredExplanation = (reasons: FitUpdateRequiredReasons):
     appendIf(explanation, reasons.modelChanged, help.modelChanged);
     appendIf(explanation, reasons.dataChanged, help.dataChanged);
     appendIf(explanation, reasons.linkChanged && !reasons.modelChanged && !reasons.dataChanged, help.linkChanged);
-    appendIf(explanation, reasons.parameterChanged && !reasons.modelChanged, help.parameterChanged);
+    appendIf(explanation, reasons.parameterValueChanged && !reasons.modelChanged, help.parameterValueChanged);
+    appendIf(explanation, reasons.parameterToVaryChanged && !reasons.modelChanged, help.parameterToVaryChanged);
     // Fallback reason if something unexpected has happened.
     appendIf(explanation, explanation.length === 0, help.unknown);
     return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;

--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -1,31 +1,43 @@
-import { ModelFitRequirements } from "../../store/modelFit/state";
+import { ModelFitRequirements, RerunFitReasons } from "../../store/modelFit/state";
 import userMessages from "../../userMessages";
 import { joinStringsSentence } from "../../utils";
 
+const appendIf = (container: string[], test: boolean, value: string) => {
+    if (test) {
+        container.push(value);
+    }
+};
+
 export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
     const reasons: string[] = [];
-    const appendIf = (test: boolean, value: string) => {
-        if (test) {
-            reasons.push(value);
-        }
-    };
     const help = userMessages.modelFit.fitRequirements;
-    appendIf(!reqs.hasModel, help.needsModel);
-    appendIf(!reqs.hasData, help.needsData);
+    appendIf(reasons, !reqs.hasModel, help.needsModel);
+    appendIf(reasons, !reqs.hasData, help.needsData);
     // Can only tell the user to set a time variable if we have data
-    appendIf(reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
+    appendIf(reasons, reqs.hasData && !reqs.hasTimeVariable, help.needsTimeVariable);
     // Can only tell the user to link variables if they have model and data
-    appendIf(reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
+    appendIf(reasons, reqs.hasModel && reqs.hasData && !reqs.hasLinkedVariables, help.needsLinkedVariables);
     // Can only tell the user to set a target if we have all of the
     // above (checking hasLinkedVariables is sufficient)
-    appendIf(reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
+    appendIf(reasons, reqs.hasLinkedVariables && !reqs.hasTarget, help.needsTarget);
     // Can only tell the user to change parameters if we have a
     // model. This shold be announced last as it's on the tab they are
     // looking at
-    appendIf(reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
+    appendIf(reasons, reqs.hasModel && !reqs.hasParamsToVary, help.needsParamsToVary);
 
     // Fallback reason if something unexpected has happened.
-    appendIf(reasons.length === 0, help.unknown);
+    appendIf(reasons, reasons.length === 0, help.unknown);
 
     return `${help.prefix} ${joinStringsSentence(reasons)}.`;
 };
+
+export const fitUpdateRequiredExplanation = (reqs: RerunFitReasons): string => {
+    const reasons: string[] = [];
+    const help = userMessages.modelFit.updateFitReasons;
+    appendIf(reasons, reqs.modelChanged, help.modelChanged);
+    appendIf(reasons, reqs.dataChanged, help.dataChanged);
+    appendIf(reasons, reqs.linkChanged && !reqs.modelChanged && !reqs.dataChanged, help.linkChanged);
+    // Fallback reason if something unexpected has happened.
+    appendIf(reasons, reasons.length === 0, help.unknown);
+    return `${help.prefix} ${joinStringsSentence(reasons)}. ${help.suffix}.`;
+}

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -68,7 +68,7 @@ export default defineComponent({
 
         const updateValue = (newValue: number, paramName: string) => {
             store.commit(`run/${RunMutation.UpdateParameterValues}`, { [paramName]: newValue });
-            store.commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { parameterChanged: true });
+            store.commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { parameterValueChanged: true });
             store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true);
         };
 
@@ -77,6 +77,7 @@ export default defineComponent({
             const currentParams = paramsToVary.value;
             const newParams = checked ? [...currentParams, paramName] : currentParams.filter((p) => p !== paramName);
             store.commit(`modelFit/${ModelFitMutation.SetParamsToVary}`, newParams);
+            store.commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { parameterToVaryChanged: true });
         };
 
         const fitTabIsOpen = computed(() => store.state.openVisualisationTab === VisualisationTab.Fit);

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -68,6 +68,7 @@ export default defineComponent({
 
         const updateValue = (newValue: number, paramName: string) => {
             store.commit(`run/${RunMutation.UpdateParameterValues}`, { [paramName]: newValue });
+            store.commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { parameterChanged: true });
             store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true);
         };
 

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -51,12 +51,14 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
 
 export const actions: ActionTree<FitDataState, FitState> = {
     [FitDataAction.Upload](context, file) {
+        const { commit } = context;
         csvUpload(context)
             .withSuccess(FitDataMutation.SetData)
             .withError(FitDataMutation.SetError)
             .then(() => {
                 updateLinkedVariables(context);
                 respondUpdatedTimeVariable(context);
+                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { dataChanged: true }, { root: true });
             })
             .upload(file);
     },

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -57,7 +57,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
             .then(() => {
                 updateLinkedVariables(context);
                 respondUpdatedTimeVariable(context);
-                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { dataChanged: true }, { root: true });
+                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { dataChanged: true }, { root: true });
             })
             .upload(file);
     },
@@ -67,7 +67,7 @@ export const actions: ActionTree<FitDataState, FitState> = {
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
         respondUpdatedTimeVariable(context);
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
     },
 
     [FitDataAction.UpdateLinkedVariables](context) {
@@ -78,13 +78,13 @@ export const actions: ActionTree<FitDataState, FitState> = {
         const { commit, state } = context;
         commit(FitDataMutation.SetLinkedVariable, payload);
         if (payload.column === state.columnToFit) {
-            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
+            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
         }
     },
 
     [FitDataAction.UpdateColumnToFit](context, payload: string) {
         const { commit } = context;
         commit(FitDataMutation.SetColumnToFit, payload);
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
     }
 };

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -44,20 +44,19 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
         commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
     }
 };
 
 export const actions: ActionTree<FitDataState, FitState> = {
     [FitDataAction.Upload](context, file) {
+        const { commit } = context;
         csvUpload(context)
             .withSuccess(FitDataMutation.SetData)
             .withError(FitDataMutation.SetError)
             .then(() => {
                 updateLinkedVariables(context);
                 respondUpdatedTimeVariable(context);
-                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
                 commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { dataChanged: true }, { root: true });
             })
             .upload(file);
@@ -68,7 +67,6 @@ export const actions: ActionTree<FitDataState, FitState> = {
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
         respondUpdatedTimeVariable(context);
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
     },
 
@@ -80,8 +78,6 @@ export const actions: ActionTree<FitDataState, FitState> = {
         const { commit, state } = context;
         commit(FitDataMutation.SetLinkedVariable, payload);
         if (payload.column === state.columnToFit) {
-            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
-            // TODO: as above
             commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
         }
     },
@@ -89,7 +85,6 @@ export const actions: ActionTree<FitDataState, FitState> = {
     [FitDataAction.UpdateColumnToFit](context, payload: string) {
         const { commit } = context;
         commit(FitDataMutation.SetColumnToFit, payload);
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
     }
 };

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -57,6 +57,8 @@ export const actions: ActionTree<FitDataState, FitState> = {
             .then(() => {
                 updateLinkedVariables(context);
                 respondUpdatedTimeVariable(context);
+                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { dataChanged: true }, { root: true });
             })
             .upload(file);
     },
@@ -66,6 +68,8 @@ export const actions: ActionTree<FitDataState, FitState> = {
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
         respondUpdatedTimeVariable(context);
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
     },
 
     [FitDataAction.UpdateLinkedVariables](context) {
@@ -77,6 +81,8 @@ export const actions: ActionTree<FitDataState, FitState> = {
         commit(FitDataMutation.SetLinkedVariable, payload);
         if (payload.column === state.columnToFit) {
             commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+            // TODO: as above
+            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
         }
     },
 
@@ -84,5 +90,6 @@ export const actions: ActionTree<FitDataState, FitState> = {
         const { commit } = context;
         commit(FitDataMutation.SetColumnToFit, payload);
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { linkChanged: true }, { root: true });
     }
 };

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -44,20 +44,19 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
+        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
         commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
     }
 };
 
 export const actions: ActionTree<FitDataState, FitState> = {
     [FitDataAction.Upload](context, file) {
-        const { commit } = context;
         csvUpload(context)
             .withSuccess(FitDataMutation.SetData)
             .withError(FitDataMutation.SetError)
             .then(() => {
                 updateLinkedVariables(context);
                 respondUpdatedTimeVariable(context);
-                commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { dataChanged: true }, { root: true });
             })
             .upload(file);
     },
@@ -67,7 +66,6 @@ export const actions: ActionTree<FitDataState, FitState> = {
         commit(FitDataMutation.SetTimeVariable, timeVariable);
         updateLinkedVariables(context);
         respondUpdatedTimeVariable(context);
-        commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
     },
 
     [FitDataAction.UpdateLinkedVariables](context) {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -75,6 +75,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         if (rootState.appType === AppType.Fit) {
             commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
+            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { modelChanged: true }, { root: true });
             // initialise data links
             dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, { root: true });
             dispatch(`modelFit/${ModelFitAction.UpdateParamsToVary}`, null, { root: true });

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -74,7 +74,6 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
         }
 
         if (rootState.appType === AppType.Fit) {
-            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, true, { root: true });
             commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { modelChanged: true }, { root: true });
             // initialise data links
             dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, { root: true });

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -74,7 +74,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
         }
 
         if (rootState.appType === AppType.Fit) {
-            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequiredReasons}`, { modelChanged: true }, { root: true });
+            commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { modelChanged: true }, { root: true });
             // initialise data links
             dispatch(`fitData/${FitDataAction.UpdateLinkedVariables}`, null, { root: true });
             dispatch(`modelFit/${ModelFitAction.UpdateParamsToVary}`, null, { root: true });

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -47,6 +47,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             };
 
             commit(ModelFitMutation.SetFitUpdateRequired, false);
+            commit(ModelFitMutation.SetFitUpdateRequiredReasons, null);
             commit(ModelFitMutation.SetInputs, inputs);
             dispatch(ModelFitAction.FitModelStep, simplex);
         }

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -46,7 +46,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
                 link
             };
 
-            commit(ModelFitMutation.SetFitUpdateRequiredReasons, null);
+            commit(ModelFitMutation.SetFitUpdateRequired, null);
             commit(ModelFitMutation.SetInputs, inputs);
             dispatch(ModelFitAction.FitModelStep, simplex);
         }

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -46,7 +46,6 @@ export const actions: ActionTree<ModelFitState, FitState> = {
                 link
             };
 
-            commit(ModelFitMutation.SetFitUpdateRequired, false);
             commit(ModelFitMutation.SetFitUpdateRequiredReasons, null);
             commit(ModelFitMutation.SetInputs, inputs);
             dispatch(ModelFitAction.FitModelStep, simplex);

--- a/app/static/src/app/store/modelFit/getters.ts
+++ b/app/static/src/app/store/modelFit/getters.ts
@@ -16,7 +16,7 @@ export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
         const linkedVariables = rootState.fitData?.linkedVariables;
         const hasLinkedVariables = linkedVariables !== null
             && Object.values(linkedVariables).some((el: string | null) => el !== null);
-        const checklist = {
+        return {
             hasModel: !!rootState.model.odin,
             hasData: !!rootState.fitData.data,
             hasTimeVariable: !!rootState.fitData.timeVariable,
@@ -24,6 +24,5 @@ export const getters: ModelFitGetters & GetterTree<ModelFitState, FitState> = {
             hasTarget: !!rootState.fitData.columnToFit,
             hasParamsToVary: !!state.paramsToVary.length
         };
-        return checklist;
     }
 };

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -5,7 +5,6 @@ import { getters } from "./getters";
 
 export const defaultState: ModelFitState = {
     fitting: false,
-    fitUpdateRequired: true,
     fitUpdateRequiredReasons: {
         modelChanged: false,
         dataChanged: false,

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -5,7 +5,7 @@ import { getters } from "./getters";
 
 export const defaultState: ModelFitState = {
     fitting: false,
-    fitUpdateRequiredReasons: {
+    fitUpdateRequired: {
         modelChanged: false,
         dataChanged: false,
         linkChanged: false

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -10,7 +10,7 @@ export const defaultState: ModelFitState = {
         dataChanged: false,
         linkChanged: false,
         parameterValueChanged: false,
-        parameterToVaryChanged: false,
+        parameterToVaryChanged: false
     },
     iterations: null,
     converged: null,

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -9,7 +9,8 @@ export const defaultState: ModelFitState = {
         modelChanged: false,
         dataChanged: false,
         linkChanged: false,
-        parameterChanged: false
+        parameterValueChanged: false,
+        parameterToVaryChanged: false,
     },
     iterations: null,
     converged: null,

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -8,7 +8,8 @@ export const defaultState: ModelFitState = {
     fitUpdateRequired: {
         modelChanged: false,
         dataChanged: false,
-        linkChanged: false
+        linkChanged: false,
+        parameterChanged: false
     },
     iterations: null,
     converged: null,

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -6,6 +6,11 @@ import { getters } from "./getters";
 export const defaultState: ModelFitState = {
     fitting: false,
     fitUpdateRequired: true,
+    fitUpdateRequiredReasons: {
+        modelChanged: false,
+        dataChanged: false,
+        linkChanged: false
+    },
     iterations: null,
     converged: null,
     sumOfSquares: null,

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -43,7 +43,8 @@ export const mutations: MutationTree<ModelFitState> = {
             state.fitUpdateRequired = {
                 modelChanged: false,
                 dataChanged: false,
-                linkChanged: false
+                linkChanged: false,
+                parameterChanged: false
             };
         } else {
             state.fitUpdateRequired = {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from "vuex";
-import { ModelFitInputs, ModelFitState } from "./state";
+import { ModelFitInputs, ModelFitState, RerunFitReasons } from "./state";
 import { SimplexResult } from "../../types/responseTypes";
 
 export enum ModelFitMutation {
@@ -7,7 +7,9 @@ export enum ModelFitMutation {
     SetResult = "SetResult",
     SetInputs = "SetInputs",
     SetParamsToVary = "SetParamsToVary",
-    SetFitUpdateRequired = "SetFitUpdateRequired"
+    SetFitUpdateRequired = "SetFitUpdateRequired",
+    // TODO: rename to SetFitUpdateRequired when working
+    SetFitUpdateRequiredReasons = "SetFitUpdateRequiredReasons"
 }
 
 export const mutations: MutationTree<ModelFitState> = {
@@ -40,5 +42,20 @@ export const mutations: MutationTree<ModelFitState> = {
 
     [ModelFitMutation.SetFitUpdateRequired](state: ModelFitState, payload: boolean) {
         state.fitUpdateRequired = payload;
+    },
+
+    [ModelFitMutation.SetFitUpdateRequiredReasons](state: ModelFitState, payload: null | Partial<RerunFitReasons>) {
+        if (payload === null) {
+            state.fitUpdateRequiredReasons = {
+                modelChanged: false,
+                dataChanged: false,
+                linkChanged: false
+            };
+        } else {
+            state.fitUpdateRequiredReasons = {
+                ...state.fitUpdateRequiredReasons,
+                ...payload
+            };
+        }
     }
 };

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from "vuex";
-import { ModelFitInputs, ModelFitState, RerunFitReasons } from "./state";
+import { ModelFitInputs, ModelFitState, FitUpdateRequiredReasons } from "./state";
 import { SimplexResult } from "../../types/responseTypes";
 
 export enum ModelFitMutation {
@@ -7,8 +7,7 @@ export enum ModelFitMutation {
     SetResult = "SetResult",
     SetInputs = "SetInputs",
     SetParamsToVary = "SetParamsToVary",
-    // TODO: rename to SetFitUpdateRequired when working
-    SetFitUpdateRequiredReasons = "SetFitUpdateRequiredReasons"
+    SetFitUpdateRequired = "SetFitUpdateRequired"
 }
 
 export const mutations: MutationTree<ModelFitState> = {
@@ -39,16 +38,16 @@ export const mutations: MutationTree<ModelFitState> = {
         state.paramsToVary = payload;
     },
 
-    [ModelFitMutation.SetFitUpdateRequiredReasons](state: ModelFitState, payload: null | Partial<RerunFitReasons>) {
+    [ModelFitMutation.SetFitUpdateRequired](state: ModelFitState, payload: null | Partial<FitUpdateRequiredReasons>) {
         if (payload === null) {
-            state.fitUpdateRequiredReasons = {
+            state.fitUpdateRequired = {
                 modelChanged: false,
                 dataChanged: false,
                 linkChanged: false
             };
         } else {
-            state.fitUpdateRequiredReasons = {
-                ...state.fitUpdateRequiredReasons,
+            state.fitUpdateRequired = {
+                ...state.fitUpdateRequired,
                 ...payload
             };
         }

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -44,7 +44,8 @@ export const mutations: MutationTree<ModelFitState> = {
                 modelChanged: false,
                 dataChanged: false,
                 linkChanged: false,
-                parameterChanged: false
+                parameterValueChanged: false,
+                parameterToVaryChanged: false
             };
         } else {
             state.fitUpdateRequired = {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -7,7 +7,6 @@ export enum ModelFitMutation {
     SetResult = "SetResult",
     SetInputs = "SetInputs",
     SetParamsToVary = "SetParamsToVary",
-    SetFitUpdateRequired = "SetFitUpdateRequired",
     // TODO: rename to SetFitUpdateRequired when working
     SetFitUpdateRequiredReasons = "SetFitUpdateRequiredReasons"
 }
@@ -38,10 +37,6 @@ export const mutations: MutationTree<ModelFitState> = {
 
     [ModelFitMutation.SetParamsToVary](state: ModelFitState, payload: string[]) {
         state.paramsToVary = payload;
-    },
-
-    [ModelFitMutation.SetFitUpdateRequired](state: ModelFitState, payload: boolean) {
-        state.fitUpdateRequired = payload;
     },
 
     [ModelFitMutation.SetFitUpdateRequiredReasons](state: ModelFitState, payload: null | Partial<RerunFitReasons>) {

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -10,7 +10,8 @@ export interface ModelFitInputs {
 export interface FitUpdateRequiredReasons {
     modelChanged: boolean,
     dataChanged: boolean,
-    linkChanged: boolean
+    linkChanged: boolean,
+    parameterChanged: boolean
 }
 
 export interface ModelFitState {

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -7,9 +7,17 @@ export interface ModelFitInputs {
     link: FitDataLink;
 }
 
+// TODO: perhaps UpdatefitRequiredReasons?
+export interface RerunFitReasons {
+    modelChanged: boolean,
+    dataChanged: boolean,
+    linkChanged: boolean
+}
+
 export interface ModelFitState {
     fitting: boolean,
     fitUpdateRequired: boolean,
+    fitUpdateRequiredReasons: RerunFitReasons,
     iterations: number | null,
     converged: boolean | null,
     sumOfSquares: number | null,

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -7,8 +7,7 @@ export interface ModelFitInputs {
     link: FitDataLink;
 }
 
-// TODO: perhaps UpdatefitRequiredReasons?
-export interface FitUpdateRequiredReasons /* RerunFitReasons */ {
+export interface FitUpdateRequiredReasons {
     modelChanged: boolean,
     dataChanged: boolean,
     linkChanged: boolean
@@ -16,7 +15,7 @@ export interface FitUpdateRequiredReasons /* RerunFitReasons */ {
 
 export interface ModelFitState {
     fitting: boolean,
-    fitUpdateRequired: FitUpdateRequiredReasons, // TODO: rename member
+    fitUpdateRequired: FitUpdateRequiredReasons,
     iterations: number | null,
     converged: boolean | null,
     sumOfSquares: number | null,

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -8,7 +8,7 @@ export interface ModelFitInputs {
 }
 
 // TODO: perhaps UpdatefitRequiredReasons?
-export interface RerunFitReasons {
+export interface FitUpdateRequiredReasons /* RerunFitReasons */ {
     modelChanged: boolean,
     dataChanged: boolean,
     linkChanged: boolean
@@ -16,7 +16,7 @@ export interface RerunFitReasons {
 
 export interface ModelFitState {
     fitting: boolean,
-    fitUpdateRequiredReasons: RerunFitReasons,
+    fitUpdateRequired: FitUpdateRequiredReasons, // TODO: rename member
     iterations: number | null,
     converged: boolean | null,
     sumOfSquares: number | null,

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -8,10 +8,11 @@ export interface ModelFitInputs {
 }
 
 export interface FitUpdateRequiredReasons {
-    modelChanged: boolean,
-    dataChanged: boolean,
-    linkChanged: boolean,
-    parameterChanged: boolean
+    modelChanged: boolean;
+    dataChanged: boolean;
+    linkChanged: boolean;
+    parameterValueChanged: boolean;
+    parameterToVaryChanged: boolean;
 }
 
 export interface ModelFitState {

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -16,7 +16,6 @@ export interface RerunFitReasons {
 
 export interface ModelFitState {
     fitting: boolean,
-    fitUpdateRequired: boolean,
     fitUpdateRequiredReasons: RerunFitReasons,
     iterations: number | null,
     converged: boolean | null,

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -35,6 +35,15 @@ export default {
         compileRequired: "Model code has been updated. Compile code and Fit Model for updated best fit.",
         fitRequired: "Model code has been recompiled, or options or data have been updated. "
             + "Fit Model for updated best fit.",
+        updateFitReasons: {
+            prefix: "Fit is out of date:",
+            unknown: "unknown reasons, contact the administrator, as this is unexpected",
+            modelChanged: "model has been recompiled",
+            dataChanged: "data have been updated",
+            linkChanged: "model-data link has changed",
+            parametersChanged: "parameters have been updated",
+            suffix: "Rerun fit to view updated result"
+        },
         fitRequirements: {
             prefix: "Cannot fit model. Please",
             unknown: "contact the administrator, as this is unexpected",

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -39,7 +39,8 @@ export default {
             modelChanged: "model has been recompiled",
             dataChanged: "data have been updated",
             linkChanged: "model-data link has changed",
-            parameterChanged: "parameters have been updated",
+            parameterValueChanged: "parameters have been updated",
+            parameterToVaryChanged: "parameters to vary have been updated",
             suffix: "Rerun fit to view updated result"
         },
         fitRequirements: {

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -39,7 +39,7 @@ export default {
             modelChanged: "model has been recompiled",
             dataChanged: "data have been updated",
             linkChanged: "model-data link has changed",
-            parametersChanged: "parameters have been updated",
+            parameterChanged: "parameters have been updated",
             suffix: "Rerun fit to view updated result"
         },
         fitRequirements: {

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -33,8 +33,6 @@ export default {
         notFittedYet: "Model has not been fitted.",
         selectParamToVary: "Please select at least one parameter to vary during model fit.",
         compileRequired: "Model code has been updated. Compile code and Fit Model for updated best fit.",
-        fitRequired: "Model code has been recompiled, or options or data have been updated. "
-            + "Fit Model for updated best fit.",
         updateFitReasons: {
             prefix: "Fit is out of date:",
             unknown: "unknown reasons, contact the administrator, as this is unexpected",

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -194,4 +194,4 @@ export const allTrue = (x: Dict<boolean>): boolean => {
 
 export const anyTrue = (x: Dict<boolean>): boolean => {
     return Object.values(x).some((el: boolean) => el);
-}
+};

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -191,3 +191,7 @@ export const joinStringsSentence = (strings: string[], last = " and ", sep = ", 
 export const allTrue = (x: Dict<boolean>): boolean => {
     return Object.values(x).every((el: boolean) => el);
 };
+
+export const anyTrue = (x: Dict<boolean>): boolean => {
+    return Object.values(x).some((el: boolean) => el);
+}

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -258,9 +258,6 @@ test.describe("Wodin App model fit tests", () => {
         expect(newSumOfSquares).not.toEqual(sumOfSquares);
     });
 
-    const fitRequiredMsg = "Model code has been recompiled, or options or data have been updated. "
-        + "Fit Model for updated best fit.";
-
     test("can see expected update required messages when code changes", async ({ page }) => {
         await runFit(page);
         await expectUpdateFitMsg(page, "");
@@ -272,7 +269,7 @@ test.describe("Wodin App model fit tests", () => {
 
         // Compile code
         await page.click("#compile-btn");
-        await expectUpdateFitMsg(page, fitRequiredMsg);
+        await expectUpdateFitMsg(page, "Fit is out of date: model has been recompiled. Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -284,13 +281,14 @@ test.describe("Wodin App model fit tests", () => {
         await expect(await page.locator("#fitDataUpload")).toBeVisible({ timeout });
 
         await uploadCSVData(page, multiTimeFitData);
-        await expectUpdateFitMsg(page, fitRequiredMsg);
+
+        await expectUpdateFitMsg(page, "Fit is out of date: data have been updated. Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
 
         // Change time variable
         await page.selectOption("#select-time-variable", "Day2");
-        await expectUpdateFitMsg(page, fitRequiredMsg);
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -301,7 +299,7 @@ test.describe("Wodin App model fit tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
         await expect(await page.locator("#link-data select")).toBeVisible({ timeout });
         await page.selectOption("#link-data select", "E");
-        await expectUpdateFitMsg(page, fitRequiredMsg);
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -320,7 +318,7 @@ test.describe("Wodin App model fit tests", () => {
         const targetSelect = await page.locator("#optimisation select");
         await targetSelect.selectOption("Day2");
 
-        await expectUpdateFitMsg(page, fitRequiredMsg);
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -269,7 +269,8 @@ test.describe("Wodin App model fit tests", () => {
 
         // Compile code
         await page.click("#compile-btn");
-        await expectUpdateFitMsg(page, "Fit is out of date: model has been recompiled. Rerun fit to view updated result.");
+        await expectUpdateFitMsg(page, "Fit is out of date: model has been recompiled. "
+                                 + "Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -288,7 +289,8 @@ test.describe("Wodin App model fit tests", () => {
 
         // Change time variable
         await page.selectOption("#select-time-variable", "Day2");
-        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
+                                 + "Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -299,7 +301,8 @@ test.describe("Wodin App model fit tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
         await expect(await page.locator("#link-data select")).toBeVisible({ timeout });
         await page.selectOption("#link-data select", "E");
-        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
+                                 + "Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -318,7 +321,8 @@ test.describe("Wodin App model fit tests", () => {
         const targetSelect = await page.locator("#optimisation select");
         await targetSelect.selectOption("Day2");
 
-        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. Rerun fit to view updated result.");
+        await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
+                                 + "Rerun fit to view updated result.");
 
         await reRunFit(page); // checks message is reset
     });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -137,7 +137,7 @@ export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitS
             dataChanged: false,
             linkChanged: false,
             parameterValueChanged: false,
-            parameterToVaryChanged: false,
+            parameterToVaryChanged: false
         },
         iterations: null,
         converged: null,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -132,7 +132,11 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
 export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitState => {
     return {
         fitting: false,
-        fitUpdateRequired: true,
+        fitUpdateRequired: {
+            modelChanged: false,
+            dataChanged: false,
+            linkChanged: false
+        },
         iterations: null,
         converged: null,
         sumOfSquares: null,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -136,7 +136,8 @@ export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitS
             modelChanged: false,
             dataChanged: false,
             linkChanged: false,
-            parameterChanged: false
+            parameterValueChanged: false,
+            parameterToVaryChanged: false,
         },
         iterations: null,
         converged: null,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -135,7 +135,8 @@ export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitS
         fitUpdateRequired: {
             modelChanged: false,
             dataChanged: false,
-            linkChanged: false
+            linkChanged: false,
+            parameterChanged: false
         },
         iterations: null,
         converged: null,

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -16,7 +16,7 @@ describe("Fit Tab", () => {
     const getWrapper = (
         fitRequirements = {}, // ends up being true
         compileRequired = false,
-        fitUpdateRequired = false,
+        fitUpdateRequired = {},
         iterations: number | null = 10,
         converged: boolean | null = true,
         fitting = false,
@@ -40,8 +40,10 @@ describe("Fit Tab", () => {
                         converged,
                         fitting,
                         sumOfSquares,
-                        fitUpdateRequired
-
+                        fitUpdateRequired,
+                        result: {
+                            solution: jest.fn()
+                        }
                     } as any,
                     getters: {
                         fitRequirements: () => fitRequirements
@@ -152,11 +154,10 @@ describe("Fit Tab", () => {
     });
 
     it("renders as expected when fit update is required", () => {
-        const wrapper = getWrapper({}, false, true);
+        const wrapper = getWrapper({}, false, { dataChanged: true });
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Model code has been recompiled, or options or data have been updated. "
-                + "Fit Model for updated best fit.");
+            .toBe("Fit is out of date: data have been updated. Rerun fit to view updated result.");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(true);
         expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -72,7 +72,7 @@ describe("construct actionable fit update messages from fit state changes", () =
             dataChanged: true,
             linkChanged: true,
             parameterValueChanged: true,
-            parameterToVaryChanged: true,
+            parameterToVaryChanged: true
         };
         expect(fitUpdateRequiredExplanation(everything))
             .toBe("Fit is out of date: model has been recompiled and data have been updated. "

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -56,7 +56,8 @@ describe("construct actionable fit update messages from fit state changes", () =
         modelChanged: false,
         dataChanged: false,
         linkChanged: false,
-        parameterChanged: false
+        parameterValueChanged: false,
+        parameterToVaryChanged: false
     };
 
     it("shows fallback when no reason can be found", () => {
@@ -70,7 +71,8 @@ describe("construct actionable fit update messages from fit state changes", () =
             modelChanged: true,
             dataChanged: true,
             linkChanged: true,
-            parameterChanged: true
+            parameterValueChanged: true,
+            parameterToVaryChanged: true,
         };
         expect(fitUpdateRequiredExplanation(everything))
             .toBe("Fit is out of date: model has been recompiled and data have been updated. "
@@ -86,7 +88,9 @@ describe("construct actionable fit update messages from fit state changes", () =
             .toBe(`${prefix}: data have been updated. ${suffix}`);
         expect(fitUpdateRequiredExplanation({ ...base, linkChanged: true }))
             .toBe(`${prefix}: model-data link has changed. ${suffix}`);
-        expect(fitUpdateRequiredExplanation({ ...base, parameterChanged: true }))
+        expect(fitUpdateRequiredExplanation({ ...base, parameterValueChanged: true }))
             .toBe(`${prefix}: parameters have been updated. ${suffix}`);
+        expect(fitUpdateRequiredExplanation({ ...base, parameterToVaryChanged: true }))
+            .toBe(`${prefix}: parameters to vary have been updated. ${suffix}`);
     });
 });

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -1,4 +1,4 @@
-import { fitRequirementsExplanation } from "../../../../src/app/components/fit/support";
+import { fitRequirementsExplanation, fitUpdateRequiredExplanation } from "../../../../src/app/components/fit/support";
 
 describe("construct actionable error messages from requirements", () => {
     const reqsTrue = {
@@ -48,5 +48,45 @@ describe("construct actionable error messages from requirements", () => {
             .toBe("Cannot fit model. Please select a time variable for the data (Data tab).");
         expect(fitRequirementsExplanation({ ...reqsTrue, hasTarget: false }))
             .toBe("Cannot fit model. Please select a target to fit (Options tab).");
+    });
+});
+
+describe("construct actionable fit update messages from fit state changes", () => {
+    const base = {
+        modelChanged: false,
+        dataChanged: false,
+        linkChanged: false,
+        parameterChanged: false
+    };
+
+    it("shows fallback when no reason can be found", () => {
+        expect(fitUpdateRequiredExplanation(base))
+            .toBe("Fit is out of date: unknown reasons, contact the administrator, as this is unexpected. " +
+                  "Rerun fit to view updated result.");
+    });
+
+    it("shows sensible message when everything has changed", () => {
+        const everything = {
+            modelChanged: true,
+            dataChanged: true,
+            linkChanged: true,
+            parameterChanged: true
+        };
+        expect(fitUpdateRequiredExplanation(everything))
+            .toBe("Fit is out of date: model has been recompiled and data have been updated. " +
+                  "Rerun fit to view updated result.");
+    });
+
+    it("gives specific messages when little has changed", () => {
+        const prefix = "Fit is out of date";
+        const suffix = "Rerun fit to view updated result."
+        expect(fitUpdateRequiredExplanation({ ...base, modelChanged: true }))
+            .toBe(`${prefix}: model has been recompiled. ${suffix}`);
+        expect(fitUpdateRequiredExplanation({ ...base, dataChanged: true }))
+            .toBe(`${prefix}: data have been updated. ${suffix}`);
+        expect(fitUpdateRequiredExplanation({ ...base, linkChanged: true }))
+            .toBe(`${prefix}: model-data link has changed. ${suffix}`);
+        expect(fitUpdateRequiredExplanation({ ...base, parameterChanged: true }))
+            .toBe(`${prefix}: parameters have been updated. ${suffix}`);
     });
 });

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -61,8 +61,8 @@ describe("construct actionable fit update messages from fit state changes", () =
 
     it("shows fallback when no reason can be found", () => {
         expect(fitUpdateRequiredExplanation(base))
-            .toBe("Fit is out of date: unknown reasons, contact the administrator, as this is unexpected. " +
-                  "Rerun fit to view updated result.");
+            .toBe("Fit is out of date: unknown reasons, contact the administrator, as this is unexpected. "
+                  + "Rerun fit to view updated result.");
     });
 
     it("shows sensible message when everything has changed", () => {
@@ -73,13 +73,13 @@ describe("construct actionable fit update messages from fit state changes", () =
             parameterChanged: true
         };
         expect(fitUpdateRequiredExplanation(everything))
-            .toBe("Fit is out of date: model has been recompiled and data have been updated. " +
-                  "Rerun fit to view updated result.");
+            .toBe("Fit is out of date: model has been recompiled and data have been updated. "
+                  + "Rerun fit to view updated result.");
     });
 
     it("gives specific messages when little has changed", () => {
         const prefix = "Fit is out of date";
-        const suffix = "Rerun fit to view updated result."
+        const suffix = "Rerun fit to view updated result.";
         expect(fitUpdateRequiredExplanation({ ...base, modelChanged: true }))
             .toBe(`${prefix}: model has been recompiled. ${suffix}`);
         expect(fitUpdateRequiredExplanation({ ...base, dataChanged: true }))

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -145,21 +145,27 @@ describe("ParameterValues", () => {
 
     it("updates params to vary when checkbox is checked", async () => {
         const mockSetParamsToVary = jest.fn();
-        const store = getStore(true, null, jest.fn(), jest.fn(), ["param1"], mockSetParamsToVary);
+        const mockSetFitUpdateRequired = jest.fn();
+        const store = getStore(true, null, jest.fn(), mockSetFitUpdateRequired, ["param1"], mockSetParamsToVary);
         const wrapper = getWrapper(store);
         const row2 = wrapper.findAll("div.row").at(1)!;
         await row2.find("input.vary-param-check").setValue(true);
         expect(mockSetParamsToVary).toHaveBeenCalledTimes(1);
         expect(mockSetParamsToVary.mock.calls[0][1]).toStrictEqual(["param1", "param2"]);
+        expect(mockSetFitUpdateRequired).toHaveBeenCalledTimes(1);
+        expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterToVaryChanged: true });
     });
 
     it("updates params to vary when checkbox is unchecked", async () => {
         const mockSetParamsToVary = jest.fn();
-        const store = getStore(true, null, jest.fn(), jest.fn(), ["param1"], mockSetParamsToVary);
+        const mockSetFitUpdateRequired = jest.fn();
+        const store = getStore(true, null, jest.fn(), mockSetFitUpdateRequired, ["param1"], mockSetParamsToVary);
         const wrapper = getWrapper(store);
         const row1 = wrapper.findAll("div.row").at(0)!;
         await row1.find("input.vary-param-check").setValue(false);
         expect(mockSetParamsToVary).toHaveBeenCalledTimes(1);
         expect(mockSetParamsToVary.mock.calls[0][1]).toStrictEqual([]);
+        expect(mockSetFitUpdateRequired).toHaveBeenCalledTimes(1);
+        expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterToVaryChanged: true });
     });
 });

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -117,7 +117,7 @@ describe("ParameterValues", () => {
         const mockSetSensitivityUpdateRequired = jest.fn();
         const mockSetFitUpdateRequired = jest.fn();
         const wrapper = getWrapper(getStore(false, mockUpdateParameterValues, mockSetSensitivityUpdateRequired,
-                                            mockSetFitUpdateRequired));
+            mockSetFitUpdateRequired));
         const input2 = wrapper.findAllComponents(NumericInput).at(1)!;
         await input2.vm.$emit("update", 3.3);
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -15,6 +15,7 @@ describe("ParameterValues", () => {
     const getStore = (fitTabIsOpen = false,
         mockUpdateParameterValues: Mock<any, any> | null = null,
         mockSetSensitivityUpdateRequired = jest.fn(),
+        mockSetFitUpdateRequired = jest.fn(),
         paramsToVary: string[] = [],
         mockSetParamsToVary = jest.fn()) => {
         // Use mock or real mutations
@@ -42,7 +43,8 @@ describe("ParameterValues", () => {
                     namespaced: true,
                     state: mockModelFitState({ paramsToVary }),
                     mutations: {
-                        [ModelFitMutation.SetParamsToVary]: mockSetParamsToVary
+                        [ModelFitMutation.SetParamsToVary]: mockSetParamsToVary,
+                        [ModelFitMutation.SetFitUpdateRequired]: mockSetFitUpdateRequired
                     }
                 },
                 sensitivity: {
@@ -84,7 +86,7 @@ describe("ParameterValues", () => {
     });
 
     it("renders as expected when fit tab is open", () => {
-        const wrapper = getWrapper(getStore(true, null, jest.fn(), ["param1"]));
+        const wrapper = getWrapper(getStore(true, null, jest.fn(), jest.fn(), ["param1"]));
         const rows = wrapper.findAll("div.row");
 
         const p1 = rows.at(0)!;
@@ -104,7 +106,7 @@ describe("ParameterValues", () => {
     });
 
     it("shows select param to vary message if fit tab is open and none are selected", () => {
-        const wrapper = getWrapper(getStore(true, null, jest.fn(), []));
+        const wrapper = getWrapper(getStore(true, null, jest.fn(), jest.fn(), []));
         expect(wrapper.find("#select-param-msg").text()).toBe(
             "Please select at least one parameter to vary during model fit."
         );
@@ -113,13 +115,17 @@ describe("ParameterValues", () => {
     it("commits parameter value change", async () => {
         const mockUpdateParameterValues = jest.fn();
         const mockSetSensitivityUpdateRequired = jest.fn();
-        const wrapper = getWrapper(getStore(false, mockUpdateParameterValues, mockSetSensitivityUpdateRequired));
+        const mockSetFitUpdateRequired = jest.fn();
+        const wrapper = getWrapper(getStore(false, mockUpdateParameterValues, mockSetSensitivityUpdateRequired,
+                                            mockSetFitUpdateRequired));
         const input2 = wrapper.findAllComponents(NumericInput).at(1)!;
         await input2.vm.$emit("update", 3.3);
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
         expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({ param2: 3.3 });
         expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);
         expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toBe(true);
+        expect(mockSetFitUpdateRequired).toHaveBeenCalledTimes(1);
+        expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterChanged: true });
     });
 
     it("refreshes cleared input when odinSolution changes", async () => {
@@ -139,7 +145,7 @@ describe("ParameterValues", () => {
 
     it("updates params to vary when checkbox is checked", async () => {
         const mockSetParamsToVary = jest.fn();
-        const store = getStore(true, null, jest.fn(), ["param1"], mockSetParamsToVary);
+        const store = getStore(true, null, jest.fn(), jest.fn(), ["param1"], mockSetParamsToVary);
         const wrapper = getWrapper(store);
         const row2 = wrapper.findAll("div.row").at(1)!;
         await row2.find("input.vary-param-check").setValue(true);
@@ -149,7 +155,7 @@ describe("ParameterValues", () => {
 
     it("updates params to vary when checkbox is unchecked", async () => {
         const mockSetParamsToVary = jest.fn();
-        const store = getStore(true, null, jest.fn(), ["param1"], mockSetParamsToVary);
+        const store = getStore(true, null, jest.fn(), jest.fn(), ["param1"], mockSetParamsToVary);
         const wrapper = getWrapper(store);
         const row1 = wrapper.findAll("div.row").at(0)!;
         await row1.find("input.vary-param-check").setValue(false);

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -125,7 +125,7 @@ describe("ParameterValues", () => {
         expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);
         expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toBe(true);
         expect(mockSetFitUpdateRequired).toHaveBeenCalledTimes(1);
-        expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterChanged: true });
+        expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterValueChanged: true });
     });
 
     it("refreshes cleared input when odinSolution changes", async () => {

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -87,7 +87,7 @@ describe("Fit Data actions", () => {
             expect(commit.mock.calls[2][1]).toBe(9);
             expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-            expect(commit.mock.calls[3][1]).toBe(true);
+            expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
             expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
             expect(commit.mock.calls[4][1]).toBe(true);
@@ -278,7 +278,7 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[2][1]).toBe(10);
         expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
         expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[3][1]).toBe(true);
+        expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
         expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
         expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
         expect(commit.mock.calls[4][1]).toBe(true);
@@ -297,7 +297,7 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetLinkedVariable);
         expect(commit.mock.calls[0][1]).toBe(payload);
         expect(commit.mock.calls[1][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[1][1]).toBe(true);
+        expect(commit.mock.calls[1][1]).toStrictEqual({ linkChanged: true });
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
     });
 
@@ -321,7 +321,7 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetColumnToFit);
         expect(commit.mock.calls[0][1]).toBe("col1");
         expect(commit.mock.calls[1][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[1][1]).toBe(true);
+        expect(commit.mock.calls[1][1]).toStrictEqual({ linkChanged: true });
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
     });
 });

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -73,7 +73,7 @@ describe("Fit Data actions", () => {
         (actions[FitDataAction.Upload] as any)(context, file);
         expectFileRead(mockFileReader);
         setTimeout(() => {
-            expect(commit).toHaveBeenCalledTimes(5);
+            expect(commit).toHaveBeenCalledTimes(6);
             expect(commit.mock.calls[0][0]).toBe(FitDataMutation.SetData);
             const expectedSetDataPayload = {
                 data: mockData,
@@ -92,6 +92,9 @@ describe("Fit Data actions", () => {
             expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
             expect(commit.mock.calls[4][1]).toBe(true);
             expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
+            expect(commit.mock.calls[5][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
+            expect(commit.mock.calls[5][1]).toStrictEqual({ dataChanged: true });
+            expect(commit.mock.calls[5][2]).toStrictEqual({ root: true });
             done();
         }, fileTimeout);
     });

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -165,7 +165,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[6][1]).toBe(null);
         expect(commit.mock.calls[6][2]).toStrictEqual({ root: true });
         expect(commit.mock.calls[7][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[7][1]).toBe(true);
+        expect(commit.mock.calls[7][1]).toStrictEqual({ modelChanged: true });
         expect(commit.mock.calls[7][2]).toStrictEqual({ root: true });
 
         expect(dispatch).toHaveBeenCalledTimes(2);

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -68,7 +68,7 @@ describe("ModelFit actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetFitting);
         expect(commit.mock.calls[0][1]).toBe(true);
         expect(commit.mock.calls[1][0]).toBe(ModelFitMutation.SetFitUpdateRequired);
-        expect(commit.mock.calls[1][1]).toBe(false);
+        expect(commit.mock.calls[1][1]).toBe(null);
         expect(commit.mock.calls[2][0]).toBe(ModelFitMutation.SetInputs);
         expect(commit.mock.calls[2][1]).toEqual({
             data: expectedData,

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -67,7 +67,8 @@ describe("ModelFit mutations", () => {
             dataChanged: false,
             linkChanged: false,
             modelChanged: false,
-            parameterChanged: false
+            parameterValueChanged: false,
+            parameterToVaryChanged: false
         };
         expect(state.fitUpdateRequired).toEqual(base);
         mutations.SetFitUpdateRequired(state, { dataChanged: true });

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -66,7 +66,8 @@ describe("ModelFit mutations", () => {
         const base = {
             dataChanged: false,
             linkChanged: false,
-            modelChanged: false
+            modelChanged: false,
+            parameterChanged: false
         };
         expect(state.fitUpdateRequired).toEqual(base);
         mutations.SetFitUpdateRequired(state, { dataChanged: true });

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -63,8 +63,15 @@ describe("ModelFit mutations", () => {
 
     it("sets fitUpdateRequired", () => {
         const state = mockModelFitState();
-        expect(state.fitUpdateRequired).toBe(true);
-        mutations.SetFitUpdateRequired(state, false);
-        expect(state.fitUpdateRequired).toBe(false);
+        const base = {
+            dataChanged: false,
+            linkChanged: false,
+            modelChanged: false
+        };
+        expect(state.fitUpdateRequired).toEqual(base);
+        mutations.SetFitUpdateRequired(state, { dataChanged: true });
+        expect(state.fitUpdateRequired).toEqual({ ...base, dataChanged: true });
+        mutations.SetFitUpdateRequired(state, null);
+        expect(state.fitUpdateRequired).toEqual(base);
     });
 });


### PR DESCRIPTION
This PR breaks apart one of the other omnibus error messages:

> Model code has been recompiled, or options or data have been updated. Fit Model for updated best fit.

with one that explains more precisely what has changed. This turned out to be a little more involved than the fit requirements one (#67) because it wasn't a case of looking at the inputs we have and saying "is this what I need" but keeping track of what has been invalidated. So I've updated the `fitUpdateRequired` member of state from being a boolean to being a Dict of reasons. When we update one of the bits of state that previously set this flag to `true` it now sets the reason. At that point the pattern looks very similar with a little helper to try and construct sensible error messages from the set of flags.

I have snuck in a missing error case, when the parameters are updated we need to warn that the fit is out of date. Currently that was set up for the run and sensitivity but not the fit