### PR TITLE
mrc-3535 Get sessions metadata

### DIFF
--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,12 +1,12 @@
 import { Request, Response } from "express";
-import {AppLocals, SessionMetadata} from "../types";
+import { AppLocals, SessionMetadata } from "../types";
 import { SessionStore } from "../db/sessionStore";
-import {jsonResponseSuccess} from "../jsonResponse";
+import { jsonResponseSuccess } from "../jsonResponse";
 
 export class SessionsController {
     private static getStore = (req: Request) => {
         const { redis, wodinConfig } = req.app.locals as AppLocals;
-        const {appName} = req.params;
+        const { appName } = req.params;
         return new SessionStore(redis, wodinConfig.savePrefix, appName);
     };
 

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,13 +1,31 @@
 import { Request, Response } from "express";
 import { AppLocals } from "../types";
 import { SessionStore } from "../db/sessionStore";
+import {jsonResponseSuccess} from "../jsonResponse";
 
 export class SessionsController {
-    static postSession = async (req: Request, res: Response) => {
+    private static getStore = (req: Request) => {
         const { redis, wodinConfig } = req.app.locals as AppLocals;
-        const { appName, id } = req.params;
-        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        const {appName} = req.params;
+        return new SessionStore(redis, wodinConfig.savePrefix, appName);
+    };
+
+    static postSession = async (req: Request, res: Response) => {
+        const { id } = req.params;
+        const store = SessionsController.getStore(req);
         await store.saveSession(id, req.body as string);
         res.end();
+    };
+
+    static getSessionsMetadata = async (req: Request, res: Response) => {
+        const sessionIdsString = req.query.sessionIds as string;
+        if (sessionIdsString) {
+            const sessionIds = sessionIdsString.split(",");
+            const store = SessionsController.getStore(req);
+            const metadata = store.getSessionsMetadata(sessionIds);
+            jsonResponseSuccess(metadata, res);
+        } else {
+            res.end();
+        }
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -23,7 +23,6 @@ export class SessionsController {
             const sessionIds = sessionIdsString.split(",");
             const store = SessionsController.getStore(req);
             const metadata = await store.getSessionsMetadata(sessionIds);
-            console.log("metadata is: " + JSON.stringify(metadata))
             jsonResponseSuccess(metadata, res);
         } else {
             res.end();

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { AppLocals } from "../types";
+import {AppLocals, SessionMetadata} from "../types";
 import { SessionStore } from "../db/sessionStore";
 import {jsonResponseSuccess} from "../jsonResponse";
 
@@ -19,13 +19,12 @@ export class SessionsController {
 
     static getSessionsMetadata = async (req: Request, res: Response) => {
         const sessionIdsString = req.query.sessionIds as string;
+        let metadata: SessionMetadata[] = [];
         if (sessionIdsString) {
             const sessionIds = sessionIdsString.split(",");
             const store = SessionsController.getStore(req);
-            const metadata = await store.getSessionsMetadata(sessionIds);
-            jsonResponseSuccess(metadata, res);
-        } else {
-            res.end();
+            metadata = await store.getSessionsMetadata(sessionIds);
         }
+        jsonResponseSuccess(metadata, res);
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -22,7 +22,8 @@ export class SessionsController {
         if (sessionIdsString) {
             const sessionIds = sessionIdsString.split(",");
             const store = SessionsController.getStore(req);
-            const metadata = store.getSessionsMetadata(sessionIds);
+            const metadata = await store.getSessionsMetadata(sessionIds);
+            console.log("metadata is: " + JSON.stringify(metadata))
             jsonResponseSuccess(metadata, res);
         } else {
             res.end();

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -21,15 +21,14 @@ export class SessionStore {
     }
 
     async getSessionsMetadata(ids: string[]) {
-        console.log("ids:" + JSON.stringify(ids))
-        const result = [];
-        console.log("session key on get is: " + this.sessionKey("time"))
+        const result: any[] = [];
         for (const id of ids) {
-            // eslint-disable-next-line no-await-in-loop
-            const time = await this._redis.hget(this.sessionKey("time"), id);
-            console.log("got time value: " + time)
-            const label = await this._redis.hget(this.sessionKey("label"), id);
-            result.push({id, time, label});
+            await Promise.all([
+                this._redis.hget(this.sessionKey("time"), id),
+                this._redis.hget(this.sessionKey("label"), id)
+            ]).then((values) => {
+                result.push({id, time: values[0], label: values[1]});
+            });
         }
         return result;
     }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -18,4 +18,15 @@ export class SessionStore {
             .hset(this.sessionKey("data"), id, data)
             .exec();
     }
+
+    async getSessionsMetadata(ids: string[]) {
+        const result = [];
+        for (const id of ids) {
+            // eslint-disable-next-line no-await-in-loop
+            const time = await this._redis.hget(this.sessionKey(id), "time");
+            const label = await this._redis.hget(this.sessionKey(id), "label");
+            result.push({id, time, label});
+        }
+        return result;
+    }
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -28,13 +28,13 @@ export class SessionStore {
             const times = values[0];
             const labels = values[1];
             const allResults = ids.map((id: string, idx: number) => {
-                return {id, time: times[idx], label: labels[idx]};
+                return { id, time: times[idx], label: labels[idx] };
             });
             return allResults.filter((session) => session.time !== null) as SessionMetadata[];
         });
-    };
+    }
 
     async saveSessionLabel(id: string, label: string) {
         await this._redis.hset(this.sessionKey("label"), id, label);
-    };
+    }
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -1,5 +1,4 @@
 import Redis from "ioredis";
-import {SessionMetadata} from "../types";
 
 export class SessionStore {
     private readonly _redis: Redis;
@@ -28,7 +27,7 @@ export class SessionStore {
             const times = values[0];
             const labels = values[1];
             return ids.map((id: string, idx: number) => {
-                return {id, time: times[idx], label: labels[idx]};
+                return { id, time: times[idx], label: labels[idx] };
             });
         });
     }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -1,4 +1,5 @@
 import Redis from "ioredis";
+import { SessionMetadata } from "../types";
 
 export class SessionStore {
     private readonly _redis: Redis;
@@ -26,9 +27,10 @@ export class SessionStore {
         ]).then((values) => {
             const times = values[0];
             const labels = values[1];
-            return ids.map((id: string, idx: number) => {
+            const allResults = ids.map((id: string, idx: number) => {
                 return { id, time: times[idx], label: labels[idx] };
             });
+            return allResults.filter((session) => session.time !== null) as SessionMetadata[];
         });
     }
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -13,6 +13,7 @@ export class SessionStore {
     private sessionKey = (name: string) => `${this._sessionPrefix}${name}`;
 
     async saveSession(id: string, data: string) {
+        console.log("session key on save is: " + this.sessionKey("time"))
         await this._redis.pipeline()
             .hset(this.sessionKey("time"), id, new Date(Date.now()).toISOString())
             .hset(this.sessionKey("data"), id, data)
@@ -20,11 +21,14 @@ export class SessionStore {
     }
 
     async getSessionsMetadata(ids: string[]) {
+        console.log("ids:" + JSON.stringify(ids))
         const result = [];
+        console.log("session key on get is: " + this.sessionKey("time"))
         for (const id of ids) {
             // eslint-disable-next-line no-await-in-loop
-            const time = await this._redis.hget(this.sessionKey(id), "time");
-            const label = await this._redis.hget(this.sessionKey(id), "label");
+            const time = await this._redis.hget(this.sessionKey("time"), id);
+            console.log("got time value: " + time)
+            const label = await this._redis.hget(this.sessionKey("label"), id);
             result.push({id, time, label});
         }
         return result;

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -8,5 +8,6 @@ router.get("/:appName", AppsController.getApp);
 
 // Parse the posted JSON as text since all we are going to do with it is to save it to redis
 router.post("/:appName/sessions/:id", bodyParser.text({ type: "application/json" }), SessionsController.postSession);
+router.get("/:appName/sessions/metadata", SessionsController.getSessionsMetadata);
 
 export default router;

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -30,6 +30,6 @@ export interface AppLocals {
 
 export interface SessionMetadata {
     id: string,
-    time: string | null,
+    time: string,
     label: string | null
 }

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -27,3 +27,9 @@ export interface AppLocals {
     wodinVersion: String,
     redis: Redis
 }
+
+export interface SessionMetadata {
+    id: string,
+    time: string | null,
+    label: string | null
+}

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -34,10 +34,6 @@ describe("SessionsController", () => {
 
     it("can save session", async () => {
         await SessionsController.postSession(req, res);
-    });
-
-    it("can save session", () => {
-        SessionsController.postSession(req, res);
         expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
         expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
         expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -73,7 +73,7 @@ describe("SessionsController", () => {
     });
 
     it("can save label", () => {
-        const req = {
+        const labelReq = {
             app: {
                 locals: {
                     redis: {},
@@ -89,9 +89,9 @@ describe("SessionsController", () => {
             body: "some label"
         } as any;
 
-        SessionsController.postSessionLabel(req, res);
+        SessionsController.postSessionLabel(labelReq, res);
         expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
-        expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
+        expect(mockSessionStore.mock.calls[0][0]).toBe(labelReq.app.locals.redis);
         expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
         expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
         const storeInstance = mockSessionStore.mock.instances[0];

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -1,6 +1,7 @@
 import { SessionStore } from "../../src/db/sessionStore";
 import Mock = jest.Mock;
 import { SessionsController } from "../../src/controllers/sessionsController";
+import mock = jest.mock;
 
 jest.mock("../../src/db/sessionStore");
 
@@ -20,19 +21,21 @@ describe("SessionsController", () => {
             appName: "testApp",
             id: "1234"
         },
+        query: {},
         body: "testBody"
     } as any;
 
     const res = {
-        end: jest.fn()
+        end: jest.fn(),
+        header: jest.fn()
     } as any;
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it("can save session", () => {
-        SessionsController.postSession(req, res);
+    it("can save session", async () => {
+        await SessionsController.postSession(req, res);
         expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
         expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
         expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
@@ -41,5 +44,33 @@ describe("SessionsController", () => {
         expect(storeInstance.saveSession).toHaveBeenCalledTimes(1);
         expect(storeInstance.saveSession.mock.calls[0][0]).toBe("1234");
         expect(storeInstance.saveSession.mock.calls[0][1]).toBe("testBody");
+        expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("can get session metadata", async () => {
+        const metadataReq = {
+            ...req,
+            query: {
+                sessionIds: "1234,5678"
+            }
+        };
+        await SessionsController.getSessionsMetadata(metadataReq, res);
+        expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
+        expect(mockSessionStore.mock.calls[0][0]).toBe(req.app.locals.redis);
+        expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
+        expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
+        const storeInstance = mockSessionStore.mock.instances[0];
+        expect(storeInstance.getSessionsMetadata).toHaveBeenCalledTimes(1);
+        expect(storeInstance.getSessionsMetadata.mock.calls[0][0]).toStrictEqual(["1234", "5678"]);
+
+        expect(res.header).toHaveBeenCalledWith("Content-Type", "application/json");
+        expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("can get empty session metadata with missing ids parameter", async () =>{
+        await SessionsController.getSessionsMetadata(req, res);
+        expect(mockSessionStore).not.toHaveBeenCalled();
+        expect(res.header).toHaveBeenCalledWith("Content-Type", "application/json");
+        expect(res.end).toHaveBeenCalledTimes(1);
     });
 });

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -1,7 +1,6 @@
 import { SessionStore } from "../../src/db/sessionStore";
 import Mock = jest.Mock;
 import { SessionsController } from "../../src/controllers/sessionsController";
-import mock = jest.mock;
 
 jest.mock("../../src/db/sessionStore");
 
@@ -67,7 +66,7 @@ describe("SessionsController", () => {
         expect(res.end).toHaveBeenCalledTimes(1);
     });
 
-    it("can get empty session metadata with missing ids parameter", async () =>{
+    it("can get empty session metadata with missing ids parameter", async () => {
         await SessionsController.getSessionsMetadata(req, res);
         expect(mockSessionStore).not.toHaveBeenCalled();
         expect(res.header).toHaveBeenCalledWith("Content-Type", "application/json");

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -15,13 +15,10 @@ describe("Sessionstore", () => {
 
     const mockRedis = {
         pipeline: jest.fn().mockReturnValue(mockPipeline),
-<<<<<<< HEAD
         hmget: jest.fn().mockImplementation(async (key: string, ...fields: string[]) => {
             return fields.map((field: string) => `${field} value for ${key}`);
-        })
-=======
+        }),
         hset: jest.fn().mockReturnValue(mockPipeline)
->>>>>>> main
     } as any;
 
     it("can save session", async () => {

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -36,7 +36,7 @@ describe("Sessionstore", () => {
         expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
     });
 
-    it("cam get session metadata", async () => {
+    it("can get session metadata", async () => {
         const sut = new SessionStore(mockRedis, "Test Course", "testApp");
         const result = await sut.getSessionsMetadata(["1234", "5678"]);
         expect(result).toStrictEqual([
@@ -51,5 +51,16 @@ describe("Sessionstore", () => {
                 label: "5678 value for Test Course:testApp:sessions:label"
             }
         ]);
+    });
+
+    it("filters out session metadata for session ids with no values in db", async () => {
+        const mockNullResultRedis = {
+            hmget: jest.fn().mockImplementation(async (key: string, ...fields: string[]) => {
+                return fields.map(() => null);
+            })
+        } as any;
+        const sut = new SessionStore(mockNullResultRedis, "Test Course", "testApp");
+        const result = await sut.getSessionsMetadata(["1234", "5678"]);
+        expect(result).toStrictEqual([]);
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -53,7 +53,6 @@ describe("Session integration", () => {
         // get sessions
         const getMetadataUrl = `apps/day1/sessions/metadata?sessionIds=${sessionId},${anotherSessionId}`;
         const response = await get(getMetadataUrl);
-        console.log(response.data);
         const sessions = response.data.data;
         expect(Array.isArray(sessions)).toBe(true);
         expect(sessions.length).toBe(2);
@@ -65,5 +64,14 @@ describe("Session integration", () => {
         expect(sessions[1].id).toBe(anotherSessionId);
         expectRecentTime(sessions[1].time);
         expect(sessions[1].label).toBe("label2");
+    });
+
+    it("gets empty sessionMetadata if sessionIds parameter omitted", async () => {
+        const getMetadataUrl = `apps/day1/sessions/metadata`;
+        const response = await get(getMetadataUrl);
+        const sessions = response.data.data;
+        console.log(JSON.stringify(sessions))
+        expect(Array.isArray(sessions)).toBe(true);
+        expect(sessions.length).toBe(0);
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -1,5 +1,5 @@
 import {
-    flushRedis, getRedisValue, expectRedisJSONValue, post
+    flushRedis, getRedisValue, setRedisValue, expectRedisJSONValue, post, get
 } from "./utils";
 
 describe("Session integration", () => {
@@ -9,29 +9,61 @@ describe("Session integration", () => {
 
     const redisKeyPrefix = "example:day1:sessions:";
     const sessionId = "1234";
-    const url = `apps/day1/sessions/${sessionId}`;
+    const postSessionUrl = (id: string = sessionId) => `apps/day1/sessions/${id}`;
+
+    const expectRecentTime = (isoTime: string) => {
+        const date = Date.parse(isoTime!);
+        expect(Date.now() - date).toBeLessThan(1000); // expect saved time to be in last second
+    };
 
     it("can post new session", async () => {
         const data = { test: "value" };
-        const response = await post(url, data);
+        const response = await post(postSessionUrl(), data);
         expect(response.status).toBe(200);
         await expectRedisJSONValue(`${redisKeyPrefix}data`, sessionId, data);
         const time = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
-        const date = Date.parse(time!);
-        expect(Date.now() - date).toBeLessThan(1000); // expect saved time to be in last second
+        expectRecentTime(time);
     });
 
     it("can update session", async () => {
         const oldData = { test: "oldValue" };
-        await post(url, oldData);
+        await post(postSessionUrl(), oldData);
         const oldTime = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
 
         const newData = { test: "newValue" };
-        const response = await post(url, newData);
+        const response = await post(postSessionUrl(), newData);
         expect(response.status).toBe(200);
         await expectRedisJSONValue(`${redisKeyPrefix}data`, sessionId, newData);
 
         const newTime = await getRedisValue(`${redisKeyPrefix}time`, sessionId);
         expect(Date.parse(newTime!)).toBeGreaterThan(Date.parse(oldTime!));
+    });
+
+    it("can get session metadata", async () => {
+        // post sessions
+        const data = { test: "value" };
+        await post(postSessionUrl(), data);
+        const anotherSessionId = "5678";
+        await post(postSessionUrl(anotherSessionId), data);
+
+        // set labels
+        await setRedisValue(`${redisKeyPrefix}label`, sessionId, "label1");
+        await setRedisValue(`${redisKeyPrefix}label`, anotherSessionId, "label2");
+
+        // get sessions
+        const getMetadataUrl = `apps/day1/sessions/metadata?sessionIds=${sessionId},${anotherSessionId}`;
+        const response = await get(getMetadataUrl);
+        console.log(response.data);
+        const sessions = response.data.data;
+        expect(Array.isArray(sessions)).toBe(true);
+        expect(sessions.length).toBe(2);
+
+        expect(sessions[0].id).toBe(sessionId);
+        expectRecentTime(sessions[0].time);
+        expect(sessions[0].label).toBe("label1");
+
+        expect(sessions[1].id).toBe(anotherSessionId);
+        expectRecentTime(sessions[1].time);
+        expect(sessions[1].label).toBe("label2");
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -72,4 +72,23 @@ describe("Session integration", () => {
         expect(Array.isArray(sessions)).toBe(true);
         expect(sessions.length).toBe(0);
     });
+
+    it("does not return metadata for non-existent sessions", async () => {
+        let getMetadataUrl = "apps/day1/sessions/metadata?sessionIds=nonexistent1,nonexistent2";
+        let response = await get(getMetadataUrl);
+        let sessions = response.data.data;
+        expect(Array.isArray(sessions)).toBe(true);
+        expect(sessions.length).toBe(0);
+
+        // check can also handle a mixture of existent and non-existent ids
+        await post(postSessionUrl(sessionId), { test: "value" });
+        getMetadataUrl = `apps/day1/sessions/metadata?sessionIds=nonexistent1,${sessionId}`;
+        response = await get(getMetadataUrl);
+        sessions = response.data.data;
+        expect(Array.isArray(sessions)).toBe(true);
+        expect(sessions.length).toBe(1);
+        expect(sessions[0].id).toBe(sessionId);
+        expectRecentTime(sessions[0].time);
+        expect(sessions[0].label).toBe(null);
+    });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -69,7 +69,6 @@ describe("Session integration", () => {
         const getMetadataUrl = "apps/day1/sessions/metadata";
         const response = await get(getMetadataUrl);
         const sessions = response.data.data;
-        console.log(JSON.stringify(sessions));
         expect(Array.isArray(sessions)).toBe(true);
         expect(sessions.length).toBe(0);
     });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -46,9 +46,8 @@ describe("Session integration", () => {
         const anotherSessionId = "5678";
         await post(postSessionUrl(anotherSessionId), data);
 
-        // set labels
+        // set label for one of the sessions
         await setRedisValue(`${redisKeyPrefix}label`, sessionId, "label1");
-        await setRedisValue(`${redisKeyPrefix}label`, anotherSessionId, "label2");
 
         // get sessions
         const getMetadataUrl = `apps/day1/sessions/metadata?sessionIds=${sessionId},${anotherSessionId}`;
@@ -63,14 +62,14 @@ describe("Session integration", () => {
 
         expect(sessions[1].id).toBe(anotherSessionId);
         expectRecentTime(sessions[1].time);
-        expect(sessions[1].label).toBe("label2");
+        expect(sessions[1].label).toBe(null);
     });
 
     it("gets empty sessionMetadata if sessionIds parameter omitted", async () => {
-        const getMetadataUrl = `apps/day1/sessions/metadata`;
+        const getMetadataUrl = "apps/day1/sessions/metadata";
         const response = await get(getMetadataUrl);
         const sessions = response.data.data;
-        console.log(JSON.stringify(sessions))
+        console.log(JSON.stringify(sessions));
         expect(Array.isArray(sessions)).toBe(true);
         expect(sessions.length).toBe(0);
     });

--- a/app/server/tests/integration/utils.ts
+++ b/app/server/tests/integration/utils.ts
@@ -9,6 +9,10 @@ export const post = async (url: string, body: any) => {
     return axios.post(fullUrl(url), body, { headers });
 };
 
+export const get = async (url: string) => {
+    return axios.get(fullUrl(url));
+};
+
 const withRedis = async (func: (redis: Redis) => any) => {
     const redis = new Redis(redisUrl);
     try {
@@ -21,6 +25,12 @@ const withRedis = async (func: (redis: Redis) => any) => {
 export const getRedisValue = async (key: string, field: string) => {
     return withRedis((redis: Redis) => {
         return redis.hget(key, field);
+    });
+};
+
+export const setRedisValue = async (key: string, field: string, value: string) => {
+    await withRedis(async (redis: Redis) => {
+        await redis.hset(key, field, value);
     });
 };
 

--- a/app/server/tests/routes/apps.test.ts
+++ b/app/server/tests/routes/apps.test.ts
@@ -24,9 +24,11 @@ describe("odin routes", () => {
     it("registers expected routes", async () => {
         await import("../../src/routes/apps");
 
-        expect(mockRouter.get).toBeCalledTimes(1);
+        expect(mockRouter.get).toBeCalledTimes(2);
         expect(mockRouter.get.mock.calls[0][0]).toBe("/:appName");
         expect(mockRouter.get.mock.calls[0][1]).toBe(AppsController.getApp);
+        expect(mockRouter.get.mock.calls[1][0]).toBe("/:appName/sessions/metadata");
+        expect(mockRouter.get.mock.calls[1][1]).toBe(SessionsController.getSessionsMetadata);
         expect(mockRouter.post.mock.calls[0][0]).toBe("/:appName/sessions/:id");
         expect(mockRouter.post.mock.calls[0][2]).toBe(SessionsController.postSession);
         expect(spyText).toHaveBeenCalledWith({ type: "application/json" });


### PR DESCRIPTION
This branch adds the endpoint to get session metadata given a list of session ids, provided in a 'sessionIds' query string parameters where ids are comma-separated. The response data is an array of objects containing 'id' (session id), 'time' and 'label'.

This will be used to display metadata on the user's sessions on the Sessions page. 