### PR TITLE
Add session label endpoint

### DIFF
--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -15,7 +15,7 @@ export class SessionsController {
         const { redis, wodinConfig } = req.app.locals as AppLocals;
         const { appName, id } = req.params;
         const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
-        await store.saveSessionLabel(id, JSON.parse(req.body as string));
+        await store.saveSessionLabel(id, req.body as string);
         res.end();
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -10,4 +10,12 @@ export class SessionsController {
         await store.saveSession(id, req.body as string);
         res.end();
     };
+
+    static postSessionLabel = async (req: Request, res: Response) => {
+        const { redis, wodinConfig } = req.app.locals as AppLocals;
+        const { appName, id } = req.params;
+        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        await store.saveSessionLabel(id, JSON.parse(req.body as string));
+        res.end();
+    };
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -18,4 +18,8 @@ export class SessionStore {
             .hset(this.sessionKey("data"), id, data)
             .exec();
     }
+
+    async saveSessionLabel(id: string, label: string) {
+        await this._redis.hset(this.sessionKey("label"), id, label);
+    }
 }

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -10,7 +10,7 @@ router.get("/:appName", AppsController.getApp);
 router.post("/:appName/sessions/:id", bodyParser.text({ type: "application/json" }), SessionsController.postSession);
 router.post(
     "/:appName/sessions/:id/label",
-    bodyParser.text({ type: "application/json" }),
+    bodyParser.text(),
     SessionsController.postSessionLabel
 );
 

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -8,6 +8,10 @@ router.get("/:appName", AppsController.getApp);
 
 // Parse the posted JSON as text since all we are going to do with it is to save it to redis
 router.post("/:appName/sessions/:id", bodyParser.text({ type: "application/json" }), SessionsController.postSession);
-router.post("/:appName/sessions/:id/label", bodyParser.text({ type: "application/json" }), SessionsController.postSessionLabel);
+router.post(
+    "/:appName/sessions/:id/label",
+    bodyParser.text({ type: "application/json" }),
+    SessionsController.postSessionLabel
+);
 
 export default router;

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -8,5 +8,6 @@ router.get("/:appName", AppsController.getApp);
 
 // Parse the posted JSON as text since all we are going to do with it is to save it to redis
 router.post("/:appName/sessions/:id", bodyParser.text({ type: "application/json" }), SessionsController.postSession);
+router.post("/:appName/sessions/:id/label", bodyParser.text({ type: "application/json" }), SessionsController.postSessionLabel);
 
 export default router;

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -57,7 +57,7 @@ describe("SessionsController", () => {
                 appName: "testApp",
                 id: "1234"
             },
-            body: "some label"
+            body: "\"some label\""
         } as any;
 
         SessionsController.postSessionLabel(req, res);

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -7,22 +7,6 @@ jest.mock("../../src/db/sessionStore");
 describe("SessionsController", () => {
     const mockSessionStore = SessionStore as Mock;
 
-    const req = {
-        app: {
-            locals: {
-                redis: {},
-                wodinConfig: {
-                    savePrefix: "testPrefix"
-                }
-            }
-        },
-        params: {
-            appName: "testApp",
-            id: "1234"
-        },
-        body: "testBody"
-    } as any;
-
     const res = {
         end: jest.fn()
     } as any;
@@ -32,6 +16,22 @@ describe("SessionsController", () => {
     });
 
     it("can save session", () => {
+        const req = {
+            app: {
+                locals: {
+                    redis: {},
+                    wodinConfig: {
+                        savePrefix: "testPrefix"
+                    }
+                }
+            },
+            params: {
+                appName: "testApp",
+                id: "1234"
+            },
+            body: "testBody"
+        } as any;
+
         SessionsController.postSession(req, res);
         expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
         expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
@@ -41,5 +41,33 @@ describe("SessionsController", () => {
         expect(storeInstance.saveSession).toHaveBeenCalledTimes(1);
         expect(storeInstance.saveSession.mock.calls[0][0]).toBe("1234");
         expect(storeInstance.saveSession.mock.calls[0][1]).toBe("testBody");
+    });
+
+    it("can save label", () => {
+        const req = {
+            app: {
+                locals: {
+                    redis: {},
+                    wodinConfig: {
+                        savePrefix: "testPrefix"
+                    }
+                }
+            },
+            params: {
+                appName: "testApp",
+                id: "1234"
+            },
+            body: "some label"
+        } as any;
+
+        SessionsController.postSessionLabel(req, res);
+        expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
+        expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
+        expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
+        expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
+        const storeInstance = mockSessionStore.mock.instances[0];
+        expect(storeInstance.saveSessionLabel).toHaveBeenCalledTimes(1);
+        expect(storeInstance.saveSessionLabel.mock.calls[0][0]).toBe("1234");
+        expect(storeInstance.saveSessionLabel.mock.calls[0][1]).toBe("some label");
     });
 });

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -57,7 +57,7 @@ describe("SessionsController", () => {
                 appName: "testApp",
                 id: "1234"
             },
-            body: "\"some label\""
+            body: "some label"
         } as any;
 
         SessionsController.postSessionLabel(req, res);

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -35,9 +35,8 @@ describe("Sessionstore", () => {
     });
 
     it("can save label", async () => {
-        const data = "testSession";
         const id = "1234";
-        const label = "some label"
+        const label = "some label";
         const sut = new SessionStore(mockRedis, "Test Course", "testApp");
         await sut.saveSessionLabel(id, label);
         expect(mockRedis.hset).toHaveBeenCalledTimes(1);

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -14,7 +14,8 @@ describe("Sessionstore", () => {
     mockPipeline.hset = jest.fn().mockReturnValue(mockPipeline);
 
     const mockRedis = {
-        pipeline: jest.fn().mockReturnValue(mockPipeline)
+        pipeline: jest.fn().mockReturnValue(mockPipeline),
+        hset: jest.fn().mockReturnValue(mockPipeline)
     } as any;
 
     it("can save session", async () => {
@@ -31,5 +32,17 @@ describe("Sessionstore", () => {
         expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
         expect(mockPipeline.hset.mock.calls[1][2]).toBe("testSession");
         expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it("can save label", async () => {
+        const data = "testSession";
+        const id = "1234";
+        const label = "some label"
+        const sut = new SessionStore(mockRedis, "Test Course", "testApp");
+        await sut.saveSessionLabel(id, label);
+        expect(mockRedis.hset).toHaveBeenCalledTimes(1);
+        expect(mockRedis.hset.mock.calls[0][0]).toBe("Test Course:testApp:sessions:label");
+        expect(mockRedis.hset.mock.calls[0][1]).toBe("1234");
+        expect(mockRedis.hset.mock.calls[0][2]).toBe("some label");
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -46,12 +46,12 @@ describe("Session label integration", () => {
     const url = `apps/day1/sessions/${sessionId}/label`;
 
     it("can post and update new label", async () => {
-        const response1 = await post(url, "some label");
+        const response1 = await post(url, "some label", "text/plain");
         expect(response1.status).toBe(200);
         const label1 = await getRedisValue(`${redisKeyPrefix}label`, sessionId);
         expect(label1).toBe("some label");
 
-        const response2 = await post(url, "some other label");
+        const response2 = await post(url, "some other label", "text/plain");
         expect(response2.status).toBe(200);
         const label2 = await getRedisValue(`${redisKeyPrefix}label`, sessionId);
         expect(label2).toBe("some other label");

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -2,7 +2,7 @@ import {
     flushRedis, getRedisValue, expectRedisJSONValue, post
 } from "./utils";
 
-describe("Session integration", () => {
+describe("Session id integration", () => {
     afterEach(async () => {
         await flushRedis();
     });
@@ -33,5 +33,27 @@ describe("Session integration", () => {
 
         const newTime = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
         expect(Date.parse(newTime!)).toBeGreaterThan(Date.parse(oldTime!));
+    });
+});
+
+describe("Session label integration", () => {
+    afterEach(async () => {
+        await flushRedis();
+    });
+
+    const redisKeyPrefix = "example:day1:sessions:";
+    const sessionId = "1234";
+    const url = `apps/day1/sessions/${sessionId}/label`;
+
+    it("can post and update new label", async () => {
+        const response1 = await post(url, "some label");
+        expect(response1.status).toBe(200);
+        const label1 = await getRedisValue(`${redisKeyPrefix}label`, sessionId);
+        expect(label1).toBe("some label");
+
+        const response2 = await post(url, "some other label");
+        expect(response2.status).toBe(200);
+        const label2 = await getRedisValue(`${redisKeyPrefix}label`, sessionId);
+        expect(label2).toBe("some other label");
     });
 });

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -4,8 +4,8 @@ import Redis from "ioredis";
 const fullUrl = (url: string) => `http://localhost:3000/${url}`;
 const redisUrl = "redis://localhost:6379";
 
-export const post = async (url: string, body: any) => {
-    const headers = { "Content-Type": "application/json" };
+export const post = async (url: string, body: any, contentType: string = "application/json") => {
+    const headers = { "Content-Type": contentType };
     return axios.post(fullUrl(url), body, { headers });
 };
 

--- a/app/server/tests/routes/apps.test.ts
+++ b/app/server/tests/routes/apps.test.ts
@@ -29,6 +29,8 @@ describe("odin routes", () => {
         expect(mockRouter.get.mock.calls[0][1]).toBe(AppsController.getApp);
         expect(mockRouter.post.mock.calls[0][0]).toBe("/:appName/sessions/:id");
         expect(mockRouter.post.mock.calls[0][2]).toBe(SessionsController.postSession);
+        expect(mockRouter.post.mock.calls[1][0]).toBe("/:appName/sessions/:id/label");
+        expect(mockRouter.post.mock.calls[1][2]).toBe(SessionsController.postSessionLabel);
         expect(spyText).toHaveBeenCalledWith({ type: "application/json" });
     });
 });


### PR DESCRIPTION
This just blatently duplicates the pattern from your previous PR (https://github.com/mrc-ide/wodin/pull/59)

The label ends up passed as a string, picks up the extra json quotes along the way, then gets stripped off (see the `JSON.parse` in sessionController.ts and the the bodyParser.text call in apps.ts - not sure if that's the best way