### PR TITLE
Prepend session ids

### DIFF
--- a/app/static/src/app/localStorageManager.ts
+++ b/app/static/src/app/localStorageManager.ts
@@ -8,7 +8,7 @@ class LocalStorageManager {
 
     addSessionId = (sessionId: string) => {
         const sessionIds = this.getSessionIds();
-        sessionIds.push(sessionId);
+        sessionIds.unshift(sessionId); // prepends the id
         window.localStorage.setItem(LocalStorageManager.sessionIdsKey, JSON.stringify(sessionIds));
     }
 }

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -20,6 +20,6 @@ describe("localStorageManager", () => {
         expect(spyOnGetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem.mock.calls[0][0]).toBe("sessionIds");
-        expect(spyOnSetItem.mock.calls[0][1]).toBe(JSON.stringify(["session1", "session2", "session3"]));
+        expect(spyOnSetItem.mock.calls[0][1]).toBe(JSON.stringify(["session3", "session1", "session2"]));
     });
 });


### PR DESCRIPTION
Don't append session ids, but prepend them, so that they come out naturally in reverse chronological order. Most recent will now always be first