### PR TITLE
Plot fit data on sensitivity traces plot

### DIFF
--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -43,8 +43,10 @@ export default defineComponent({
             if (!result) {
                 return [];
             }
-            return [...odinToPlotly(result, palette.value),
-                ...allFitDataToPlotly(allFitData.value, palette.value, start, end)];
+            return [
+                ...odinToPlotly(result, palette.value),
+                ...allFitDataToPlotly(allFitData.value, palette.value, start, end)
+            ];
         };
 
         return {

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -4,7 +4,7 @@
       :placeholder-message="placeholderMessage"
       :end-time="endTime"
       :plot-data="allPlotData"
-      :redrawWatches="solutions ? [...solutions] : []">
+      :redrawWatches="solutions ? [...solutions, allFitData] : []">
     <slot></slot>
   </wodin-ode-plot>
 </template>
@@ -14,9 +14,10 @@ import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
 import { PlotData } from "plotly.js";
 import { format } from "d3-format";
+import { FitDataGetter } from "../../store/fitData/getters";
 import WodinOdePlot from "../WodinOdePlot.vue";
 import userMessages from "../../userMessages";
-import { odinToPlotly, WodinPlotData } from "../../plot";
+import { allFitDataToPlotly, odinToPlotly, WodinPlotData } from "../../plot";
 import { OdinSolution } from "../../types/responseTypes";
 
 export default defineComponent({
@@ -43,6 +44,8 @@ export default defineComponent({
             // eslint-disable-next-line no-param-reassign
             plotTrace.name = `${plotTrace.name} (${param}=${format(".3f")(value)})`;
         };
+
+        const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const result: Partial<PlotData>[] = [];
@@ -73,6 +76,10 @@ export default defineComponent({
                         result.push(...odinToPlotly(centralData, palette.value, plotlyOptions));
                     }
                 }
+
+                if (allFitData.value) {
+                    result.push(...allFitDataToPlotly(allFitData.value, palette.value, start, end));
+                }
             }
 
             return result;
@@ -82,7 +89,8 @@ export default defineComponent({
             placeholderMessage,
             endTime,
             solutions,
-            allPlotData
+            allPlotData,
+            allFitData
         };
     }
 });

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -7,6 +7,7 @@ import { shallowMount } from "@vue/test-utils";
 import WodinOdePlot from "../../../../src/app/components/WodinOdePlot.vue";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
+import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 
 const mockSln1 = jest.fn().mockReturnValue({
     names: ["y", "z"],
@@ -117,8 +118,30 @@ const expectedPlotData = [
     }
 ];
 
+const mockFitData = [
+    { t: 0, v: 10 },
+    { t: 1, v: 20 },
+    { t: 2, v: 0 }
+];
+const mockAllFitData = {
+    timeVariable: "t",
+    data: mockFitData,
+    linkedVariables: { v: "y" }
+};
+
+const expectedFitPlotData = {
+    mode: "markers",
+    marker: {
+        color: "#0000ff"
+    },
+    name: "v",
+    type: "scatter",
+    x: [0, 1],
+    y: [10, 20]
+};
+
 describe("SensitivityTracesPlot", () => {
-    const getWrapper = (sensitivityHasSolutions = true, fadePlot = false) => {
+    const getWrapper = (sensitivityHasSolutions = true, fadePlot = false, sensitivityHasData = false) => {
         const store = new Vuex.Store<BasicState>({
             state: {
                 model: {
@@ -134,6 +157,7 @@ describe("SensitivityTracesPlot", () => {
                     result: {
                         batch: {
                             solutions: sensitivityHasSolutions ? mockSolutions : null,
+                            allFitData: sensitivityHasData ? mockAllFitData : undefined,
                             pars: {
                                 name: "alpha",
                                 values: [1.11111, 2.22222]
@@ -141,7 +165,15 @@ describe("SensitivityTracesPlot", () => {
                         }
                     }
                 }
-            } as any
+            } as any,
+            modules: {
+                fitData: {
+                    namespaced: true,
+                    getters: {
+                        [FitDataGetter.allData]: () => (sensitivityHasData ? mockAllFitData : undefined)
+                    }
+                }
+            }
         });
 
         return shallowMount(SensitivityTracesPlot, {
@@ -162,10 +194,24 @@ describe("SensitivityTracesPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Sensitivity has not been run.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("redrawWatches")).toStrictEqual(mockSolutions);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([...mockSolutions, undefined]);
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
+        expect(mockSln1).toBeCalledWith(0, 1, 100);
+        expect(mockSln2).toBeCalledWith(0, 1, 100);
+    });
+
+    it("renders as expected when there are sensitivity solutions and data", () => {
+        const wrapper = getWrapper(true, false, true);
+        const wodinPlot = wrapper.findComponent(WodinOdePlot);
+        expect(wodinPlot.props("fadePlot")).toBe(false);
+        expect(wodinPlot.props("placeholderMessage")).toBe("Sensitivity has not been run.");
+        expect(wodinPlot.props("endTime")).toBe(1);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([...mockSolutions, mockAllFitData]);
+
+        const plotData = wodinPlot.props("plotData");
+        expect(plotData(0, 1, 100)).toStrictEqual([...expectedPlotData, expectedFitPlotData]);
         expect(mockSln1).toBeCalledWith(0, 1, 100);
         expect(mockSln2).toBeCalledWith(0, 1, 100);
     });
@@ -176,7 +222,7 @@ describe("SensitivityTracesPlot", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Sensitivity has not been run.");
         expect(wodinPlot.props("endTime")).toBe(1);
-        expect(wodinPlot.props("redrawWatches")).toStrictEqual([]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([undefined]);
 
         const plotData = wodinPlot.props("plotData");
         const data = plotData(0, 1, 100);


### PR DESCRIPTION
We could probably do something additional for the other plot types, but it's not super easy, nor do I think it's that useful (and it's not on the existing shiny app either).

~Contains commits from #80, merge that first.~
