### PR TITLE
Clean up ids

### DIFF
--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -9,7 +9,7 @@ export const cleanFriendlyId = (id: string): string => {
         ret = ret.replace(re, "$1$2-$3");
     }
     return ret;
-}
+};
 
 export const friendlyAdjectiveAnimal = (): string => {
     return cleanFriendlyId(generateId(null, {

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -12,11 +12,11 @@ export const cleanFriendlyId = (id: string): string => {
 }
 
 export const friendlyAdjectiveAnimal = (): string => {
-    return generateId(null, {
+    return cleanFriendlyId(generateId(null, {
         caseStyle: "lowercase",
         delimiter: "-",
         numAdjectives: 1
-    });
+    }));
 };
 
 export class SessionStore {

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -2,7 +2,16 @@ import Redis from "ioredis";
 import { generateId } from "zoo-ids";
 import { SessionMetadata } from "../types";
 
-export const friendlyAdjectiveAnimal = () => {
+export const cleanFriendlyId = (id: string): string => {
+    let ret = id.toLowerCase();
+    const re = /(.+)-(.+)-(.+)/;
+    while (ret.match(re)) {
+        ret = ret.replace(re, "$1$2-$3");
+    }
+    return ret;
+}
+
+export const friendlyAdjectiveAnimal = (): string => {
     return generateId(null, {
         caseStyle: "lowercase",
         delimiter: "-",

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -177,7 +177,7 @@ describe("generate friendly id", () => {
 
     it("generates ids that always match pattern", () => {
         const n = 10000;
-        for (let i = 0; i < n; ++i) {
+        for (let i = 0; i < n; i += 1) {
             expect(friendlyAdjectiveAnimal()).toMatch(/^[a-z]+-[a-z]+$/);
         }
     });

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -1,4 +1,4 @@
-import { friendlyAdjectiveAnimal, SessionStore } from "../../src/db/sessionStore";
+import { friendlyAdjectiveAnimal, cleanFriendlyId, SessionStore } from "../../src/db/sessionStore";
 
 // Mock Date.now to return hardcoded date
 Date.now = jest.spyOn(Date, "now").mockImplementation(() => new Date(2022, 0, 24, 17).getTime()) as any;
@@ -168,5 +168,10 @@ describe("generate friendly id", () => {
         const id = friendlyAdjectiveAnimal();
         expect(id).toMatch(/^[a-z]+-[a-z]+$/);
         expect(friendlyAdjectiveAnimal()).not.toEqual(id);
+    });
+
+    it.only("cleans weird ids", () => {
+        expect(cleanFriendlyId("Spanish-albatross")).toBe("spanish-albatross");
+        expect(cleanFriendlyId("well-to-do-bug")).toBe("welltodo-bug");
     });
 });

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -170,8 +170,15 @@ describe("generate friendly id", () => {
         expect(friendlyAdjectiveAnimal()).not.toEqual(id);
     });
 
-    it.only("cleans weird ids", () => {
+    it("cleans weird ids", () => {
         expect(cleanFriendlyId("Spanish-albatross")).toBe("spanish-albatross");
         expect(cleanFriendlyId("well-to-do-bug")).toBe("welltodo-bug");
+    });
+
+    it("generates ids that always match pattern", () => {
+        const n = 10000;
+        for (let i = 0; i < n; ++i) {
+            expect(friendlyAdjectiveAnimal()).toMatch(/^[a-z]+-[a-z]+$/);
+        }
     });
 });

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -114,14 +114,13 @@ describe("Session id integration", () => {
 
     it("can create a friendly label for a session", async () => {
         const url = `apps/day1/sessions/${sessionId}/friendly`;
-        const friendlyIdRegex = /^([a-z]+-)+[a-z]+$/;
 
         // Gets created
         const response1 = await post(url, undefined);
         expect(response1.status).toBe(200);
         expect(response1.headers["content-type"]).toMatch("application/json");
         const friendly = response1.data.data;
-        expect(friendly).toMatch(friendlyIdRegex);
+        expect(friendly).toMatch(/^[a-z]+-[a-z]+$/);
 
         // Re-creating it does not change the friendly id
         const response2 = await post(url, undefined);
@@ -132,7 +131,7 @@ describe("Session id integration", () => {
         const response3 = await post("apps/day1/sessions/12345/friendly", undefined);
         expect(response3.status).toBe(200);
         expect(response3.data.data).not.toEqual(friendly);
-        expect(response3.data.data).toMatch(friendlyIdRegex);
+        expect(response3.data.data).toMatch(/^[a-z]+-[a-z]+$/);
     });
 });
 


### PR DESCRIPTION
This PR reverts the change added within #89 that allowed multiple hyphens and instead sanitises names so that we:

* always return lower case everything
* never have more than one hyphen

I've looked though zoo-ids lists and we only get uppercase letters for "French" and "Spanish", and only get multiple hyphens for adjectives