### PR TITLE
Implement generation of friendly ids in session store

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -15,7 +15,8 @@
         "ioredis": "^5.2.2",
         "morgan": "^1.10.0",
         "uid": "^2.0.0",
-        "yargs": "^17.4.0"
+        "yargs": "^17.4.0",
+        "zoo-ids": "^2.0.0"
       },
       "bin": {
         "wodin": "dist/server.js"
@@ -7095,6 +7096,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/zoo-ids": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zoo-ids/-/zoo-ids-2.0.0.tgz",
+      "integrity": "sha512-3Qzoary/OwJzeGlPCUPOI/MHJykBNz+0J8AbyMHOveV6Yk7x/FujfGSd9thoe5C5f8NQXBrIBv8W6pD3A+xvxw=="
     }
   },
   "dependencies": {
@@ -12382,6 +12388,11 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
+    },
+    "zoo-ids": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zoo-ids/-/zoo-ids-2.0.0.tgz",
+      "integrity": "sha512-3Qzoary/OwJzeGlPCUPOI/MHJykBNz+0J8AbyMHOveV6Yk7x/FujfGSd9thoe5C5f8NQXBrIBv8W6pD3A+xvxw=="
     }
   }
 }

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -20,7 +20,8 @@
     "ioredis": "^5.2.2",
     "morgan": "^1.10.0",
     "uid": "^2.0.0",
-    "yargs": "^17.4.0"
+    "yargs": "^17.4.0",
+    "zoo-ids": "^2.0.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -56,4 +56,13 @@ export class SessionsController {
         const session = await store.getSession(id);
         serialiseSession(session, res);
     };
+
+    static generateFriendlyId = async (req: Request, res: Response) => {
+        const { redis, wodinConfig } = req.app.locals as AppLocals;
+        const { appName, id } = req.params;
+        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        const friendly = store.generateFriendlyId(id);
+        res.header("Content-Type", "application/json");
+        res.end(friendly);
+    };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -61,8 +61,7 @@ export class SessionsController {
         const { redis, wodinConfig } = req.app.locals as AppLocals;
         const { appName, id } = req.params;
         const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
-        const friendly = store.generateFriendlyId(id);
-        res.header("Content-Type", "application/json");
-        res.end(friendly);
+        const friendly = await store.generateFriendlyId(id);
+        jsonResponseSuccess(friendly, res);
     };
 }

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -42,25 +42,22 @@ export class SessionsController {
     };
 
     static postSessionLabel = async (req: Request, res: Response) => {
-        const { redis, wodinConfig } = req.app.locals as AppLocals;
-        const { appName, id } = req.params;
-        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        const { id } = req.params;
+        const store = SessionsController.getStore(req);
         await store.saveSessionLabel(id, req.body as string);
         res.end();
     };
 
     static getSession = async (req: Request, res: Response) => {
-        const { redis, wodinConfig } = req.app.locals as AppLocals;
-        const { appName, id } = req.params;
-        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        const { id } = req.params;
+        const store = SessionsController.getStore(req);
         const session = await store.getSession(id);
         serialiseSession(session, res);
     };
 
     static generateFriendlyId = async (req: Request, res: Response) => {
-        const { redis, wodinConfig } = req.app.locals as AppLocals;
-        const { appName, id } = req.params;
-        const store = new SessionStore(redis, wodinConfig.savePrefix, appName);
+        const { id } = req.params;
+        const store = SessionsController.getStore(req);
         const friendly = await store.generateFriendlyId(id);
         jsonResponseSuccess(friendly, res);
     };

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -68,6 +68,12 @@ export class SessionStore {
         const keyFriendlyToMachine = this.sessionKey("machine");
         const keyMachineToFriendly = this.sessionKey("friendly");
 
+        // The app will probably not do this, but if an id already exists, return that
+        const existing = await this._redis.hget(keyMachineToFriendly, id);
+        if (existing) {
+            return existing;
+        }
+
         while (retries > 0) {
             const friendly = this._newFriendlyId();
             const wasSet = await this._redis.hsetnx(keyFriendlyToMachine, friendly, id);

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -1,14 +1,27 @@
 import Redis from "ioredis";
 import { SessionMetadata } from "../types";
+import { generateId } from "zoo-ids";
+
+export const friendlyAdjectiveAnimal = () => {
+    return generateId(null, {
+        caseStyle: "lowercase",
+        delimiter: "-",
+        numAdjectives: 1
+    });
+};
 
 export class SessionStore {
     private readonly _redis: Redis;
 
     private readonly _sessionPrefix: string;
 
-    constructor(redis: Redis, savePrefix: string, app: string) {
+    private readonly _newFriendlyId: () => string;
+
+    constructor(redis: Redis, savePrefix: string, app: string,
+                newFriendlyId: () => string = friendlyAdjectiveAnimal) {
         this._redis = redis;
         this._sessionPrefix = `${savePrefix}:${app}:sessions:`;
+        this._newFriendlyId = newFriendlyId;
     }
 
     private sessionKey = (name: string) => `${this._sessionPrefix}${name}`;
@@ -40,5 +53,34 @@ export class SessionStore {
 
     async getSession(id: string) {
         return this._redis.hget(this.sessionKey("data"), id);
+    }
+
+    async generateFriendlyId(id: string, retries: number = 10) : Promise<string> {
+        // Try several times to generate a friendly id but fall back
+        // on the machine readable id (which should be globally
+        // unique) in the unlikely event that we can't find a free
+        // friendly id, avoiding both collisions and infinite
+        // loops. There are ~300k possible friendly ids with our
+        // current configuration so is essentially impossible unless
+        // we have something on the order of 100k sessions, but single
+        // collisions are likely enough to be worth the faff of
+        // retrying, and it makes sense to avoid an infinite loop...
+        const keyFriendlyToMachine = this.sessionKey("machine");
+        const keyMachineToFriendly = this.sessionKey("friendly");
+
+        while (retries > 0) {
+            const friendly = this._newFriendlyId();
+            const wasSet = await this._redis.hsetnx(keyFriendlyToMachine, friendly, id);
+            if (wasSet) {
+                this._redis.hset(keyMachineToFriendly, id, friendly);
+                return friendly;
+            }
+            retries -= 1;
+        }
+
+        // Fall-back on linking machine to machine
+        await this._redis.hset(keyFriendlyToMachine, id, id);
+        await this._redis.hset(keyMachineToFriendly, id, id);
+        return id;
     }
 }

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -85,7 +85,8 @@ export class SessionStore {
             // eslint-disable-next-line no-await-in-loop
             const wasSet = await this._redis.hsetnx(keyFriendlyToMachine, friendly, id);
             if (wasSet) {
-                this._redis.hset(keyMachineToFriendly, id, friendly);
+                // eslint-disable-next-line no-await-in-loop
+                await this._redis.hset(keyMachineToFriendly, id, friendly);
                 return friendly;
             }
             retries -= 1;

--- a/app/server/src/routes/apps.ts
+++ b/app/server/src/routes/apps.ts
@@ -16,5 +16,6 @@ router.post(
     SessionsController.postSessionLabel
 );
 router.get("/:appName/sessions/:id", SessionsController.getSession);
+router.post("/:appName/sessions/:id/friendly", SessionsController.generateFriendlyId);
 
 export default router;

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -124,6 +124,31 @@ describe("SessionsController", () => {
         expect(storeInstance.getSession).toHaveBeenCalledTimes(1);
         expect(storeInstance.getSession.mock.calls[0][0]).toBe("1234");
     });
+
+    it("can generate friendly ids", () => {
+        const sessionReq = {
+            app: {
+                locals: {
+                    redis: {},
+                    wodinConfig: {
+                        savePrefix: "testPrefix"
+                    }
+                }
+            },
+            params: {
+                appName: "testApp",
+                id: "1234"
+            }
+        } as any;
+        SessionsController.generateFriendlyId(sessionReq, res);
+        expect(mockSessionStore).toHaveBeenCalledTimes(1); // expect store constructor
+        expect(mockSessionStore.mock.calls[0][0]).toBe(sessionReq.app.locals.redis);
+        expect(mockSessionStore.mock.calls[0][1]).toBe("testPrefix");
+        expect(mockSessionStore.mock.calls[0][2]).toBe("testApp");
+        const storeInstance = mockSessionStore.mock.instances[0];
+        expect(storeInstance.generateFriendlyId).toHaveBeenCalledTimes(1);
+        expect(storeInstance.generateFriendlyId.mock.calls[0][0]).toBe("1234");
+    });
 });
 
 describe("Sessions serialise correctly", () => {

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -12,7 +12,6 @@ describe("Sessionstore", () => {
         exec: jest.fn()
     } as any;
     mockPipeline.hset = jest.fn().mockReturnValue(mockPipeline);
-    mockPipeline.hsetnx = jest.fn().mockReturnValue(mockPipeline);
 
     const mockRedis = {
         pipeline: jest.fn().mockReturnValue(mockPipeline),

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -111,6 +111,28 @@ describe("Session id integration", () => {
         expectRecentTime(sessions[0].time);
         expect(sessions[0].label).toBe(null);
     });
+
+    it("can create a friendly label for a session", async () => {
+        const url = `apps/day1/sessions/${sessionId}/friendly`;
+
+        // Gets created
+        const response1 = await post(url, undefined);
+        expect(response1.status).toBe(200);
+        expect(response1.headers["content-type"]).toMatch("application/json");
+        const friendly = response1.data.data;
+        expect(friendly).toMatch(/^[a-z]+-[a-z]+$/);
+
+        // Re-creating it does not change the friendly id
+        const response2 = await post(url, undefined);
+        expect(response2.status).toBe(200);
+        expect(response2.data).toStrictEqual(response1.data);
+
+        // Creating another friendly id is different
+        const response3 = await post("apps/day1/sessions/12345/friendly", undefined);
+        expect(response3.status).toBe(200);
+        expect(response3.data.data).not.toEqual(friendly);
+        expect(response3.data.data).toMatch(/^[a-z]+-[a-z]+$/);
+    });
 });
 
 describe("Session label integration", () => {

--- a/app/server/tests/routes/apps.test.ts
+++ b/app/server/tests/routes/apps.test.ts
@@ -31,11 +31,13 @@ describe("odin routes", () => {
         expect(mockRouter.get.mock.calls[1][1]).toBe(SessionsController.getSessionsMetadata);
         expect(mockRouter.get.mock.calls[2][0]).toBe("/:appName/sessions/:id");
         expect(mockRouter.get.mock.calls[2][1]).toBe(SessionsController.getSession);
-        expect(mockRouter.post).toBeCalledTimes(2);
+        expect(mockRouter.post).toBeCalledTimes(3);
         expect(mockRouter.post.mock.calls[0][0]).toBe("/:appName/sessions/:id");
         expect(mockRouter.post.mock.calls[0][2]).toBe(SessionsController.postSession);
         expect(mockRouter.post.mock.calls[1][0]).toBe("/:appName/sessions/:id/label");
         expect(mockRouter.post.mock.calls[1][2]).toBe(SessionsController.postSessionLabel);
+        expect(mockRouter.post.mock.calls[2][0]).toBe("/:appName/sessions/:id/friendly");
+        expect(mockRouter.post.mock.calls[2][1]).toBe(SessionsController.generateFriendlyId);
         expect(spyText).toHaveBeenCalledWith({ type: "application/json" });
     });
 });


### PR DESCRIPTION
This uses an implementation of adjective-animal style ids that promises fairly "simple" versions of the ids, and seems to do ok at that.

The logic in id creation is a bit complicated if we want to avoid both collisions and pool exhaustion, but that seems worthwhile

Test with:

```
curl -X POST http://localhost:3000/apps/day1/sessions/c055e6ad675e274b93f1012f08bb5895/friendly
```

Hitting the same id twice will return the same friendly id, different ids will return different ids