### PR TITLE
Update to work with new odin-js, allowing better reuse of solution

### DIFF
--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -40,7 +40,7 @@ export default defineComponent({
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const { data } = store.state.fitData;
-            const result = solution.value && solution.value(start, end, points);
+            const result = solution.value && solution.value({mode: "grid", tStart: start, tEnd: end, nPoints: points});
             if (!data || !link.value || !result) {
                 return [];
             }

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -40,7 +40,9 @@ export default defineComponent({
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
             const { data } = store.state.fitData;
-            const result = solution.value && solution.value({mode: "grid", tStart: start, tEnd: end, nPoints: points});
+            const result = solution.value && solution.value({
+                mode: "grid", tStart: start, tEnd: end, nPoints: points
+            });
             if (!data || !link.value || !result) {
                 return [];
             }

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -39,7 +39,9 @@ export default defineComponent({
         const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
-            const result = solution.value && solution.value({mode: "grid", tStart: start, tEnd: end, nPoints: points});
+            const result = solution.value && solution.value({
+                mode: "grid", tStart: start, tEnd: end, nPoints: points
+            });
             if (!result) {
                 return [];
             }

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -39,7 +39,7 @@ export default defineComponent({
         const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
-            const result = solution.value && solution.value(start, end, points);
+            const result = solution.value && solution.value({mode: "grid", tStart: start, tEnd: end, nPoints: points});
             if (!result) {
                 return [];
             }

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -52,7 +52,9 @@ export default defineComponent({
             if (solutions.value.length) {
                 const { pars } = store.state.sensitivity.result!.batch!;
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
-                    const data = sln({mode: "grid", tStart: start, tEnd: end, nPoints: points});
+                    const data = sln({
+                        mode: "grid", tStart: start, tEnd: end, nPoints: points
+                    });
                     const plotlyOptions = {
                         includeLegendGroup: true,
                         lineWidth: 1,

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -51,10 +51,11 @@ export default defineComponent({
             const result: Partial<PlotData>[] = [];
             if (solutions.value.length) {
                 const { pars } = store.state.sensitivity.result!.batch!;
+                const time = {
+                    mode: "grid" as const, tStart: start, tEnd: end, nPoints: points
+                };
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
-                    const data = sln({
-                        mode: "grid", tStart: start, tEnd: end, nPoints: points
-                    });
+                    const data = sln(time);
                     const plotlyOptions = {
                         includeLegendGroup: true,
                         lineWidth: 1,
@@ -72,7 +73,7 @@ export default defineComponent({
                 });
 
                 if (centralSolution.value) {
-                    const centralData = centralSolution.value(start, end, points);
+                    const centralData = centralSolution.value(time);
                     if (centralData) {
                         const plotlyOptions = { includeLegendGroup: true };
                         result.push(...odinToPlotly(centralData, palette.value, plotlyOptions));

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -52,7 +52,7 @@ export default defineComponent({
             if (solutions.value.length) {
                 const { pars } = store.state.sensitivity.result!.batch!;
                 solutions.value.forEach((sln: OdinSolution, slnIdx: number) => {
-                    const data = sln(start, end, points);
+                    const data = sln({mode: "grid", tStart: start, tEnd: end, nPoints: points});
                     const plotlyOptions = {
                         includeLegendGroup: true,
                         lineWidth: 1,

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -72,8 +72,20 @@ export type OdinSeriesSet = {
     y: number[][];
 }
 
+export interface TimeGrid {
+    mode: "grid";
+    tStart: number;
+    tEnd: number;
+    nPoints: number;
+}
+
+export interface TimeGiven {
+    mode: "given";
+    times: number[];
+}
+
 // This is Odin's InterpolatedSolution
-export type OdinSolution = (t0: number, t1: number, nPoints: number) => OdinSeriesSet;
+export type OdinSolution = (times: TimeGrid | TimeGiven) => OdinSeriesSet;
 
 export interface OdinFitData {
     time: number[],

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -102,7 +102,7 @@ describe("FitPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
-        expect(mockSolution).toBeCalledWith(0, 1, 100);
+        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
     });
 
     it("renders as expected whn modelFit does not have solution", () => {

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -102,7 +102,9 @@ describe("FitPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
-        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
+        expect(mockSolution).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 100
+        });
     });
 
     it("renders as expected whn modelFit does not have solution", () => {

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -88,7 +88,9 @@ describe("RunPlot", () => {
             }
         ]);
 
-        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 10});
+        expect(mockSolution).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 10
+        });
     });
 
     it("renders as expected when model has no solution", () => {
@@ -228,6 +230,8 @@ describe("RunPlot", () => {
             }
         ]);
 
-        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 10});
+        expect(mockSolution).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 10
+        });
     });
 });

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -88,7 +88,7 @@ describe("RunPlot", () => {
             }
         ]);
 
-        expect(mockSolution).toBeCalledWith(0, 1, 10);
+        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 10});
     });
 
     it("renders as expected when model has no solution", () => {
@@ -228,6 +228,6 @@ describe("RunPlot", () => {
             }
         ]);
 
-        expect(mockSolution).toBeCalledWith(0, 1, 10);
+        expect(mockSolution).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 10});
     });
 });

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -198,8 +198,12 @@ describe("SensitivityTracesPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
-        expect(mockSln1).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
-        expect(mockSln2).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
+        expect(mockSln1).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 100
+        });
+        expect(mockSln2).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 100
+        });
     });
 
     it("renders as expected when there are sensitivity solutions and data", () => {
@@ -212,8 +216,12 @@ describe("SensitivityTracesPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual([...expectedPlotData, expectedFitPlotData]);
-        expect(mockSln1).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
-        expect(mockSln2).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
+        expect(mockSln1).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 100
+        });
+        expect(mockSln2).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 1, nPoints: 100
+        });
     });
 
     it("renders as expected when there are no sensitivity solutions", () => {

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -198,8 +198,8 @@ describe("SensitivityTracesPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual(expectedPlotData);
-        expect(mockSln1).toBeCalledWith(0, 1, 100);
-        expect(mockSln2).toBeCalledWith(0, 1, 100);
+        expect(mockSln1).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
+        expect(mockSln2).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
     });
 
     it("renders as expected when there are sensitivity solutions and data", () => {
@@ -212,8 +212,8 @@ describe("SensitivityTracesPlot", () => {
 
         const plotData = wodinPlot.props("plotData");
         expect(plotData(0, 1, 100)).toStrictEqual([...expectedPlotData, expectedFitPlotData]);
-        expect(mockSln1).toBeCalledWith(0, 1, 100);
-        expect(mockSln2).toBeCalledWith(0, 1, 100);
+        expect(mockSln1).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
+        expect(mockSln2).toBeCalledWith({mode: "grid", tStart: 0, tEnd: 1, nPoints: 100});
     });
 
     it("renders as expected when there are no sensitivity solutions", () => {

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=main
+ODIN_API_BRANCH=mrc-3182-next
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=mrc-3182-next
+ODIN_API_BRANCH=main
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH


### PR DESCRIPTION
Unpin branch in scripts/run-dependencies.sh before merging, after merging the odin PRs

Depends on https://github.com/mrc-ide/odin-js/pull/18, https://github.com/mrc-ide/odin/pull/271, https://github.com/mrc-ide/odin.api/pull/11

In https://github.com/mrc-ide/odin-js/pull/18 I've changed the solution so that we can both evaluate it over a grid of points (which we need for the plots) but also at some pre-specified set of points (which we would need to be able to evaluate the solution at exactly the same points in time as the data to fit to). This enables easy calculation of sum of squares without running or starting a fit.