### PR TITLE
Better messages when run/sensitivity update required

### DIFF
--- a/app/static/src/app/components/fit/support.ts
+++ b/app/static/src/app/components/fit/support.ts
@@ -1,12 +1,6 @@
 import { ModelFitRequirements, FitUpdateRequiredReasons } from "../../store/modelFit/state";
 import userMessages from "../../userMessages";
-import { joinStringsSentence } from "../../utils";
-
-const appendIf = (container: string[], test: boolean, value: string) => {
-    if (test) {
-        container.push(value);
-    }
-};
+import { appendIf, joinStringsSentence } from "../../utils";
 
 export const fitRequirementsExplanation = (reqs: ModelFitRequirements): string => {
     const explanation: string[] = [];

--- a/app/static/src/app/components/options/ParameterValues.vue
+++ b/app/static/src/app/components/options/ParameterValues.vue
@@ -69,7 +69,7 @@ export default defineComponent({
         const updateValue = (newValue: number, paramName: string) => {
             store.commit(`run/${RunMutation.UpdateParameterValues}`, { [paramName]: newValue });
             store.commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { parameterValueChanged: true });
-            store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true);
+            store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { parameterValueChanged: true });
         };
 
         const checkBoxChange = (paramName: string, event: Event) => {

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -41,9 +41,7 @@ export default defineComponent({
 
         const updateEndTime = (newValue: number) => {
             store.commit(`run/${RunMutation.SetEndTime}`, newValue);
-            // TODO: perhaps not, see elsewhere
-            // app/static/src/app/store/fitData/actions.ts
-            store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { endTimeChanged: true });
+            store.commit(`sensitivity/${SensitivityMutation.SetEndTime}`, newValue);
         };
 
         return {

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -41,7 +41,9 @@ export default defineComponent({
 
         const updateEndTime = (newValue: number) => {
             store.commit(`run/${RunMutation.SetEndTime}`, newValue);
-            store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true);
+            // TODO: perhaps not, see elsewhere
+            // app/static/src/app/store/fitData/actions.ts
+            store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { endTimeChanged: true });
         };
 
         return {

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -17,6 +17,8 @@ import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { RunAction } from "../../store/run/actions";
 import userMessages from "../../userMessages";
 import ErrorInfo from "../ErrorInfo.vue";
+import { runRequiredExplanation } from "./support";
+import { anyTrue } from "../../utils";
 
 export default defineComponent({
     name: "RunTab",
@@ -39,9 +41,9 @@ export default defineComponent({
             if (store.state.model.compileRequired) {
                 return userMessages.run.compileRequired;
             }
-            // TOOD: eventually make runRequired to updateRequired I think?
-            if (store.state.run.runRequired) {
-                return userMessages.run.runRequired;
+            // TOOD: eventually make runRequired to runUpdateRequired I think?
+            if (anyTrue(store.state.run.runRequired)) {
+                return runRequiredExplanation(store.state.run.runRequired);
             }
             return "";
         });

--- a/app/static/src/app/components/run/support.ts
+++ b/app/static/src/app/components/run/support.ts
@@ -1,0 +1,14 @@
+import { RunUpdateRequiredReasons } from "../../store/run/state";
+import userMessages from "../../userMessages";
+import { appendIf, joinStringsSentence } from "../../utils";
+
+export const runRequiredExplanation = (reasons: RunUpdateRequiredReasons): string => {
+    const explanation: string[] = [];
+    const help = userMessages.run.updateReasons;
+    appendIf(explanation, reasons.modelChanged, help.modelChanged);
+    appendIf(explanation, reasons.parameterValueChanged && !reasons.modelChanged, help.parameterValueChanged);
+    appendIf(explanation, reasons.endTimeChanged && !reasons.modelChanged, help.endTimeChanged);
+    // Fallback reason if something unexpected has happened.
+    appendIf(explanation, explanation.length === 0, help.unknown);
+    return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;
+};

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -24,6 +24,8 @@ import userMessages from "../../userMessages";
 import { SensitivityPlotType } from "../../store/sensitivity/state";
 import SensitivitySummaryPlot from "./SensitivitySummaryPlot.vue";
 import ErrorInfo from "../ErrorInfo.vue";
+import { sensitivityUpdateRequiredExplanation } from "./support";
+import { anyTrue } from "../../utils";
 
 export default defineComponent({
     name: "SensitivityTab",
@@ -51,8 +53,8 @@ export default defineComponent({
                 if (store.state.model.compileRequired) {
                     return userMessages.sensitivity.compileRequiredForUpdate;
                 }
-                if (sensitivityUpdateRequired.value) {
-                    return userMessages.sensitivity.runRequiredForUpdate;
+                if (anyTrue(sensitivityUpdateRequired.value)) {
+                    return sensitivityUpdateRequiredExplanation(sensitivityUpdateRequired.value);
                 }
             }
             return "";

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -4,7 +4,7 @@
       :placeholder-message="placeholderMessage"
       :end-time="endTime"
       :plot-data="allPlotData"
-      :redrawWatches="solutions">
+      :redrawWatches="solutions ? [...solutions] : []">
     <slot></slot>
   </wodin-ode-plot>
 </template>

--- a/app/static/src/app/components/sensitivity/support.ts
+++ b/app/static/src/app/components/sensitivity/support.ts
@@ -1,0 +1,15 @@
+import { SensitivityUpdateRequiredReasons } from "../../store/sensitivity/state";
+import userMessages from "../../userMessages";
+import { appendIf, joinStringsSentence } from "../../utils";
+
+export const sensitivityUpdateRequiredExplanation = (reasons: SensitivityUpdateRequiredReasons): string => {
+    const explanation: string[] = [];
+    const help = userMessages.sensitivity.updateReasons;
+    appendIf(explanation, reasons.modelChanged, help.modelChanged);
+    appendIf(explanation, reasons.parameterValueChanged && !reasons.modelChanged, help.parameterValueChanged);
+    appendIf(explanation, reasons.endTimeChanged && !reasons.modelChanged, help.endTimeChanged);
+    appendIf(explanation, reasons.sensitivityOptionsChanged && !reasons.modelChanged, help.sensitivityOptionsChanged);
+    // Fallback reason if something unexpected has happened.
+    appendIf(explanation, explanation.length === 0, help.unknown);
+    return `${help.prefix} ${joinStringsSentence(explanation)}. ${help.suffix}.`;
+};

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -44,12 +44,8 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
     if (timeVariable && data) {
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
+        commit(`sensitivity/${SensitivityMutation.SetEndTime}`, endTime, { root: true });
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
-        // TODO: here we should either mutate this from
-        // run/mutations.ts or check the value of
-        // state.modelFit.runRequired.endtimeChanged and set this
-        // accordingly, as otherwise this will be over enthusiastic...
-        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { endTimeChanged: true }, { root: true });
     }
 };
 

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -45,7 +45,11 @@ const respondUpdatedTimeVariable = (context: ActionContext<FitDataState, FitStat
         const endTime = data[data.length - 1][timeVariable]!;
         commit(`run/${RunMutation.SetEndTime}`, endTime, { root: true });
         commit(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`, { linkChanged: true }, { root: true });
-        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
+        // TODO: here we should either mutate this from
+        // run/mutations.ts or check the value of
+        // state.modelFit.runRequired.endtimeChanged and set this
+        // accordingly, as otherwise this will be over enthusiastic...
+        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { endTimeChanged: true }, { root: true });
     }
 };
 

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -62,7 +62,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
         if (state.compileRequired) {
             commit(ModelMutation.SetCompileRequired, false);
             commit(`run/${RunMutation.SetRunRequired}`, { modelChanged: true }, { root: true });
-            commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
+            commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { modelChanged: true }, { root: true });
         }
 
         // set or update selected sensitivity variable

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -61,7 +61,7 @@ const compileModel = (context: ActionContext<ModelState, AppState>) => {
 
         if (state.compileRequired) {
             commit(ModelMutation.SetCompileRequired, false);
-            commit(`run/${RunMutation.SetRunRequired}`, true, { root: true });
+            commit(`run/${RunMutation.SetRunRequired}`, { modelChanged: true }, { root: true });
             commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, true, { root: true });
         }
 

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -1,5 +1,5 @@
 import { MutationTree } from "vuex";
-import { RunState } from "./state";
+import { RunState, RunUpdateRequiredReasons } from "./state";
 import { OdinUserType } from "../../types/responseTypes";
 import { OdinRunResult } from "../../types/wrapperTypes";
 
@@ -14,11 +14,18 @@ export enum RunMutation {
 export const mutations: MutationTree<RunState> = {
     [RunMutation.SetResult](state: RunState, payload: OdinRunResult) {
         state.result = payload;
-        state.runRequired = false;
+        state.runRequired = {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false
+        };
     },
 
-    [RunMutation.SetRunRequired](state: RunState, payload: boolean) {
-        state.runRequired = payload;
+    [RunMutation.SetRunRequired](state: RunState, payload: Partial<RunUpdateRequiredReasons>) {
+        state.runRequired = {
+            ...state.runRequired,
+            ...payload
+        };
     },
 
     [RunMutation.SetParameterValues](state: RunState, payload: OdinUserType) {
@@ -30,13 +37,19 @@ export const mutations: MutationTree<RunState> = {
             Object.keys(payload).forEach((key) => {
                 state.parameterValues![key] = payload[key];
             });
-            state.runRequired = true;
+            state.runRequired = {
+                ...state.runRequired,
+                parameterValueChanged: true
+            };
         }
     },
 
     [RunMutation.SetEndTime](state: RunState, payload: number) {
         state.endTime = payload;
         const prevEndTime = state.result?.inputs?.endTime ? state.result.inputs.endTime : -1;
-        state.runRequired = payload > prevEndTime;
+        state.runRequired = {
+            ...state.runRequired,
+            endTimeChanged: payload > prevEndTime
+        }
     }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -50,6 +50,6 @@ export const mutations: MutationTree<RunState> = {
         state.runRequired = {
             ...state.runRequired,
             endTimeChanged: payload > prevEndTime
-        }
+        };
     }
 };

--- a/app/static/src/app/store/run/run.ts
+++ b/app/static/src/app/store/run/run.ts
@@ -3,7 +3,11 @@ import { mutations } from "./mutations";
 import { actions } from "./actions";
 
 export const defaultState: RunState = {
-    runRequired: false,
+    runRequired: {
+        modelChanged: false,
+        parameterValueChanged: false,
+        endTimeChanged: false
+    },
     parameterValues: null,
     endTime: 100,
     result: null

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -1,9 +1,15 @@
 import { OdinUserType } from "../../types/responseTypes";
 import { OdinRunResult } from "../../types/wrapperTypes";
 
+export interface RunUpdateRequiredReasons {
+    modelChanged: boolean;
+    parameterValueChanged: boolean;
+    endTimeChanged: boolean;
+}
+
 export interface RunState {
     // Set to true if the stored solution at `result` is out of date
-    runRequired: boolean;
+    runRequired: RunUpdateRequiredReasons;
     // Parameter values to pass into the next solution
     parameterValues: null | OdinUserType;
     // End time for the next solution

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -8,7 +8,7 @@ export interface RunUpdateRequiredReasons {
 }
 
 export interface RunState {
-    // Set to true if the stored solution at `result` is out of date
+    // Contains reasons why the run miht be out of date
     runRequired: RunUpdateRequiredReasons;
     // Parameter values to pass into the next solution
     parameterValues: null | OdinUserType;

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -37,7 +37,12 @@ export const actions: ActionTree<SensitivityState, AppState> = {
             }
             commit(SensitivityMutation.SetResult, payload);
             if (payload.batch !== null) {
-                commit(SensitivityMutation.SetUpdateRequired, false);
+                commit(SensitivityMutation.SetUpdateRequired, {
+                    modelChanged: false,
+                    parameterValueChanged: false,
+                    endTimeChanged: false,
+                    sensitivityOptionsChanged: false
+                });
                 // Also re-run model if required so that plotted central traces are correct
                 if (rootState.run.runRequired) {
                     dispatch(`run/${RunAction.RunModel}`, null, { root: true });

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -1,6 +1,10 @@
 import { MutationTree } from "vuex";
 import {
-    SensitivityParameterSettings, SensitivityPlotExtreme, SensitivityPlotType, SensitivityState
+    SensitivityParameterSettings,
+    SensitivityPlotExtreme,
+    SensitivityPlotType,
+    SensitivityState,
+    SensitivityUpdateRequiredReasons
 } from "./state";
 import { OdinSensitivityResult } from "../../types/wrapperTypes";
 
@@ -17,20 +21,30 @@ export enum SensitivityMutation {
 export const mutations: MutationTree<SensitivityState> = {
     [SensitivityMutation.SetParameterToVary](state: SensitivityState, payload: string | null) {
         state.paramSettings.parameterToVary = payload;
-        state.sensitivityUpdateRequired = true;
+        state.sensitivityUpdateRequired = {
+            ...state.sensitivityUpdateRequired,
+            sensitivityOptionsChanged: true
+        };
     },
 
     [SensitivityMutation.SetParamSettings](state: SensitivityState, payload: SensitivityParameterSettings) {
         state.paramSettings = payload;
-        state.sensitivityUpdateRequired = true;
+        state.sensitivityUpdateRequired = {
+            ...state.sensitivityUpdateRequired,
+            sensitivityOptionsChanged: true
+        };
     },
 
     [SensitivityMutation.SetResult](state: SensitivityState, payload: OdinSensitivityResult) {
         state.result = payload;
     },
 
-    [SensitivityMutation.SetUpdateRequired](state: SensitivityState, payload: boolean) {
-        state.sensitivityUpdateRequired = payload;
+    [SensitivityMutation.SetUpdateRequired](state: SensitivityState,
+        payload: Partial<SensitivityUpdateRequiredReasons>) {
+        state.sensitivityUpdateRequired = {
+            ...state.sensitivityUpdateRequired,
+            ...payload
+        };
     },
 
     [SensitivityMutation.SetPlotType](state: SensitivityState, payload: SensitivityPlotType) {

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -12,6 +12,7 @@ export enum SensitivityMutation {
     SetParameterToVary = "SetParameterToVary",
     SetParamSettings = "SetParamSettings",
     SetResult = "SetResult",
+    SetEndTime = "SetEndTime",
     SetUpdateRequired = "SetUpdateRequired",
     SetPlotType = "SetPlotType",
     SetPlotExtreme = "SetPlotExtreme",
@@ -44,6 +45,14 @@ export const mutations: MutationTree<SensitivityState> = {
         state.sensitivityUpdateRequired = {
             ...state.sensitivityUpdateRequired,
             ...payload
+        };
+    },
+
+    [SensitivityMutation.SetEndTime](state: SensitivityState, payload: number) {
+        const prevEndTime = state.result?.inputs?.endTime ? state.result.inputs.endTime : -1;
+        state.sensitivityUpdateRequired = {
+            ...state.sensitivityUpdateRequired,
+            endTimeChanged: payload > prevEndTime
         };
     },
 

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -24,7 +24,12 @@ export const defaultState: SensitivityState = {
         extreme: SensitivityPlotExtreme.Max,
         time: null
     },
-    sensitivityUpdateRequired: false,
+    sensitivityUpdateRequired: {
+        modelChanged: false,
+        parameterValueChanged: false,
+        endTimeChanged: false,
+        sensitivityOptionsChanged: false
+    },
     result: null
 };
 

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -38,10 +38,17 @@ export interface SensitivityPlotSettings {
     time: null | number
 }
 
+export interface SensitivityUpdateRequiredReasons {
+    modelChanged: boolean;
+    parameterValueChanged: boolean;
+    endTimeChanged: boolean;
+    sensitivityOptionsChanged: boolean;
+}
+
 export interface SensitivityState {
     paramSettings: SensitivityParameterSettings,
     // Whether sensitivity needs to be re-run because of change to settings or model
-    sensitivityUpdateRequired: boolean
+    sensitivityUpdateRequired: SensitivityUpdateRequiredReasons
     plotSettings: SensitivityPlotSettings,
     result: OdinSensitivityResult | null;
 }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -26,7 +26,15 @@ export default {
     run: {
         compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",
         runRequired: "Model code has been recompiled or options have been updated. Run Model to view updated graph.",
-        notRunYet: "Model has not been run."
+        notRunYet: "Model has not been run.",
+        updateReasons: {
+            prefix: "Plot is out of date:",
+            modelChanged: "model code has been recompiled",
+            parameterValueChanged: "parameters have been changed",
+            endTimeChanged: "end time has changed",
+            unknown: "unknown reasons, contact the administrator, as this is unexpected",
+            suffix: "Run model to view updated graph"
+        }
     },
     modelFit: {
         cancelled: "Model fit was cancelled before converging",
@@ -61,6 +69,13 @@ export default {
         runRequiredForUpdate: "Model code has been recompiled or options have been updated. "
             + "Run Sensitivity to view updated graph.",
         invalidSettings: "Invalid settings",
-        notRunYet: "Sensitivity has not been run."
+        notRunYet: "Sensitivity has not been run.",
+        updateReasons: {
+            prefix: "Plot is out of date:",
+            modelChanged: "model code has been recompiled",
+            parameterValueChanged: "parameters have been changed",
+            sensitivityOptionschanged: "sensitivity options have been changed",
+            suffix: "Run model to view updated graph"
+        }
     }
 };

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -25,7 +25,6 @@ export default {
     },
     run: {
         compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",
-        runRequired: "Model code has been recompiled or options have been updated. Run Model to view updated graph.",
         notRunYet: "Model has not been run.",
         updateReasons: {
             prefix: "Plot is out of date:",
@@ -66,8 +65,6 @@ export default {
         compileRequiredForOptions: "Please compile a valid model in order to set sensitivity options.",
         compileRequiredForUpdate: "Model code has been updated. "
             + "Compile code and Run Sensitivity to view updated graph.",
-        runRequiredForUpdate: "Model code has been recompiled or options have been updated. "
-            + "Run Sensitivity to view updated graph.",
         invalidSettings: "Invalid settings",
         notRunYet: "Sensitivity has not been run.",
         updateReasons: {

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -24,7 +24,7 @@ export default {
         columnToFitPrerequisites: "Please link at least one column in order to set target to fit."
     },
     run: {
-        compileRequired: "Model code has been updated. Compile code and Run Model to view updated graph.",
+        compileRequired: "Model code has been updated. Compile code and Run Model to update.",
         notRunYet: "Model has not been run.",
         updateReasons: {
             prefix: "Plot is out of date:",
@@ -32,7 +32,7 @@ export default {
             parameterValueChanged: "parameters have been changed",
             endTimeChanged: "end time has changed",
             unknown: "unknown reasons, contact the administrator, as this is unexpected",
-            suffix: "Run model to view updated graph"
+            suffix: "Run model to update"
         }
     },
     modelFit: {
@@ -48,7 +48,7 @@ export default {
             linkChanged: "model-data link has changed",
             parameterValueChanged: "parameters have been updated",
             parameterToVaryChanged: "parameters to vary have been updated",
-            suffix: "Rerun fit to view updated result"
+            suffix: "Rerun fit to update"
         },
         fitRequirements: {
             prefix: "Cannot fit model. Please",
@@ -64,7 +64,7 @@ export default {
     sensitivity: {
         compileRequiredForOptions: "Please compile a valid model in order to set sensitivity options.",
         compileRequiredForUpdate: "Model code has been updated. "
-            + "Compile code and Run Sensitivity to view updated graph.",
+            + "Compile code and Run Sensitivity to update.",
         invalidSettings: "Invalid settings",
         notRunYet: "Sensitivity has not been run.",
         updateReasons: {
@@ -74,7 +74,7 @@ export default {
             sensitivityOptionsChanged: "sensitivity options have been changed",
             endTimeChanged: "end time has changed",
             unknown: "unknown reasons, contact the administrator, as this is unexpected",
-            suffix: "Run sensitivity to view updated graph"
+            suffix: "Run sensitivity to update"
         }
     }
 };

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -74,8 +74,10 @@ export default {
             prefix: "Plot is out of date:",
             modelChanged: "model code has been recompiled",
             parameterValueChanged: "parameters have been changed",
-            sensitivityOptionschanged: "sensitivity options have been changed",
-            suffix: "Run model to view updated graph"
+            sensitivityOptionsChanged: "sensitivity options have been changed",
+            endTimeChanged: "end time has changed",
+            unknown: "unknown reasons, contact the administrator, as this is unexpected",
+            suffix: "Run sensitivity to view updated graph"
         }
     }
 };

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -188,6 +188,12 @@ export const joinStringsSentence = (strings: string[], last = " and ", sep = ", 
     return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
 };
 
+export const appendIf = (container: string[], test: boolean, value: string) => {
+    if (test) {
+        container.push(value);
+    }
+};
+
 export const allTrue = (x: Dict<boolean>): boolean => {
     return Object.values(x).every((el: boolean) => el);
 };

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -188,7 +188,7 @@ export const joinStringsSentence = (strings: string[], last = " and ", sep = ", 
     return strings.slice(0, n - 1).join(sep) + last + strings[n - 1];
 };
 
-export const appendIf = (container: string[], test: boolean, value: string) => {
+export const appendIf = (container: string[], test: boolean, value: string): void => {
     if (test) {
         container.push(value);
     }

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -70,7 +70,7 @@ test.describe("Code Tab tests", () => {
         // Compile code - see new update message
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -58,7 +58,7 @@ test.describe("Code Tab tests", () => {
         await writeCode(page, newValidCode);
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
@@ -70,7 +70,7 @@ test.describe("Code Tab tests", () => {
         // Compile code - see new update message
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to update.", {
                 timeout
             }
         );
@@ -92,7 +92,7 @@ test.describe("Code Tab tests", () => {
         await writeCode(page, invalidCode);
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
@@ -106,7 +106,7 @@ test.describe("Code Tab tests", () => {
         const invalidCode = "faker\n";
         await writeCode(page, invalidCode);
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
@@ -124,7 +124,7 @@ test.describe("Code Tab tests", () => {
         await writeCode(page, invalidCode);
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
@@ -137,7 +137,7 @@ test.describe("Code Tab tests", () => {
         const defaultCode = await page.innerText(".wodin-left .wodin-content .editor-container");
         await writeCode(page, newInvalidCode);
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -270,7 +270,7 @@ test.describe("Wodin App model fit tests", () => {
         // Compile code
         await page.click("#compile-btn");
         await expectUpdateFitMsg(page, "Fit is out of date: model has been recompiled. "
-                                 + "Rerun fit to view updated result.");
+                                 + "Rerun fit to update.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -283,14 +283,14 @@ test.describe("Wodin App model fit tests", () => {
 
         await uploadCSVData(page, multiTimeFitData);
 
-        await expectUpdateFitMsg(page, "Fit is out of date: data have been updated. Rerun fit to view updated result.");
+        await expectUpdateFitMsg(page, "Fit is out of date: data have been updated. Rerun fit to update.");
 
         await reRunFit(page); // checks message is reset
 
         // Change time variable
         await page.selectOption("#select-time-variable", "Day2");
         await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
-                                 + "Rerun fit to view updated result.");
+                                 + "Rerun fit to update.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -302,7 +302,7 @@ test.describe("Wodin App model fit tests", () => {
         await expect(await page.locator("#link-data select")).toBeVisible({ timeout });
         await page.selectOption("#link-data select", "E");
         await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
-                                 + "Rerun fit to view updated result.");
+                                 + "Rerun fit to update.");
 
         await reRunFit(page); // checks message is reset
     });
@@ -322,7 +322,7 @@ test.describe("Wodin App model fit tests", () => {
         await targetSelect.selectOption("Day2");
 
         await expectUpdateFitMsg(page, "Fit is out of date: model-data link has changed. "
-                                 + "Rerun fit to view updated result.");
+                                 + "Rerun fit to update.");
 
         await reRunFit(page); // checks message is reset
     });

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -109,7 +109,7 @@ test.describe("Link Variables tests", () => {
         );
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/link.etest.ts
+++ b/app/static/tests/e2e/link.etest.ts
@@ -103,13 +103,13 @@ test.describe("Link Variables tests", () => {
         await page.fill(".monaco-editor textarea", newVariableCode);
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to update.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -63,7 +63,7 @@ test.describe("Options Tab tests", () => {
         await page.fill(":nth-match(#model-params input, 1)", "3");
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Plot is out of date: parameters have been changed. Run model to view updated graph.", {
+            "Plot is out of date: parameters have been changed. Run model to update.", {
                 timeout
             }
         );
@@ -88,7 +88,7 @@ test.describe("Options Tab tests", () => {
         await page.fill(".monaco-editor textarea", newValidCode);
 
         await expect(page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been updated. Compile code and Run Model to view updated graph.", {
+            "Model code has been updated. Compile code and Run Model to update.", {
                 timeout
             }
         );
@@ -96,7 +96,7 @@ test.describe("Options Tab tests", () => {
         // Compile code
         await page.click("#compile-btn");
         await expect(page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to update.", {
                 timeout
             }
         );
@@ -120,7 +120,7 @@ test.describe("Options Tab tests", () => {
         await page.fill("#run-options input", "200");
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Plot is out of date: end time has changed. Run model to view updated graph.", {
+            "Plot is out of date: end time has changed. Run model to update.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -63,7 +63,7 @@ test.describe("Options Tab tests", () => {
         await page.fill(":nth-match(#model-params input, 1)", "3");
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+            "Plot is out of date: parameters have been changed. Run model to view updated graph.", {
                 timeout
             }
         );
@@ -96,7 +96,7 @@ test.describe("Options Tab tests", () => {
         // Compile code
         await page.click("#compile-btn");
         await expect(page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+            "Plot is out of date: model code has been recompiled. Run model to view updated graph.", {
                 timeout
             }
         );
@@ -120,7 +120,7 @@ test.describe("Options Tab tests", () => {
         await page.fill("#run-options input", "200");
 
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph.", {
+            "Plot is out of date: end time has changed. Run model to view updated graph.", {
                 timeout
             }
         );

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -111,8 +111,7 @@ test.describe("Sensitivity tests", () => {
         // change parameter - should see update required message
         await page.fill("#model-params .parameter-input", "5");
         await expect(await page.innerText(".action-required-msg"))
-            .toBe("Model code has been recompiled or options have been updated. "
-                + "Run Sensitivity to view updated graph.");
+            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to view updated graph.");
 
         // re-run - message should be removed
         await page.click("#run-sens-btn");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -111,7 +111,7 @@ test.describe("Sensitivity tests", () => {
         // change parameter - should see update required message
         await page.fill("#model-params .parameter-input", "5");
         await expect(await page.innerText(".action-required-msg"))
-            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to view updated graph.");
+            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to update.");
 
         // re-run - message should be removed
         await page.click("#run-sens-btn");

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -109,7 +109,12 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
             extreme: SensitivityPlotExtreme.Max,
             time: null
         },
-        sensitivityUpdateRequired: false,
+        sensitivityUpdateRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false,
+            sensitivityOptionsChanged: false
+        },
         result: null,
         ...state
     };

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -61,7 +61,11 @@ export const mockModelState = (state: Partial<ModelState> = {}): ModelState => {
 
 export const mockRunState = (state: Partial<RunState> = {}): RunState => {
     return {
-        runRequired: false,
+        runRequired: {
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false
+        },
         parameterValues: null,
         endTime: 100,
         result: null,

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -157,7 +157,7 @@ describe("Fit Tab", () => {
         const wrapper = getWrapper({}, false, { dataChanged: true });
         expect((wrapper.find("#fit-btn").element as HTMLButtonElement).disabled).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Fit is out of date: data have been updated. Rerun fit to view updated result.");
+            .toBe("Fit is out of date: data have been updated. Rerun fit to update.");
         const fitPlot = wrapper.findComponent(FitPlot);
         expect(fitPlot.props("fadePlot")).toBe(true);
         expect(fitPlot.findComponent(LoadingSpinner).exists()).toBe(false);

--- a/app/static/tests/unit/components/fit/support.test.ts
+++ b/app/static/tests/unit/components/fit/support.test.ts
@@ -63,7 +63,7 @@ describe("construct actionable fit update messages from fit state changes", () =
     it("shows fallback when no reason can be found", () => {
         expect(fitUpdateRequiredExplanation(base))
             .toBe("Fit is out of date: unknown reasons, contact the administrator, as this is unexpected. "
-                  + "Rerun fit to view updated result.");
+                  + "Rerun fit to update.");
     });
 
     it("shows sensible message when everything has changed", () => {
@@ -76,12 +76,12 @@ describe("construct actionable fit update messages from fit state changes", () =
         };
         expect(fitUpdateRequiredExplanation(everything))
             .toBe("Fit is out of date: model has been recompiled and data have been updated. "
-                  + "Rerun fit to view updated result.");
+                  + "Rerun fit to update.");
     });
 
     it("gives specific messages when little has changed", () => {
         const prefix = "Fit is out of date";
-        const suffix = "Rerun fit to view updated result.";
+        const suffix = "Rerun fit to update.";
         expect(fitUpdateRequiredExplanation({ ...base, modelChanged: true }))
             .toBe(`${prefix}: model has been recompiled. ${suffix}`);
         expect(fitUpdateRequiredExplanation({ ...base, dataChanged: true }))

--- a/app/static/tests/unit/components/options/parameterValues.test.ts
+++ b/app/static/tests/unit/components/options/parameterValues.test.ts
@@ -123,7 +123,7 @@ describe("ParameterValues", () => {
         expect(mockUpdateParameterValues).toHaveBeenCalledTimes(1);
         expect(mockUpdateParameterValues.mock.calls[0][1]).toStrictEqual({ param2: 3.3 });
         expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);
-        expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toBe(true);
+        expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterValueChanged: true });
         expect(mockSetFitUpdateRequired).toHaveBeenCalledTimes(1);
         expect(mockSetFitUpdateRequired.mock.calls[0][1]).toStrictEqual({ parameterValueChanged: true });
     });

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -77,6 +77,6 @@ describe("RunOptions", () => {
         expect(mockSetEndTime).toHaveBeenCalledTimes(1);
         expect(mockSetEndTime.mock.calls[0][1]).toBe(101);
         expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);
-        expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toBe(true);
+        expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toStrictEqual({ endTimeChanged: true });
     });
 });

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -6,8 +6,8 @@ import RunOptions from "../../../../src/app/components/options/RunOptions.vue";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 
 describe("RunOptions", () => {
-    const getWrapper = (mockSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn(),
-        mockDataEnd: number | null = 0) => {
+    const getWrapper = (mockRunSetEndTime = jest.fn(), mockSetSensitivityUpdateRequired = jest.fn(),
+        mockDataEnd: number | null = 0, mockSensitivitySetEndTime = jest.fn()) => {
         const modules = {
             run: {
                 namespaced: true,
@@ -15,13 +15,14 @@ describe("RunOptions", () => {
                     endTime: 99
                 },
                 mutations: {
-                    SetEndTime: mockSetEndTime
+                    SetEndTime: mockRunSetEndTime
                 }
             },
             sensitivity: {
                 namespaced: true,
                 mutations: {
-                    SetUpdateRequired: mockSetSensitivityUpdateRequired
+                    SetUpdateRequired: mockSetSensitivityUpdateRequired,
+                    SetEndTime: mockSensitivitySetEndTime
                 }
             }
         } as any;
@@ -69,14 +70,14 @@ describe("RunOptions", () => {
     });
 
     it("commits end time change", () => {
-        const mockSetEndTime = jest.fn();
-        const mockSetSensitivityUpdateRequired = jest.fn();
-        const wrapper = getWrapper(mockSetEndTime, mockSetSensitivityUpdateRequired);
+        const mockRunSetEndTime = jest.fn();
+        const mockSensitivitySetEndTime = jest.fn();
+        const wrapper = getWrapper(mockRunSetEndTime, jest.fn(), 0, mockSensitivitySetEndTime);
         const input = wrapper.findComponent(NumericInput);
         input.vm.$emit("update", 101);
-        expect(mockSetEndTime).toHaveBeenCalledTimes(1);
-        expect(mockSetEndTime.mock.calls[0][1]).toBe(101);
-        expect(mockSetSensitivityUpdateRequired).toHaveBeenCalledTimes(1);
-        expect(mockSetSensitivityUpdateRequired.mock.calls[0][1]).toStrictEqual({ endTimeChanged: true });
+        expect(mockRunSetEndTime).toHaveBeenCalledTimes(1);
+        expect(mockRunSetEndTime.mock.calls[0][1]).toBe(101);
+        expect(mockSensitivitySetEndTime).toHaveBeenCalledTimes(1);
+        expect(mockSensitivitySetEndTime.mock.calls[0][1]).toBe(101);
     });
 });

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -91,7 +91,7 @@ describe("RunTab", () => {
             compileRequired: true
         });
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe(
-            "Model code has been updated. Compile code and Run Model to view updated graph."
+            "Model code has been updated. Compile code and Run Model to update."
         );
         expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(true);
     });
@@ -104,7 +104,7 @@ describe("RunTab", () => {
         };
         const wrapper = getWrapper({ compileRequired: false }, { runRequired });
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe(
-            "Plot is out of date: model code has been recompiled. Run model to view updated graph."
+            "Plot is out of date: model code has been recompiled. Run model to update."
         );
         expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(true);
     });

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -21,7 +21,11 @@ describe("RunTab", () => {
     };
 
     const defaultRunState = {
-        runRequired: false
+        runRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false
+        }
     };
 
     beforeEach(() => {
@@ -93,9 +97,14 @@ describe("RunTab", () => {
     });
 
     it("fades plot and shows message when model run required", () => {
-        const wrapper = getWrapper({ compileRequired: false }, { runRequired: true });
+        const runRequired = {
+            modelChanged: true,
+            parameterValueChanged: false,
+            endTimeChanged: false
+        };
+        const wrapper = getWrapper({ compileRequired: false }, { runRequired });
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe(
-            "Model code has been recompiled or options have been updated. Run Model to view updated graph."
+            "Plot is out of date: model code has been recompiled. Run model to view updated graph."
         );
         expect(wrapper.findComponent(RunPlot).props("fadePlot")).toBe(true);
     });

--- a/app/static/tests/unit/components/run/support.test.ts
+++ b/app/static/tests/unit/components/run/support.test.ts
@@ -10,7 +10,7 @@ describe("construct actionable fit update messages from fit state changes", () =
     it("shows fallback when no reason can be found", () => {
         expect(runRequiredExplanation(base))
             .toBe("Plot is out of date: unknown reasons, contact the administrator, as this is unexpected. "
-                  + "Run model to view updated graph.");
+                  + "Run model to update.");
     });
 
     it("shows sensible message when everything has changed", () => {
@@ -21,12 +21,12 @@ describe("construct actionable fit update messages from fit state changes", () =
         };
         expect(runRequiredExplanation(everything))
             .toBe("Plot is out of date: model code has been recompiled. "
-                  + "Run model to view updated graph.");
+                  + "Run model to update.");
     });
 
     it("gives specific messages when little has changed", () => {
         const prefix = "Plot is out of date";
-        const suffix = "Run model to view updated graph.";
+        const suffix = "Run model to update.";
         expect(runRequiredExplanation({ ...base, modelChanged: true }))
             .toBe(`${prefix}: model code has been recompiled. ${suffix}`);
         expect(runRequiredExplanation({ ...base, parameterValueChanged: true }))

--- a/app/static/tests/unit/components/run/support.test.ts
+++ b/app/static/tests/unit/components/run/support.test.ts
@@ -1,0 +1,37 @@
+import { runRequiredExplanation } from "../../../../src/app/components/run/support";
+
+describe("construct actionable fit update messages from fit state changes", () => {
+    const base = {
+        modelChanged: false,
+        parameterValueChanged: false,
+        endTimeChanged: false
+    };
+
+    it("shows fallback when no reason can be found", () => {
+        expect(runRequiredExplanation(base))
+            .toBe("Plot is out of date: unknown reasons, contact the administrator, as this is unexpected. "
+                  + "Run model to view updated graph.");
+    });
+
+    it("shows sensible message when everything has changed", () => {
+        const everything = {
+            modelChanged: true,
+            parameterValueChanged: true,
+            endTimeChanged: true
+        };
+        expect(runRequiredExplanation(everything))
+            .toBe("Plot is out of date: model code has been recompiled. "
+                  + "Run model to view updated graph.");
+    });
+
+    it("gives specific messages when little has changed", () => {
+        const prefix = "Plot is out of date";
+        const suffix = "Run model to view updated graph.";
+        expect(runRequiredExplanation({ ...base, modelChanged: true }))
+            .toBe(`${prefix}: model code has been recompiled. ${suffix}`);
+        expect(runRequiredExplanation({ ...base, parameterValueChanged: true }))
+            .toBe(`${prefix}: parameters have been changed. ${suffix}`);
+        expect(runRequiredExplanation({ ...base, endTimeChanged: true }))
+            .toBe(`${prefix}: end time has changed. ${suffix}`);
+    });
+});

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -147,7 +147,7 @@ describe("SensitivityTab", () => {
         } as any;
         const wrapper = getWrapper({ compileRequired: true }, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Model code has been updated. Compile code and Run Sensitivity to view updated graph.");
+            .toBe("Model code has been updated. Compile code and Run Sensitivity to update.");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(true);
     });
 
@@ -163,7 +163,7 @@ describe("SensitivityTab", () => {
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Plot is out of date: model code has been recompiled. Run sensitivity to view updated graph.");
+            .toBe("Plot is out of date: model code has been recompiled. Run sensitivity to update.");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(true);
     });
 
@@ -181,7 +181,7 @@ describe("SensitivityTab", () => {
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to view updated graph.");
+            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to update.");
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(true);
     });
 

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -33,7 +33,12 @@ describe("SensitivityTab", () => {
                 sensitivity: {
                     namespaced: true,
                     state: {
-                        sensitivityUpdateRequired: false,
+                        sensitivityUpdateRequired: {
+                            modelChanged: false,
+                            parameterValueChanged: false,
+                            endTimeChanged: false,
+                            sensitivityOptionsChanged: false
+                        },
                         result: {
                             inputs: {},
                             batch: {
@@ -151,12 +156,14 @@ describe("SensitivityTab", () => {
             result: {
                 batch: { solutions: [{}] }
             },
-            sensitivityUpdateRequired: true
+            sensitivityUpdateRequired: {
+                modelChanged: true,
+                endTimeChanged: false
+            }
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Model code has been recompiled or options have been updated. "
-                + "Run Sensitivity to view updated graph.");
+            .toBe("Plot is out of date: model code has been recompiled. Run model to view updated graph.");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(true);
     });
 
@@ -166,12 +173,15 @@ describe("SensitivityTab", () => {
                 batch: { solutions: [{}] }
             },
             plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any,
-            sensitivityUpdateRequired: true
+            sensitivityUpdateRequired: {
+                modelChanged: false,
+                parameterValueChanged: true,
+                endTimeChanged: false
+            }
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Model code has been recompiled or options have been updated. "
-                + "Run Sensitivity to view updated graph.");
+            .toBe("Plot is out of date: parameters have been changed. Run model to view updated graph.");
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(true);
     });
 

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -163,7 +163,7 @@ describe("SensitivityTab", () => {
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Plot is out of date: model code has been recompiled. Run model to view updated graph.");
+            .toBe("Plot is out of date: model code has been recompiled. Run sensitivity to view updated graph.");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(true);
     });
 
@@ -181,7 +181,7 @@ describe("SensitivityTab", () => {
         } as any;
         const wrapper = getWrapper({}, sensitivityState);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))
-            .toBe("Plot is out of date: parameters have been changed. Run model to view updated graph.");
+            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to view updated graph.");
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(true);
     });
 

--- a/app/static/tests/unit/components/sensitivity/support.test.ts
+++ b/app/static/tests/unit/components/sensitivity/support.test.ts
@@ -1,0 +1,41 @@
+import { sensitivityUpdateRequiredExplanation } from "../../../../src/app/components/sensitivity/support";
+
+describe("construct actionable fit update messages from fit state changes", () => {
+    const base = {
+        modelChanged: false,
+        parameterValueChanged: false,
+        endTimeChanged: false,
+        sensitivityOptionsChanged: false
+    };
+
+    it("shows fallback when no reason can be found", () => {
+        expect(sensitivityUpdateRequiredExplanation(base))
+            .toBe("Plot is out of date: unknown reasons, contact the administrator, as this is unexpected. "
+                  + "Run sensitivity to view updated graph.");
+    });
+
+    it("shows sensible message when everything has changed", () => {
+        const everything = {
+            modelChanged: true,
+            parameterValueChanged: true,
+            endTimeChanged: true,
+            sensitivityOptionsChanged: true
+        };
+        expect(sensitivityUpdateRequiredExplanation(everything))
+            .toBe("Plot is out of date: model code has been recompiled. "
+                  + "Run sensitivity to view updated graph.");
+    });
+
+    it("gives specific messages when little has changed", () => {
+        const prefix = "Plot is out of date";
+        const suffix = "Run sensitivity to view updated graph.";
+        expect(sensitivityUpdateRequiredExplanation({ ...base, modelChanged: true }))
+            .toBe(`${prefix}: model code has been recompiled. ${suffix}`);
+        expect(sensitivityUpdateRequiredExplanation({ ...base, parameterValueChanged: true }))
+            .toBe(`${prefix}: parameters have been changed. ${suffix}`);
+        expect(sensitivityUpdateRequiredExplanation({ ...base, endTimeChanged: true }))
+            .toBe(`${prefix}: end time has changed. ${suffix}`);
+        expect(sensitivityUpdateRequiredExplanation({ ...base, sensitivityOptionsChanged: true }))
+            .toBe(`${prefix}: sensitivity options have been changed. ${suffix}`);
+    });
+});

--- a/app/static/tests/unit/components/sensitivity/support.test.ts
+++ b/app/static/tests/unit/components/sensitivity/support.test.ts
@@ -11,7 +11,7 @@ describe("construct actionable fit update messages from fit state changes", () =
     it("shows fallback when no reason can be found", () => {
         expect(sensitivityUpdateRequiredExplanation(base))
             .toBe("Plot is out of date: unknown reasons, contact the administrator, as this is unexpected. "
-                  + "Run sensitivity to view updated graph.");
+                  + "Run sensitivity to update.");
     });
 
     it("shows sensible message when everything has changed", () => {
@@ -23,12 +23,12 @@ describe("construct actionable fit update messages from fit state changes", () =
         };
         expect(sensitivityUpdateRequiredExplanation(everything))
             .toBe("Plot is out of date: model code has been recompiled. "
-                  + "Run sensitivity to view updated graph.");
+                  + "Run sensitivity to update.");
     });
 
     it("gives specific messages when little has changed", () => {
         const prefix = "Plot is out of date";
-        const suffix = "Run sensitivity to view updated graph.";
+        const suffix = "Run sensitivity to update.";
         expect(sensitivityUpdateRequiredExplanation({ ...base, modelChanged: true }))
             .toBe(`${prefix}: model code has been recompiled. ${suffix}`);
         expect(sensitivityUpdateRequiredExplanation({ ...base, parameterValueChanged: true }))

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -46,7 +46,11 @@ describe("serialise", () => {
     };
 
     const runState = {
-        runRequired: true,
+        runRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false
+        },
         parameterValues: { alpha: 1, beta: 1.1 },
         endTime: 20,
         result: {
@@ -74,7 +78,12 @@ describe("serialise", () => {
             rangeTo: 1,
             numberOfRuns: 5
         },
-        sensitivityUpdateRequired: false,
+        sensitivityUpdateRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false,
+            sensitivityOptionsChanged: false
+        },
         plotSettings: {
             plotType: SensitivityPlotType.ValueAtTime,
             extreme: SensitivityPlotExtreme.Min,
@@ -172,7 +181,11 @@ describe("serialise", () => {
         odinModelCodeError: modelState.odinModelCodeError
     };
     const expectedRun = {
-        runRequired: true,
+        runRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false
+        },
         parameterValues: runState.parameterValues,
         endTime: 20,
         result: {
@@ -183,7 +196,12 @@ describe("serialise", () => {
     };
     const expectedSensitivity = {
         paramSettings: sensitivityState.paramSettings,
-        sensitivityUpdateRequired: false,
+        sensitivityUpdateRequired: {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false,
+            sensitivityOptionsChanged: false
+        },
         plotSettings: sensitivityState.plotSettings,
         result: {
             inputs: sensitivityState.result.inputs,

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -86,11 +86,11 @@ describe("Fit Data actions", () => {
             expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetEndTime}`);
             expect(commit.mock.calls[2][1]).toBe(9);
             expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
-            expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-            expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
+            expect(commit.mock.calls[3][0]).toBe(`sensitivity/${SensitivityMutation.SetEndTime}`);
+            expect(commit.mock.calls[3][1]).toStrictEqual(9);
             expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
-            expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-            expect(commit.mock.calls[4][1]).toStrictEqual({ endTimeChanged: true });
+            expect(commit.mock.calls[4][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
+            expect(commit.mock.calls[4][1]).toStrictEqual({ linkChanged: true });
             expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[5][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
             expect(commit.mock.calls[5][1]).toStrictEqual({ dataChanged: true });
@@ -280,11 +280,11 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetEndTime}`);
         expect(commit.mock.calls[2][1]).toBe(10);
         expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
-        expect(commit.mock.calls[3][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
-        expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
+        expect(commit.mock.calls[3][0]).toBe(`sensitivity/${SensitivityMutation.SetEndTime}`);
+        expect(commit.mock.calls[3][1]).toStrictEqual(10);
         expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
-        expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-        expect(commit.mock.calls[4][1]).toStrictEqual({ endTimeChanged: true });
+        expect(commit.mock.calls[4][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
+        expect(commit.mock.calls[4][1]).toStrictEqual({ linkChanged: true });
         expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
     });
 

--- a/app/static/tests/unit/store/fitData/actions.test.ts
+++ b/app/static/tests/unit/store/fitData/actions.test.ts
@@ -90,7 +90,7 @@ describe("Fit Data actions", () => {
             expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
             expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-            expect(commit.mock.calls[4][1]).toBe(true);
+            expect(commit.mock.calls[4][1]).toStrictEqual({ endTimeChanged: true });
             expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
             expect(commit.mock.calls[5][0]).toBe(`modelFit/${ModelFitMutation.SetFitUpdateRequired}`);
             expect(commit.mock.calls[5][1]).toStrictEqual({ dataChanged: true });
@@ -284,7 +284,7 @@ describe("Fit Data actions", () => {
         expect(commit.mock.calls[3][1]).toStrictEqual({ linkChanged: true });
         expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
         expect(commit.mock.calls[4][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-        expect(commit.mock.calls[4][1]).toBe(true);
+        expect(commit.mock.calls[4][1]).toStrictEqual({ endTimeChanged: true });
         expect(commit.mock.calls[4][2]).toStrictEqual({ root: true });
     });
 

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -117,7 +117,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[3][0]).toBe(ModelMutation.SetCompileRequired);
         expect(commit.mock.calls[3][1]).toBe(false);
         expect(commit.mock.calls[4][0]).toBe(`run/${RunMutation.SetRunRequired}`);
-        expect(commit.mock.calls[4][1]).toBe(true);
+        expect(commit.mock.calls[4][1]).toStrictEqual({ modelChanged: true });
         expect(commit.mock.calls[5][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
         expect(commit.mock.calls[5][1]).toBe(true);
         expect(commit.mock.calls[5][2]).toStrictEqual({ root: true });
@@ -318,7 +318,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[5][1]).toBe(false);
 
         expect(commit.mock.calls[6][0]).toBe(`run/${RunMutation.SetRunRequired}`);
-        expect(commit.mock.calls[6][1]).toBe(true);
+        expect(commit.mock.calls[6][1]).toStrictEqual({ modelChanged: true });
 
         expect(commit.mock.calls[7][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
         expect(commit.mock.calls[7][1]).toBe(true);

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -119,8 +119,9 @@ describe("Model actions", () => {
         expect(commit.mock.calls[4][0]).toBe(`run/${RunMutation.SetRunRequired}`);
         expect(commit.mock.calls[4][1]).toStrictEqual({ modelChanged: true });
         expect(commit.mock.calls[5][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-        expect(commit.mock.calls[5][1]).toBe(true);
+        expect(commit.mock.calls[5][1]).toStrictEqual({ modelChanged: true });
         expect(commit.mock.calls[5][2]).toStrictEqual({ root: true });
+        // TODO: should this not also hit { sensitivityOptionsChanged: true }
         expect(commit.mock.calls[6][0]).toBe(`sensitivity/${SensitivityMutation.SetParameterToVary}`);
         expect(commit.mock.calls[6][1]).toBe("p2");
         expect(commit.mock.calls[6][2]).toStrictEqual({ root: true });
@@ -160,7 +161,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[3][0]).toBe(ModelMutation.SetCompileRequired);
         expect(commit.mock.calls[4][0]).toBe(`run/${RunMutation.SetRunRequired}`);
         expect(commit.mock.calls[5][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-        expect(commit.mock.calls[5][1]).toBe(true);
+        expect(commit.mock.calls[5][1]).toStrictEqual({ modelChanged: true });
         expect(commit.mock.calls[6][0]).toBe(`sensitivity/${SensitivityMutation.SetParameterToVary}`);
         expect(commit.mock.calls[6][1]).toBe(null);
         expect(commit.mock.calls[6][2]).toStrictEqual({ root: true });
@@ -321,7 +322,7 @@ describe("Model actions", () => {
         expect(commit.mock.calls[6][1]).toStrictEqual({ modelChanged: true });
 
         expect(commit.mock.calls[7][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
-        expect(commit.mock.calls[7][1]).toBe(true);
+        expect(commit.mock.calls[7][1]).toStrictEqual({ modelChanged: true });
 
         expect(commit.mock.calls[8][0]).toBe(`sensitivity/${SensitivityMutation.SetParameterToVary}`);
         expect(commit.mock.calls[8][1]).toStrictEqual("p1");

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -29,7 +29,11 @@ describe("Model actions", () => {
             }
         },
         run: {
-            runRequired: false,
+            runRequired: {
+                modelChanged: false,
+                parameterValueChanged: false,
+                endTimeChanged: false
+            },
             parameterValues: { p1: 1, p2: 2, p3: 3 }
         }
     };
@@ -187,7 +191,11 @@ describe("Model actions", () => {
                 }
             },
             compileRequired: true,
-            runRequired: false,
+            runRequired: {
+                modelChanged: false,
+                parameterValueChanged: false,
+                endTimeChanged: false
+            },
             parameterValues: { p2: 1, p3: 2 }
         };
 

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -19,7 +19,11 @@ describe("Run actions", () => {
             model: modelState
         } as any;
         const state = mockRunState({
-            runRequired: true,
+            runRequired: {
+                modelChanged: true,
+                parameterValueChanged: true,
+                endTimeChanged: true
+            },
             parameterValues,
             endTime: 99
         });
@@ -51,7 +55,11 @@ describe("Run actions", () => {
         });
         const rootState = { model: modelState } as any;
         const state = mockRunState({
-            runRequired: false,
+            runRequired: {
+                modelChanged: false,
+                parameterValueChanged: false,
+                endTimeChanged: false
+            },
             parameterValues: {}
         });
         const commit = jest.fn();
@@ -119,7 +127,11 @@ describe("Run actions", () => {
             model: modelState
         } as any;
         const state = mockRunState({
-            runRequired: true,
+            runRequired: {
+                modelChanged: true,
+                parameterValueChanged: true,
+                endTimeChanged: true
+            },
             parameterValues,
             endTime: 99
         });

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -6,7 +6,7 @@ describe("Run mutations", () => {
         endTimeChanged: false,
         modelChanged: false,
         parameterValueChanged: false
-    }
+    };
     it("sets odin solution", () => {
         const mockSolution = () => [{ x: 1, y: 2 }];
         const state = mockRunState({

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -2,9 +2,20 @@ import { mutations } from "../../../../src/app/store/run/mutations";
 import { mockError, mockRunState } from "../../../mocks";
 
 describe("Run mutations", () => {
+    const noRunRequired = {
+        endTimeChanged: false,
+        modelChanged: false,
+        parameterValueChanged: false
+    }
     it("sets odin solution", () => {
         const mockSolution = () => [{ x: 1, y: 2 }];
-        const state = mockRunState({ runRequired: true });
+        const state = mockRunState({
+            runRequired: {
+                endTimeChanged: false,
+                modelChanged: true,
+                parameterValueChanged: true
+            }
+        });
         const result = {
             inputs: { endTime: 99, parameterValues: { a: 1 } },
             error: null,
@@ -13,15 +24,27 @@ describe("Run mutations", () => {
 
         mutations.SetResult(state, result);
         expect(state.result).toBe(result);
-        expect(state.runRequired).toBe(false);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
     });
 
     it("sets run required", () => {
         const state = mockRunState();
-        mutations.SetRunRequired(state, true);
-        expect(state.runRequired).toBe(true);
-        mutations.SetRunRequired(state, false);
-        expect(state.runRequired).toBe(false);
+        mutations.SetRunRequired(state, { modelChanged: true });
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: true,
+            parameterValueChanged: false
+        });
+        mutations.SetRunRequired(state, { modelChanged: false });
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
     });
 
     it("sets parameter values", () => {
@@ -34,27 +57,35 @@ describe("Run mutations", () => {
     it("updates parameter values and sets runRequired to true", () => {
         const state = mockRunState({
             parameterValues: { p1: 1, p2: 2 },
-            runRequired: true
+            runRequired: noRunRequired
         });
         mutations.UpdateParameterValues(state, { p1: 10, p3: 30 });
         expect(state.parameterValues).toStrictEqual({ p1: 10, p2: 2, p3: 30 });
-        expect(state.runRequired).toBe(true);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: true
+        });
     });
 
     it("sets end time and sets runRequired to Run", () => {
         const state = mockRunState({
             endTime: 99,
-            runRequired: false
+            runRequired: noRunRequired
         });
         mutations.SetEndTime(state, 101);
         expect(state.endTime).toBe(101);
-        expect(state.runRequired).toBe(true);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: true,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
     });
 
     it("sets end time does not require run if it shrinks", () => {
         const state = mockRunState({
             endTime: 100,
-            runRequired: false,
+            runRequired: noRunRequired,
             result: {
                 inputs: {
                     endTime: 100
@@ -64,15 +95,27 @@ describe("Run mutations", () => {
         // shrinking is fine
         mutations.SetEndTime(state, 50);
         expect(state.endTime).toBe(50);
-        expect(state.runRequired).toBe(false);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
         // increasing, even right up to the original limit, is fine
         mutations.SetEndTime(state, 100);
         expect(state.endTime).toBe(100);
-        expect(state.runRequired).toBe(false);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
         // but any additional time requires a rerun
         mutations.SetEndTime(state, 101);
         expect(state.endTime).toBe(101);
-        expect(state.runRequired).toBe(true);
+        expect(state.runRequired).toStrictEqual({
+            endTimeChanged: true,
+            modelChanged: false,
+            parameterValueChanged: false
+        });
     });
 
     it("sets odinRunnerResponseError", () => {

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -149,7 +149,11 @@ describe("Sensitivity actions", () => {
             },
             run: {
                 ...mockRunState,
-                runRequired: true
+                runRequired: {
+                    modelChanged: true,
+                    parameterValueChanged: true,
+                    endTimeChanged: true
+                }
             }
         };
 

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -44,7 +44,12 @@ describe("Sensitivity actions", () => {
             error: null
         });
         expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetUpdateRequired);
-        expect(commit.mock.calls[1][1]).toBe(false);
+        expect(commit.mock.calls[1][1]).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false,
+            sensitivityOptionsChanged: false
+        });
 
         expect(mockRunner.batchRun).toHaveBeenCalledWith(rootState.model.odin, mockBatchPars, 0, 99, {});
 

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -2,6 +2,13 @@ import { mutations, SensitivityMutation } from "../../../../src/app/store/sensit
 import { SensitivityPlotExtreme, SensitivityPlotType } from "../../../../src/app/store/sensitivity/state";
 
 describe("Sensitivity mutations", () => {
+    const noUpdateRequired = {
+        endTimeChanged: false,
+        modelChanged: false,
+        parameterValueChanged: false,
+        sensitivityOptionsChanged: false
+    };
+
     it("sets parameter to vary", () => {
         const state = {
             paramSettings: {
@@ -15,12 +22,7 @@ describe("Sensitivity mutations", () => {
     it("sets param settings", () => {
         const state = {
             paramSettings: {},
-            sensitivityUpdateRequired: {
-                modelChanged: false,
-                parameterValueChanged: false,
-                endTimeChanged: false,
-                sensitivityOptionsChanged: false
-            }
+            sensitivityUpdateRequired: noUpdateRequired
         } as any;
         const newSettings = { parameterToVary: "A" };
         mutations[SensitivityMutation.SetParamSettings](state, newSettings);
@@ -95,5 +97,42 @@ describe("Sensitivity mutations", () => {
         };
         mutations[SensitivityMutation.SetResult](state, batch);
         expect(state.result).toBe(batch);
+    });
+
+    it("sets end time and updates update required", () => {
+        const state = {
+            result: {
+                inputs: null,
+                batch: null
+            },
+            sensitivityUpdateRequired: noUpdateRequired
+        } as any;
+        mutations.SetEndTime(state, 100);
+        expect(state.sensitivityUpdateRequired).toStrictEqual({
+            ...state.sensitivityUpdateRequired,
+            endTimeChanged: true
+        });
+    });
+
+    it("sets end time does not require run if it shrinks", () => {
+        const state = {
+            result: {
+                inputs: { endTime: 100 },
+                batch: null
+            },
+            sensitivityUpdateRequired: noUpdateRequired
+        } as any;
+
+        // shrinking is fine
+        mutations.SetEndTime(state, 50);
+        expect(state.sensitivityUpdateRequired.endTimeChanged).toBe(false);
+
+        // increasing, even right up to the original limit, is fine
+        mutations.SetEndTime(state, 100);
+        expect(state.sensitivityUpdateRequired.endTimeChanged).toBe(false);
+
+        // but any additional time requires a rerun
+        mutations.SetEndTime(state, 101);
+        expect(state.sensitivityUpdateRequired.endTimeChanged).toBe(true);
     });
 });

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -15,12 +15,20 @@ describe("Sensitivity mutations", () => {
     it("sets param settings", () => {
         const state = {
             paramSettings: {},
-            sensitivityUpdateRequired: false
+            sensitivityUpdateRequired: {
+                modelChanged: false,
+                parameterValueChanged: false,
+                endTimeChanged: false,
+                sensitivityOptionsChanged: false
+            }
         } as any;
         const newSettings = { parameterToVary: "A" };
         mutations[SensitivityMutation.SetParamSettings](state, newSettings);
         expect(state.paramSettings).toBe(newSettings);
-        expect(state.sensitivityUpdateRequired).toBe(true);
+        expect(state.sensitivityUpdateRequired).toStrictEqual({
+            ...state.sensitivityUpdateRequired,
+            sensitivityOptionsChanged: true
+        });
     });
 
     it("sets batch", () => {
@@ -42,10 +50,16 @@ describe("Sensitivity mutations", () => {
 
     it("sets update required", () => {
         const state = {
-            sensitivityUpdateRequired: false
+            sensitivityUpdateRequired: {
+                modelChanged: false,
+                parameterValueChanged: false
+            }
         } as any;
-        mutations[SensitivityMutation.SetUpdateRequired](state, true);
-        expect(state.sensitivityUpdateRequired).toBe(true);
+        mutations[SensitivityMutation.SetUpdateRequired](state, { modelChanged: true });
+        expect(state.sensitivityUpdateRequired).toStrictEqual({
+            modelChanged: true,
+            parameterValueChanged: false
+        });
     });
 
     const plotSettings = {


### PR DESCRIPTION
Copies the approach in https://github.com/mrc-ide/wodin/pull/71 for both run and sensitivity

There's an extra feature snuck in here too, which is to make the sensitivity plot respond to endTime changing the same way that the run plot does (decreasing it just redraws, increasing it sets the update required message). I had to slightly tweak the watcher to make this work.

This PR is needed for tidying up the initialisation of the fit plot