### PR TITLE
mrc-3584 Full session rehydrate

### DIFF
--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -5,6 +5,20 @@
     <div v-if="!hasPlotData" class="plot-placeholder">
       {{ placeholderMessage }}
     </div>
+    <div v-if="hasPlotData" hidden class="wodin-plot-data-summary">
+      <div class="wodin-plot-data-summary-series" v-for="(data, index) in baseData" :key="index"
+           :name="data.name"
+           :count="data.x?.length"
+           :xMin="Math.min(...data.x)"
+           :xMax="Math.max(...data.x)"
+           :yMin="Math.min(...data.y)"
+           :yMax="Math.max(...data.y)"
+           :mode="data.mode"
+           :type="data.type"
+           :lineColor="data.line?.color"
+           :markerColor="data.marker?.color"
+      ></div>
+    </div>
     <slot></slot>
   </div>
 </template>

--- a/app/static/src/app/components/WodinOdePlot.vue
+++ b/app/static/src/app/components/WodinOdePlot.vue
@@ -9,14 +9,13 @@
       <div class="wodin-plot-data-summary-series" v-for="(data, index) in baseData" :key="index"
            :name="data.name"
            :count="data.x?.length"
-           :xMin="Math.min(...data.x)"
-           :xMax="Math.max(...data.x)"
-           :yMin="Math.min(...data.y)"
-           :yMax="Math.max(...data.y)"
+           :x-min="Math.min(...data.x)"
+           :x-max="Math.max(...data.x)"
+           :y-min="Math.min(...data.y)"
+           :y-max="Math.max(...data.y)"
            :mode="data.mode"
-           :type="data.type"
-           :lineColor="data.line?.color"
-           :markerColor="data.marker?.color"
+           :line-color="data.line?.color"
+           :marker-color="data.marker?.color"
       ></div>
     </div>
     <slot></slot>

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -21,10 +21,10 @@ export default defineComponent({
     setup(props) {
         const store = useStore();
         const initialised = computed(() => !!store.state.appName);
-        onMounted(() => {
+        onMounted(async () => {
             const { appName, loadSessionId } = props;
+            await store.dispatch(`model/${ModelAction.FetchOdinRunner}`);
             store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
-            store.dispatch(`model/${ModelAction.FetchOdinRunner}`);
         });
 
         return { initialised };

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -7,7 +7,6 @@ import { computed, defineComponent, onMounted } from "vue";
 import { RouterView } from "vue-router";
 import { useStore } from "vuex";
 import { AppStateAction } from "../store/appState/actions";
-import { ModelAction } from "../store/model/actions";
 
 export default defineComponent({
     name: "WodinSession",
@@ -22,8 +21,8 @@ export default defineComponent({
         const store = useStore();
         const initialised = computed(() => !!store.state.appName);
         onMounted(() => {
-          const { appName, loadSessionId } = props;
-          store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
+            const { appName, loadSessionId } = props;
+            store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
         });
 
         return { initialised };

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -21,10 +21,9 @@ export default defineComponent({
     setup(props) {
         const store = useStore();
         const initialised = computed(() => !!store.state.appName);
-        onMounted(async () => {
-            const { appName, loadSessionId } = props;
-            store.dispatch(`model/${ModelAction.FetchOdinRunner}`);
-            store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
+        onMounted(() => {
+          const { appName, loadSessionId } = props;
+          store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
         });
 
         return { initialised };

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -23,7 +23,7 @@ export default defineComponent({
         const initialised = computed(() => !!store.state.appName);
         onMounted(async () => {
             const { appName, loadSessionId } = props;
-            await store.dispatch(`model/${ModelAction.FetchOdinRunner}`);
+            store.dispatch(`model/${ModelAction.FetchOdinRunner}`);
             store.dispatch(AppStateAction.Initialise, { appName, loadSessionId });
         });
 

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -56,27 +56,17 @@ export default defineComponent({
         });
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
-            let dataToPlot = [];
-            const palette = store.state.model.paletteModel;
+            const { data } = store.state.fitData;
             const result = solution.value && solution.value({
                 mode: "grid", tStart: start, tEnd: end, nPoints: points
             });
-
-            if (plotRehydratedFit.value) {
-                dataToPlot = rehydratedFitDataToPlotly(store.state.modelFit.result.inputs.data, link.value, palette);
-            } else {
-                const { data } = store.state.fitData;
-
-                if (!data || !link.value || !result) {
-                    return [];
-                }
-
-                dataToPlot = fitDataToPlotly(data, link.value, palette, start, end);
+            if (!data || !link.value || !result) {
+              return [];
             }
-
+            const palette = store.state.model.paletteModel;
             return [
                 ...odinToPlotly(filterSeriesSet(result, link.value.model), palette),
-                ...dataToPlot
+                ...fitDataToPlotly(data, link.value, palette, start, end)
             ];
         };
 

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -14,11 +14,10 @@ import {
     computed, defineComponent
 } from "vue";
 import { useStore } from "vuex";
-import { plot } from "plotly.js";
 import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
 import {
-  filterSeriesSet, fitDataToPlotly, odinToPlotly, rehydratedFitDataToPlotly, WodinPlotData
+  filterSeriesSet, fitDataToPlotly, odinToPlotly, WodinPlotData
 } from "../../plot";
 import WodinOdePlot from "../WodinOdePlot.vue";
 

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -38,7 +38,6 @@ export default defineComponent({
         const plotRehydratedFit = computed(() => {
             const { modelFit } = store.state;
             const result = modelFit.result && !modelFit.result.solution && !modelFit.result.error;
-            console.log(`plotting rehyd fit: ${result}`);
             return result;
         });
 

--- a/app/static/src/app/components/fit/FitPlot.vue
+++ b/app/static/src/app/components/fit/FitPlot.vue
@@ -17,7 +17,7 @@ import { useStore } from "vuex";
 import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
 import {
-  filterSeriesSet, fitDataToPlotly, odinToPlotly, WodinPlotData
+    filterSeriesSet, fitDataToPlotly, odinToPlotly, WodinPlotData
 } from "../../plot";
 import WodinOdePlot from "../WodinOdePlot.vue";
 
@@ -46,11 +46,13 @@ export default defineComponent({
         });
 
         const endTime = computed(() => {
-          return plotRehydratedFit.value ? store.state.modelFit.result.inputs.endTime : store.getters[`fitData/${FitDataGetter.dataEnd}`];
+            return plotRehydratedFit.value ? store.state.modelFit.result.inputs.endTime
+                : store.getters[`fitData/${FitDataGetter.dataEnd}`];
         });
 
         const link = computed(() => {
-          return plotRehydratedFit.value ? store.state.modelFit.result.inputs.link : store.getters[`fitData/${FitDataGetter.link}`]
+            return plotRehydratedFit.value ? store.state.modelFit.result.inputs.link
+                : store.getters[`fitData/${FitDataGetter.link}`];
         });
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
@@ -59,7 +61,7 @@ export default defineComponent({
                 mode: "grid", tStart: start, tEnd: end, nPoints: points
             });
             if (!data || !link.value || !result) {
-              return [];
+                return [];
             }
             const palette = store.state.model.paletteModel;
             return [

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -69,7 +69,8 @@ export default {
             // makes it look like some additional action needs
             // taking. The plot already tells the user that the fit
             // needs running, so don't add a message.
-            // We do want to show message when rehydrated - will not have a solution in that case.
+            // (We do want to show message when rehydrated - will not have a solution in that case,
+            // but will have a result and no error).
             if (!store.state.modelFit.result || store.state.modelFit.error) {
               return "";
             }

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -69,8 +69,9 @@ export default {
             // makes it look like some additional action needs
             // taking. The plot already tells the user that the fit
             // needs running, so don't add a message.
-            if (!store.state.modelFit.result?.solution) {
-                return "";
+            // We do want to show message when rehydrated - will not have a solution in that case.
+            if (!store.state.modelFit.result || store.state.modelFit.error) {
+              return "";
             }
             if (compileRequired.value) {
                 return userMessages.modelFit.compileRequired;

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -72,7 +72,7 @@ export default {
             // (We do want to show message when rehydrated - will not have a solution in that case,
             // but will have a result and no error).
             if (!store.state.modelFit.result || store.state.modelFit.error) {
-              return "";
+                return "";
             }
             if (compileRequired.value) {
                 return userMessages.modelFit.compileRequired;

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -83,6 +83,20 @@ export function fitDataToPlotly(data: FitData, link: FitDataLink, palette: Palet
     }];
 }
 
+export function rehydratedFitDataToPlotly(data: Dict<number[]>, link: FitDataLink, palette: Palette): WodinPlotData {
+    //TODO: make this more DRY
+    return [{
+        name: link.data,
+        x: data["time"] as number[],
+        y: data["value"] as number[],
+        mode: "markers",
+        type: "scatter",
+        marker: {
+            color: palette[link.model]
+        }
+    }];
+}
+
 export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: Palette,
     start: number, end: number): WodinPlotData {
     if (!allFitData) {

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -83,33 +83,6 @@ export function fitDataToPlotly(data: FitData, link: FitDataLink, palette: Palet
     }];
 }
 
-function getPlotlyScatter(name: string, x: number[], y: number[], color: string): Partial<PlotData> {
-    return {
-        name,
-        x,
-        y,
-        mode: "markers",
-        type: "scatter",
-        marker: {
-            color
-        }
-    };
-}
-
-export function rehydratedFitDataToPlotly(data: Dict<number[]>, link: FitDataLink, palette: Palette): WodinPlotData {
-    return [getPlotlyScatter(link.data, data["time"] as number[], data["value"] as number[], palette[link.model])];
-    /*return [{
-        name: link.data,
-        x: data["time"] as number[],
-        y: data["value"] as number[],
-        mode: "markers",
-        type: "scatter",
-        marker: {
-            color: palette[link.model]
-        }
-    }];*/
-}
-
 export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: Palette,
     start: number, end: number): WodinPlotData {
     if (!allFitData) {
@@ -120,11 +93,7 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
     } = allFitData;
     const filteredData = filterData(data, timeVariable, start, end);
     const palette = paletteData(Object.keys(linkedVariables));
-    return Object.keys(linkedVariables).map((name: string) => getPlotlyScatter(name,
-            filteredData.map((row: Dict<number>) => row[timeVariable]),
-            filteredData.map((row: Dict<number>) => row[name]),
-            linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]));
-        /*({
+    return Object.keys(linkedVariables).map((name: string) => ({
         name,
         x: filteredData.map((row: Dict<number>) => row[timeVariable]),
         y: filteredData.map((row: Dict<number>) => row[name]),
@@ -133,5 +102,5 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
         marker: {
             color: linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]
         }
-    }));*/
+    }));
 }

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -83,9 +83,22 @@ export function fitDataToPlotly(data: FitData, link: FitDataLink, palette: Palet
     }];
 }
 
+function getPlotlyScatter(name: string, x: number[], y: number[], color: string): Partial<PlotData> {
+    return {
+        name,
+        x,
+        y,
+        mode: "markers",
+        type: "scatter",
+        marker: {
+            color
+        }
+    };
+}
+
 export function rehydratedFitDataToPlotly(data: Dict<number[]>, link: FitDataLink, palette: Palette): WodinPlotData {
-    //TODO: make this more DRY
-    return [{
+    return [getPlotlyScatter(link.data, data["time"] as number[], data["value"] as number[], palette[link.model])];
+    /*return [{
         name: link.data,
         x: data["time"] as number[],
         y: data["value"] as number[],
@@ -94,7 +107,7 @@ export function rehydratedFitDataToPlotly(data: Dict<number[]>, link: FitDataLin
         marker: {
             color: palette[link.model]
         }
-    }];
+    }];*/
 }
 
 export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: Palette,
@@ -107,7 +120,11 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
     } = allFitData;
     const filteredData = filterData(data, timeVariable, start, end);
     const palette = paletteData(Object.keys(linkedVariables));
-    return Object.keys(linkedVariables).map((name: string) => ({
+    return Object.keys(linkedVariables).map((name: string) => getPlotlyScatter(name,
+            filteredData.map((row: Dict<number>) => row[timeVariable]),
+            filteredData.map((row: Dict<number>) => row[name]),
+            linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]));
+        /*({
         name,
         x: filteredData.map((row: Dict<number>) => row[timeVariable]),
         y: filteredData.map((row: Dict<number>) => row[name]),
@@ -116,5 +133,5 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
         marker: {
             color: linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]
         }
-    }));
+    }));*/
 }

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -25,7 +25,8 @@ function serialiseModel(model: ModelState) : SerialisedModelState {
         compileRequired: model.compileRequired,
         odinModelResponse: model.odinModelResponse,
         hasOdin: !!model.odin,
-        odinModelCodeError: model.odinModelCodeError
+        odinModelCodeError: model.odinModelCodeError,
+        paletteModel: model.paletteModel
     };
 }
 

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -100,6 +100,9 @@ export const serialiseState = (state: AppState) => {
     return JSON.stringify(result);
 };
 
-export deserialiseState = (targetState: AppState, serialised: SerialisedAppState) => {
-
-}
+export const deserialiseState = (targetState: AppState, serialised: SerialisedAppState) => {
+    Object.assign(targetState, {
+        ...targetState,
+        ...serialised
+    });
+};

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,12 +1,13 @@
-import { AppState, AppType } from "./store/appState/state";
+import {AppState, AppType, VisualisationTab} from "./store/appState/state";
 import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
-import { RunState } from "./store/run/state";
+import {RunState, RunUpdateRequiredReasons} from "./store/run/state";
 import { SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
-import { OdinFitResult, OdinRunResult } from "./types/wrapperTypes";
+import {OdinFitInputs, OdinFitResult, OdinRunInputs, OdinRunResult} from "./types/wrapperTypes";
+import {OdinModelResponse, OdinUserType, WodinError} from "./types/responseTypes";
 
 function serialiseCode(code: CodeState) {
     return {
@@ -14,7 +15,7 @@ function serialiseCode(code: CodeState) {
     };
 }
 
-function serialiseModel(model: ModelState) {
+function serialiseModel(model: ModelState) : SerialisedModelState {
     return {
         compileRequired: model.compileRequired,
         odinModelResponse: model.odinModelResponse,
@@ -23,7 +24,7 @@ function serialiseModel(model: ModelState) {
     };
 }
 
-function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null) {
+function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null): SerialisedSolutionResult {
     return result ? {
         inputs: result.inputs,
         hasResult: !!result.solution,
@@ -31,7 +32,7 @@ function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null) {
     } : null;
 }
 
-function serialiseRun(run: RunState) {
+function serialiseRun(run: RunState): SerialisedRunState {
     return {
         runRequired: run.runRequired,
         parameterValues: run.parameterValues,
@@ -76,7 +77,35 @@ function serialiseModelFit(modelFit: ModelFitState) {
     };
 }
 
-export const serialiseState = (state: AppState) => {
+// TODO: mode types into types folder
+export interface SerialisedModelState {
+    compileRequired: boolean,
+    odinModelResponse: OdinModelResponse | null,
+    hasOdin: boolean,
+    odinModelCodeError: WodinError
+}
+
+export interface SerialisedRunState {
+    runRequired: RunUpdateRequiredReasons,
+    parameterValues: OdinUserType | null,
+    endTime: number,
+    result: SerialisedSolutionResult | null
+}
+
+export interface SerialisedSolutionResult {
+    inputs: OdinRunInputs | OdinFitInputs,
+    hasResult: boolean
+    error: WodinError | null
+}
+
+export interface SerialisedAppState {
+    openVisualisationTab: VisualisationTab,
+    code: CodeState,
+    model: SerialisedModelState,
+    run: SerialisedRunState
+}
+
+export const serialiseState = (state: AppState) : SerialisedAppState => {
     const result = {
         openVisualisationTab: state.openVisualisationTab,
         code: serialiseCode(state.code),
@@ -93,3 +122,9 @@ export const serialiseState = (state: AppState) => {
 
     return JSON.stringify(result);
 };
+
+
+
+export deserialiseState = (targetState: AppState, serialised: SerialisedAppState) => {
+
+}

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,12 +1,12 @@
-import {AppState, AppType} from "./store/appState/state";
+import { AppState, AppType } from "./store/appState/state";
 import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
-import {RunState,} from "./store/run/state";
-import {SensitivityState} from "./store/sensitivity/state";
+import { RunState } from "./store/run/state";
+import { SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
-import { ModelFitState} from "./store/modelFit/state";
-import { OdinFitResult, OdinRunResult} from "./types/wrapperTypes";
+import { ModelFitState } from "./store/modelFit/state";
+import { OdinFitResult, OdinRunResult } from "./types/wrapperTypes";
 import {
     SerialisedAppState, SerialisedModelState,
     SerialisedRunState,

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -1,15 +1,20 @@
-import {AppState, AppType, VisualisationTab} from "./store/appState/state";
+import {AppState, AppType} from "./store/appState/state";
 import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
-import {RunState, RunUpdateRequiredReasons} from "./store/run/state";
-import { SensitivityState } from "./store/sensitivity/state";
+import {RunState,} from "./store/run/state";
+import {SensitivityState} from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
-import { ModelFitState } from "./store/modelFit/state";
-import {OdinFitInputs, OdinFitResult, OdinRunInputs, OdinRunResult} from "./types/wrapperTypes";
-import {OdinModelResponse, OdinUserType, WodinError} from "./types/responseTypes";
+import { ModelFitState} from "./store/modelFit/state";
+import { OdinFitResult, OdinRunResult} from "./types/wrapperTypes";
+import {
+    SerialisedAppState, SerialisedModelState,
+    SerialisedRunState,
+    SerialisedSensitivityState,
+    SerialisedSolutionResult
+} from "./types/serialisationTypes";
 
-function serialiseCode(code: CodeState) {
+function serialiseCode(code: CodeState) : CodeState {
     return {
         currentCode: code.currentCode
     };
@@ -24,7 +29,7 @@ function serialiseModel(model: ModelState) : SerialisedModelState {
     };
 }
 
-function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null): SerialisedSolutionResult {
+function serialiseSolutionResult(result: OdinRunResult | OdinFitResult | null): SerialisedSolutionResult | null {
     return result ? {
         inputs: result.inputs,
         hasResult: !!result.solution,
@@ -41,7 +46,7 @@ function serialiseRun(run: RunState): SerialisedRunState {
     };
 }
 
-function serialiseSensitivity(sensitivity: SensitivityState) {
+function serialiseSensitivity(sensitivity: SensitivityState): SerialisedSensitivityState {
     return {
         paramSettings: sensitivity.paramSettings,
         sensitivityUpdateRequired: sensitivity.sensitivityUpdateRequired,
@@ -54,7 +59,7 @@ function serialiseSensitivity(sensitivity: SensitivityState) {
     };
 }
 
-function serialiseFitData(fitData: FitDataState) {
+function serialiseFitData(fitData: FitDataState) : FitDataState {
     return {
         data: fitData.data,
         columns: fitData.columns,
@@ -77,42 +82,14 @@ function serialiseModelFit(modelFit: ModelFitState) {
     };
 }
 
-// TODO: mode types into types folder
-export interface SerialisedModelState {
-    compileRequired: boolean,
-    odinModelResponse: OdinModelResponse | null,
-    hasOdin: boolean,
-    odinModelCodeError: WodinError
-}
-
-export interface SerialisedRunState {
-    runRequired: RunUpdateRequiredReasons,
-    parameterValues: OdinUserType | null,
-    endTime: number,
-    result: SerialisedSolutionResult | null
-}
-
-export interface SerialisedSolutionResult {
-    inputs: OdinRunInputs | OdinFitInputs,
-    hasResult: boolean
-    error: WodinError | null
-}
-
-export interface SerialisedAppState {
-    openVisualisationTab: VisualisationTab,
-    code: CodeState,
-    model: SerialisedModelState,
-    run: SerialisedRunState
-}
-
-export const serialiseState = (state: AppState) : SerialisedAppState => {
-    const result = {
+export const serialiseState = (state: AppState) => {
+    const result: SerialisedAppState = {
         openVisualisationTab: state.openVisualisationTab,
         code: serialiseCode(state.code),
         model: serialiseModel(state.model),
         run: serialiseRun(state.run),
         sensitivity: serialiseSensitivity(state.sensitivity)
-    } as any; // TODO: generate type from schema
+    };
 
     if (state.appType === AppType.Fit) {
         const fitState = state as FitState;
@@ -122,8 +99,6 @@ export const serialiseState = (state: AppState) : SerialisedAppState => {
 
     return JSON.stringify(result);
 };
-
-
 
 export deserialiseState = (targetState: AppState, serialised: SerialisedAppState) => {
 

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -50,6 +50,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                 // Fetch and rehydrate session data
                 await dispatch(`sessions/${SessionsAction.Rehydrate}`, loadSessionId);
             } else {
+                await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, {root: true});
                 // If not loading a session, set code from default in config
                 commit(`code/${CodeMutation.SetCurrentCode}`, state.config!.defaultCode, { root: true });
                 if (state.code.currentCode.length) {

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -51,7 +51,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                 // Fetch and rehydrate session datas
                 await dispatch(`sessions/${SessionsAction.Rehydrate}`, loadSessionId);
             } else {
-                await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, {root: true});
+                await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, { root: true });
                 // If not loading a session, set code and end time from default in config
                 commit(`code/${CodeMutation.SetCurrentCode}`, state.config!.defaultCode, { root: true });
                 if (response.data.endTime) {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -108,9 +108,9 @@ export const actions: ActionTree<ModelState, AppState> = {
         compileModelAndUpdateStore(context);
     },
 
-    CompileModelOnRehydate(context) {
+    CompileModelOnRehydrate(context) {
         // compiled the model but do not update parameters etc as those will all be rehydrated too
-        compileModel(context)
+        compileModel(context);
     },
 
     async DefaultModel(context) {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -90,8 +90,6 @@ const compileModelAndUpdateStore = (context: ActionContext<ModelState, AppState>
     }
 };
 
-
-
 export const actions: ActionTree<ModelState, AppState> = {
     async FetchOdinRunner(context) {
         await api(context)

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -13,7 +13,9 @@ export enum RunAction {
 
 const runModel = (parameterValues: OdinUserType | null, endTime: number,
     context: ActionContext<RunState, AppState>) => {
+
     const { rootState, commit } = context;
+
     if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
         const startTime = 0;
         const payload : OdinRunResult = {
@@ -21,6 +23,7 @@ const runModel = (parameterValues: OdinUserType | null, endTime: number,
             solution: null,
             error: null
         };
+
         try {
             const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
                 startTime, endTime, {});

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -1,37 +1,63 @@
-import { ActionTree } from "vuex";
+import { ActionContext, ActionTree } from "vuex";
 import { RunState } from "./state";
 import { RunMutation } from "./mutations";
 import { AppState } from "../appState/state";
 import userMessages from "../../userMessages";
 import type { OdinRunResult } from "../../types/wrapperTypes";
+import { OdinUserType } from "../../types/responseTypes";
 
 export enum RunAction {
-    RunModel = "RunModel"
+    RunModel = "RunModel",
+    RunModelOnRehydrate = "RunModelOnRehydrate"
 }
+
+const runModel = (parameterValues: OdinUserType | null, endTime: number,
+    context: ActionContext<RunState, AppState>) => {
+    console.log("0")
+    const { rootState, commit } = context;
+    console.log("1")
+    if (!rootState.model.odinRunner) {
+        console.log("no runner")
+    }
+    if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
+        console.log("2")
+        const startTime = 0;
+        const payload : OdinRunResult = {
+            inputs: { endTime, parameterValues },
+            solution: null,
+            error: null
+        };
+        try {
+            console.log("3")
+            const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
+                startTime, endTime, {});
+            payload.solution = solution;
+            console.log("4")
+        } catch (e) {
+            console.log("e5")
+            payload.error = {
+                error: userMessages.errors.wodinRunError,
+                detail: (e as Error).message
+            };
+        }
+        commit(RunMutation.SetResult, payload);
+    }
+};
 
 export const actions: ActionTree<RunState, AppState> = {
     RunModel(context) {
-        const { rootState, state, commit } = context;
-        const { parameterValues } = state;
-        if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
-            const startTime = 0;
-            const { endTime } = state;
-            const payload : OdinRunResult = {
-                inputs: { endTime, parameterValues },
-                solution: null,
-                error: null
-            };
-            try {
-                const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
-                    startTime, endTime, {});
-                payload.solution = solution;
-            } catch (e) {
-                payload.error = {
-                    error: userMessages.errors.wodinRunError,
-                    detail: (e as Error).message
-                };
-            }
-            commit(RunMutation.SetResult, payload);
+        const { state } = context;
+        const { parameterValues, endTime } = state;
+        runModel(parameterValues, endTime, context);
+    },
+
+    RunModelOnRehydrate(context) {
+        console.log("running on rehydrate")
+        const { state } = context;
+        if (state.result?.hasResult) {
+            const { parameterValues, endTime } = state.result.inputs;
+            console.log("running model")
+            runModel(parameterValues, endTime, context);
         }
     }
 };

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -13,7 +13,6 @@ export enum RunAction {
 
 const runModel = (parameterValues: OdinUserType | null, endTime: number,
     context: ActionContext<RunState, AppState>) => {
-
     const { rootState, commit } = context;
 
     if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -54,10 +54,8 @@ export const actions: ActionTree<RunState, AppState> = {
     RunModelOnRehydrate(context) {
         console.log("running on rehydrate")
         const { state } = context;
-        if (state.result?.hasResult) {
-            const { parameterValues, endTime } = state.result.inputs;
-            console.log("running model")
-            runModel(parameterValues, endTime, context);
-        }
+        const { parameterValues, endTime } = state.result!.inputs;
+        console.log("running model")
+        runModel(parameterValues, endTime, context);
     }
 };

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -13,14 +13,8 @@ export enum RunAction {
 
 const runModel = (parameterValues: OdinUserType | null, endTime: number,
     context: ActionContext<RunState, AppState>) => {
-    console.log("0")
     const { rootState, commit } = context;
-    console.log("1")
-    if (!rootState.model.odinRunner) {
-        console.log("no runner")
-    }
     if (rootState.model.odinRunner && rootState.model.odin && parameterValues) {
-        console.log("2")
         const startTime = 0;
         const payload : OdinRunResult = {
             inputs: { endTime, parameterValues },
@@ -28,13 +22,10 @@ const runModel = (parameterValues: OdinUserType | null, endTime: number,
             error: null
         };
         try {
-            console.log("3")
             const solution = rootState.model.odinRunner.wodinRun(rootState.model.odin, parameterValues,
                 startTime, endTime, {});
             payload.solution = solution;
-            console.log("4")
         } catch (e) {
-            console.log("e5")
             payload.error = {
                 error: userMessages.errors.wodinRunError,
                 detail: (e as Error).message
@@ -52,10 +43,8 @@ export const actions: ActionTree<RunState, AppState> = {
     },
 
     RunModelOnRehydrate(context) {
-        console.log("running on rehydrate")
         const { state } = context;
         const { parameterValues, endTime } = state.result!.inputs;
-        console.log("running model")
         runModel(parameterValues, endTime, context);
     }
 };

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -1,4 +1,4 @@
-import {ActionContext, ActionTree} from "vuex";
+import { ActionContext, ActionTree } from "vuex";
 import { AppState } from "../appState/state";
 import { SensitivityState } from "./state";
 import { SensitivityGetter } from "./getters";
@@ -6,7 +6,7 @@ import { SensitivityMutation } from "./mutations";
 import { RunAction } from "../run/actions";
 import userMessages from "../../userMessages";
 import { OdinSensitivityResult } from "../../types/wrapperTypes";
-import {BatchPars} from "../../types/responseTypes";
+import { BatchPars } from "../../types/responseTypes";
 
 export enum SensitivityAction {
     RunSensitivity = "RunSensitivity",
@@ -60,9 +60,9 @@ export const actions: ActionTree<SensitivityState, AppState> = {
     },
 
     [SensitivityAction.RunSensitivityOnRehydrate](context) {
-        const {state, rootState} = context;
-        const {endTime} = rootState.run;
-        const {pars} = state.result!.inputs;
+        const { state, rootState } = context;
+        const { endTime } = rootState.run;
+        const { pars } = state.result!.inputs;
 
         runSensitivity(pars, endTime, context);
     }

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -1,4 +1,4 @@
-import { ActionTree } from "vuex";
+import {ActionContext, ActionTree} from "vuex";
 import { AppState } from "../appState/state";
 import { SensitivityState } from "./state";
 import { SensitivityGetter } from "./getters";
@@ -6,48 +6,64 @@ import { SensitivityMutation } from "./mutations";
 import { RunAction } from "../run/actions";
 import userMessages from "../../userMessages";
 import { OdinSensitivityResult } from "../../types/wrapperTypes";
+import {BatchPars} from "../../types/responseTypes";
 
 export enum SensitivityAction {
-    RunSensitivity = "RunSensitivity"
+    RunSensitivity = "RunSensitivity",
+    RunSensitivityOnRehydrate = "RunSensitivityOnRehydrate"
 }
+
+const runSensitivity = (batchPars: BatchPars, endTime: number, context: ActionContext<SensitivityState, AppState>) => {
+    const {
+        rootState, commit, dispatch
+    } = context;
+    const { odinRunner, odin } = rootState.model;
+
+    if (odinRunner && odin && batchPars) {
+        const payload : OdinSensitivityResult = {
+            inputs: { endTime, pars: batchPars },
+            batch: null,
+            error: null
+        };
+        try {
+            const batch = odinRunner.batchRun(odin, batchPars, 0, endTime, {});
+            payload.batch = batch;
+        } catch (e: unknown) {
+            payload.error = {
+                error: userMessages.errors.wodinSensitivityError,
+                detail: (e as Error).message
+            };
+        }
+        commit(SensitivityMutation.SetResult, payload);
+        if (payload.batch !== null) {
+            commit(SensitivityMutation.SetUpdateRequired, {
+                modelChanged: false,
+                parameterValueChanged: false,
+                endTimeChanged: false,
+                sensitivityOptionsChanged: false
+            });
+            // Also re-run model if required so that plotted central traces are correct
+            if (rootState.run.runRequired) {
+                dispatch(`run/${RunAction.RunModel}`, null, { root: true });
+            }
+        }
+    }
+};
 
 export const actions: ActionTree<SensitivityState, AppState> = {
     [SensitivityAction.RunSensitivity](context) {
-        const {
-            rootState, getters, commit, dispatch
-        } = context;
-        const { odinRunner, odin } = rootState.model;
+        const { rootState, getters } = context;
         const { endTime } = rootState.run;
         const batchPars = getters[SensitivityGetter.batchPars];
 
-        if (odinRunner && odin && batchPars) {
-            const payload : OdinSensitivityResult = {
-                inputs: { endTime, pars: batchPars },
-                batch: null,
-                error: null
-            };
-            try {
-                const batch = odinRunner.batchRun(odin, batchPars, 0, endTime, {});
-                payload.batch = batch;
-            } catch (e: unknown) {
-                payload.error = {
-                    error: userMessages.errors.wodinSensitivityError,
-                    detail: (e as Error).message
-                };
-            }
-            commit(SensitivityMutation.SetResult, payload);
-            if (payload.batch !== null) {
-                commit(SensitivityMutation.SetUpdateRequired, {
-                    modelChanged: false,
-                    parameterValueChanged: false,
-                    endTimeChanged: false,
-                    sensitivityOptionsChanged: false
-                });
-                // Also re-run model if required so that plotted central traces are correct
-                if (rootState.run.runRequired) {
-                    dispatch(`run/${RunAction.RunModel}`, null, { root: true });
-                }
-            }
-        }
+        runSensitivity(batchPars, endTime, context);
+    },
+
+    [SensitivityAction.RunSensitivityOnRehydrate](context) {
+        const {state, rootState} = context;
+        const {endTime} = rootState.run;
+        const {pars} = state.result!.inputs;
+
+        runSensitivity(pars, endTime, context);
     }
 };

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -49,14 +49,14 @@ export const actions: ActionTree<SessionsState, AppState> = {
             const rootOption = {root: true};
             await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);
             if (sessionData.model.hasOdin) {
-                await dispatch(`model/${ModelAction.CompileModel}`, null, rootOption);
-                // Do not auto-run anything if compile was required when session was last saved
+                // Don't auto-run if compile was required i.e. model was out of date when session was last saved
                 if (!sessionData.model.compileRequired) {
+                    // compile the model to evaluate odin, which is not persisted
+                    await dispatch(`model/${ModelAction.CompileModel}`, null, rootOption);
                     if (sessionData.run.result?.hasResult) {
                         dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
                     }
                     if (sessionData.sensitivity.result?.hasResult) {
-                        console.log("running s on r")
                         dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
                     }
                 }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -11,6 +11,7 @@ import {ModelMutation} from "../model/mutations";
 import {ModelAction} from "../model/actions";
 import {SerialisedAppState} from "../../types/serialisationTypes";
 import {deserialiseState} from "../../serialise";
+import {SensitivityAction} from "../sensitivity/actions";
 
 export enum SessionsAction {
     GetSessions = "GetSessions",
@@ -49,8 +50,15 @@ export const actions: ActionTree<SessionsState, AppState> = {
             await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);
             if (sessionData.model.hasOdin) {
                 await dispatch(`model/${ModelAction.CompileModel}`, null, rootOption);
-                if (sessionData.run.result?.hasResult) {
-                    dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
+                // Do not auto-run anything if compile was required when session was last saved
+                if (!sessionData.model.compileRequired) {
+                    if (sessionData.run.result?.hasResult) {
+                        dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
+                    }
+                    if (sessionData.sensitivity.result?.hasResult) {
+                        console.log("running s on r")
+                        dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
+                    }
                 }
             }
         }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -32,7 +32,6 @@ export const actions: ActionTree<SessionsState, AppState> = {
     },
 
     async [SessionsAction.Rehydrate](context, sessionId: string) {
-        console.log("rehydrating")
         const { rootState, dispatch, commit } = context;
         const { appName } = rootState;
         const url = `/apps/${appName}/sessions/${sessionId}`;
@@ -44,16 +43,10 @@ export const actions: ActionTree<SessionsState, AppState> = {
         if (response) {
             const sessionData = response.data as SerialisedAppState;
 
-            const { odinRunner } = rootState.model; // save the odin Runner to inject into the rehydrated state
-            if (!odinRunner) {
-                console.log("no runner on rehyd")
-            } else {
-                console.log("runner is: " + JSON.stringify(odinRunner))
-            }
             deserialiseState(rootState, sessionData);
 
             const rootOption = {root: true};
-            commit(`/model/${ModelMutation.SetOdinRunner}`, odinRunner, rootOption); //TODO: maybe do this in deserialise
+            await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);
             if (sessionData.model.hasOdin) {
                 await dispatch(`model/${ModelAction.CompileModel}`, null, rootOption);
                 if (sessionData.run.result?.hasResult) {

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -46,17 +46,15 @@ export const actions: ActionTree<SessionsState, AppState> = {
 
             const rootOption = { root: true };
             await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);
-            if (sessionData.model.hasOdin) {
-                // Don't auto-run if compile was required i.e. model was out of date when session was last saved
-                if (!sessionData.model.compileRequired) {
-                    // compile the model to evaluate odin, which is not persisted
-                    await dispatch(`model/${ModelAction.CompileModelOnRehydrate}`, null, rootOption);
-                    if (sessionData.run.result?.hasResult) {
-                        dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
-                    }
-                    if (sessionData.sensitivity.result?.hasResult) {
-                        dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
-                    }
+            // Don't auto-run if compile was required i.e. model was out of date when session was last saved
+            if (sessionData.model.hasOdin && !sessionData.model.compileRequired) {
+                // compile the model to evaluate odin, which is not persisted
+                await dispatch(`model/${ModelAction.CompileModelOnRehydrate}`, null, rootOption);
+                if (sessionData.run.result?.hasResult) {
+                    dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
+                }
+                if (sessionData.sensitivity.result?.hasResult) {
+                    dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
                 }
             }
         }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -33,7 +33,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
     },
 
     async [SessionsAction.Rehydrate](context, sessionId: string) {
-        const { rootState, dispatch, commit } = context;
+        const { rootState, dispatch } = context;
         const { appName } = rootState;
         const url = `/apps/${appName}/sessions/${sessionId}`;
         const response = await api(context)
@@ -52,11 +52,13 @@ export const actions: ActionTree<SessionsState, AppState> = {
                 // Don't auto-run if compile was required i.e. model was out of date when session was last saved
                 if (!sessionData.model.compileRequired) {
                     // compile the model to evaluate odin, which is not persisted
-                    await dispatch(`model/${ModelAction.CompileModel}`, null, rootOption);
+                    await dispatch(`model/${ModelAction.CompileModelOnRehydrate}`, null, rootOption);
                     if (sessionData.run.result?.hasResult) {
+                        console.log("re-running Run")
                         dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
                     }
                     if (sessionData.sensitivity.result?.hasResult) {
+                        console.log("re-running sensitivity")
                         dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
                     }
                 }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -54,11 +54,9 @@ export const actions: ActionTree<SessionsState, AppState> = {
                     // compile the model to evaluate odin, which is not persisted
                     await dispatch(`model/${ModelAction.CompileModelOnRehydrate}`, null, rootOption);
                     if (sessionData.run.result?.hasResult) {
-                        console.log("re-running Run")
                         dispatch(`run/${RunAction.RunModelOnRehydrate}`, null, rootOption);
                     }
                     if (sessionData.sensitivity.result?.hasResult) {
-                        console.log("re-running sensitivity")
                         dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
                     }
                 }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -5,13 +5,11 @@ import { localStorageManager } from "../../localStorageManager";
 import { api } from "../../apiService";
 import { SessionsMutation } from "./mutations";
 import { ErrorsMutation } from "../errors/mutations";
-import { CodeAction } from "../code/actions";
-import {RunAction} from "../run/actions";
-import {ModelMutation} from "../model/mutations";
-import {ModelAction} from "../model/actions";
-import {SerialisedAppState} from "../../types/serialisationTypes";
-import {deserialiseState} from "../../serialise";
-import {SensitivityAction} from "../sensitivity/actions";
+import { RunAction } from "../run/actions";
+import { ModelAction } from "../model/actions";
+import { SerialisedAppState } from "../../types/serialisationTypes";
+import { deserialiseState } from "../../serialise";
+import { SensitivityAction } from "../sensitivity/actions";
 
 export enum SessionsAction {
     GetSessions = "GetSessions",
@@ -46,7 +44,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
 
             deserialiseState(rootState, sessionData);
 
-            const rootOption = {root: true};
+            const rootOption = { root: true };
             await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);
             if (sessionData.model.hasOdin) {
                 // Don't auto-run if compile was required i.e. model was out of date when session was last saved

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -27,8 +27,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
     },
 
     async [SessionsAction.Rehydrate](context, sessionId: string) {
-        // TODO: complete rehydrate of entire state, just setting code for now
-        const { rootState, dispatch } = context;
+        const { rootState } = context;
         const { appName } = rootState;
         const url = `/apps/${appName}/sessions/${sessionId}`;
         const response = await api(context)
@@ -38,7 +37,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
 
         if (response) {
             const sessionData = response.data as Partial<AppState>;
-            await dispatch(`code/${CodeAction.UpdateCode}`, sessionData.code!.currentCode, { root: true });
+            Object.assign(rootState, sessionData);
         }
     }
 };

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -1,0 +1,62 @@
+import {OdinModelResponse, OdinUserType, WodinError} from "./responseTypes";
+import {RunUpdateRequiredReasons} from "../store/run/state";
+import {OdinFitInputs, OdinRunInputs, OdinSensitivityInputs} from "./wrapperTypes";
+import {
+    SensitivityParameterSettings,
+    SensitivityPlotSettings,
+    SensitivityUpdateRequiredReasons
+} from "../store/sensitivity/state";
+import {FitUpdateRequiredReasons} from "../store/modelFit/state";
+import {VisualisationTab} from "../store/appState/state";
+import {CodeState} from "../store/code/state";
+import {FitDataState} from "../store/fitData/state";
+
+export interface SerialisedSolutionResult {
+    inputs: OdinRunInputs | OdinFitInputs,
+    hasResult: boolean
+    error: WodinError | null
+}
+
+export interface SerialisedModelState {
+    compileRequired: boolean,
+    odinModelResponse: OdinModelResponse | null,
+    hasOdin: boolean,
+    odinModelCodeError: WodinError | null
+}
+
+export interface SerialisedRunState {
+    runRequired: RunUpdateRequiredReasons,
+    parameterValues: OdinUserType | null,
+    endTime: number,
+    result: SerialisedSolutionResult | null
+}
+
+export interface SerialisedSensitivityState {
+    paramSettings: SensitivityParameterSettings,
+    sensitivityUpdateRequired: SensitivityUpdateRequiredReasons,
+    plotSettings: SensitivityPlotSettings,
+    result: null | {
+        inputs: OdinSensitivityInputs,
+        hasResult: boolean,
+        error: WodinError | null
+    }
+}
+
+export interface SerialisedModelFitState {
+    fitUpdateRequired: FitUpdateRequiredReasons,
+    iterations: number | null,
+    converged: boolean | null,
+    sumOfSquares: number | null,
+    paramsToVary: string[],
+    result: SerialisedSolutionResult | null
+}
+
+export interface SerialisedAppState {
+    openVisualisationTab: VisualisationTab,
+    code: CodeState,
+    model: SerialisedModelState,
+    run: SerialisedRunState,
+    sensitivity: SerialisedSensitivityState,
+    fitData?: FitDataState,
+    modelFit?: SerialisedModelFitState
+}

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -1,16 +1,16 @@
-import {OdinModelResponse, OdinUserType, WodinError} from "./responseTypes";
-import {RunUpdateRequiredReasons} from "../store/run/state";
-import {OdinFitInputs, OdinRunInputs, OdinSensitivityInputs} from "./wrapperTypes";
+import { OdinModelResponse, OdinUserType, WodinError } from "./responseTypes";
+import { RunUpdateRequiredReasons } from "../store/run/state";
+import { OdinFitInputs, OdinRunInputs, OdinSensitivityInputs } from "./wrapperTypes";
 import {
     SensitivityParameterSettings,
     SensitivityPlotSettings,
     SensitivityUpdateRequiredReasons
 } from "../store/sensitivity/state";
-import {FitUpdateRequiredReasons} from "../store/modelFit/state";
-import {VisualisationTab} from "../store/appState/state";
-import {CodeState} from "../store/code/state";
-import {FitDataState} from "../store/fitData/state";
-import {Palette} from "../palette";
+import { FitUpdateRequiredReasons } from "../store/modelFit/state";
+import { VisualisationTab } from "../store/appState/state";
+import { CodeState } from "../store/code/state";
+import { FitDataState } from "../store/fitData/state";
+import { Palette } from "../palette";
 
 export interface SerialisedSolutionResult {
     inputs: OdinRunInputs | OdinFitInputs,

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -10,6 +10,7 @@ import {FitUpdateRequiredReasons} from "../store/modelFit/state";
 import {VisualisationTab} from "../store/appState/state";
 import {CodeState} from "../store/code/state";
 import {FitDataState} from "../store/fitData/state";
+import {Palette} from "../palette";
 
 export interface SerialisedSolutionResult {
     inputs: OdinRunInputs | OdinFitInputs,
@@ -21,7 +22,8 @@ export interface SerialisedModelState {
     compileRequired: boolean,
     odinModelResponse: OdinModelResponse | null,
     hasOdin: boolean,
-    odinModelCodeError: WodinError | null
+    odinModelCodeError: WodinError | null,
+    paletteModel: Palette | null
 }
 
 export interface SerialisedRunState {

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -5,6 +5,7 @@ import {
     OdinUserType,
     WodinError
 } from "./responseTypes";
+import {FitData, FitDataLink} from "../store/fitData/state";
 
 export interface OdinRunInputs {
     parameterValues: OdinUserType;
@@ -15,6 +16,7 @@ export interface OdinRunResult {
     inputs: OdinRunInputs;
     solution: OdinSolution | null;
     error: WodinError | null;
+    hasResult?: boolean;
 }
 
 export interface OdinFitInputs {
@@ -28,6 +30,7 @@ export interface OdinFitResult {
     inputs: OdinFitInputs;
     solution: OdinSolution | null;
     error: WodinError | null;
+    hasResult?: boolean;
 }
 
 export interface OdinSensitivityInputs {
@@ -39,4 +42,5 @@ export interface OdinSensitivityResult {
     inputs: OdinSensitivityInputs;
     batch: Batch | null;
     error: WodinError | null;
+    hasResult?: boolean;
 }

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -16,7 +16,6 @@ export interface OdinRunResult {
     inputs: OdinRunInputs;
     solution: OdinSolution | null;
     error: WodinError | null;
-    hasResult?: boolean;
 }
 
 export interface OdinFitInputs {
@@ -30,7 +29,6 @@ export interface OdinFitResult {
     inputs: OdinFitInputs;
     solution: OdinSolution | null;
     error: WodinError | null;
-    hasResult?: boolean;
 }
 
 export interface OdinSensitivityInputs {
@@ -42,5 +40,4 @@ export interface OdinSensitivityResult {
     inputs: OdinSensitivityInputs;
     batch: Batch | null;
     error: WodinError | null;
-    hasResult?: boolean;
 }

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -5,7 +5,7 @@ import {
     OdinUserType,
     WodinError
 } from "./responseTypes";
-import {FitData, FitDataLink} from "../store/fitData/state";
+import { FitData, FitDataLink } from "../store/fitData/state";
 
 export interface OdinRunInputs {
     parameterValues: OdinUserType;

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -1,5 +1,7 @@
 import { expect, test, Page } from "@playwright/test";
-import {newFitCode, realisticFitData, uploadCSVData, writeCode, startModelFit, waitForModelFitCompletion} from "./utils";
+import {
+    newFitCode, uploadCSVData, writeCode, startModelFit, waitForModelFitCompletion
+} from "./utils";
 import PlaywrightConfig from "../../playwright.config";
 
 const multiTimeFitData = `Day,Cases,Day2

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -1,41 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
-import { uploadCSVData, writeCode } from "./utils";
+import {newFitCode, realisticFitData, uploadCSVData, writeCode, startModelFit, waitForModelFitCompletion} from "./utils";
 import PlaywrightConfig from "../../playwright.config";
-
-export const realisticFitData = `Day,Cases
-0,1
-1,1
-2,0
-3,2
-4,5
-5,3
-6,3
-7,3
-8,6
-9,2
-10,5
-11,9
-12,13
-13,12
-14,13
-15,11
-16,12
-17,6
-18,6
-19,6
-20,3
-21,1
-22,0
-23,2
-24,0
-25,0
-26,0
-27,0
-28,2
-29,0
-30,2
-31,0
-`;
 
 const multiTimeFitData = `Day,Cases,Day2
 0,1,0
@@ -105,68 +70,7 @@ const multiCasesFitData = `Day,Cases,Cases2
 30,2,0
 31,0,0`;
 
-const newFitCode = `# JUST CHANGE A COMMENT
-initial(S) <- N - I_0
-initial(E) <- 0
-initial(I) <- I_0
-initial(R) <- 0
-
-# equations
-deriv(S) <- -beta * S * I / N
-deriv(E) <- beta * S * I / N - gamma * E
-deriv(I) <- gamma * E - sigma * I
-deriv(R) <- sigma * I
-
-# parameter values
-R_0 <- user(1.5)
-L <- user(1)
-D <- user(1)
-I_0 <- 1 # default value
-N <- 370
-
-# convert parameters
-gamma <- 1 / L
-sigma <- 1 / D
-beta <- R_0 * sigma
-
-#Output
-output(onset) <- if(t == 0) I_0 else gamma*E
-`;
-
 const { timeout } = PlaywrightConfig;
-
-const startModelFit = async (page: Page, data: string = realisticFitData) => {
-    // Upload data
-    await uploadCSVData(page, data);
-    await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
-
-    // link variables
-    await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
-    await expect(await page.innerText("#optimisation")).toBe(
-        "Please link at least one column in order to set target to fit."
-    );
-    const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
-    const select1 = await linkContainer.locator(":nth-match(select, 1)");
-    await select1.selectOption("I");
-
-    await expect(await page.innerText("#optimisation label#target-fit-label")).toBe("Cases ~ I");
-
-    // select param to vary
-    await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
-    await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Fit");
-    await expect(await page.innerText("#select-param-msg"))
-        .toBe("Please select at least one parameter to vary during model fit.");
-    await page.click(":nth-match(input.vary-param-check, 1)");
-    await expect(await page.innerText("#select-param-msg")).toBe("");
-
-    // run fit
-    await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Fit");
-    await page.click(".wodin-right .wodin-content div.mt-4 button#fit-btn");
-};
-
-const waitForModelFitCompletion = async (page: Page) => {
-    await expect(await page.getAttribute(".wodin-plot-container .vue-feather", "data-type")).toBe("check");
-};
 
 const runFit = async (page: Page) => {
     await startModelFit(page);

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -1,6 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
 import * as fs from "fs";
-import { realisticFitData } from "./fit.etest";
+import { realisticFitData } from "./utils";
 
 test.describe("Index tests", () => {
     const tmpPath = "tmp";

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -85,11 +85,16 @@ test.describe("Sessions tests", () => {
         console.log("8 " + (Date.now()-now))
 
         await expect(await page.innerText(".container h2")).toBe("Sessions");
+        console.log("8.1 " + (Date.now()-now))
         await expect(await page.innerText(":nth-match(.session-col-header, 1)")).toBe("Saved");
+        console.log("8.2 " + (Date.now()-now))
         await expect(await page.innerText(":nth-match(.session-col-header, 2)")).toBe("Label");
+        console.log("8.3 " + (Date.now()-now))
         await expect(await page.innerText(":nth-match(.session-col-header, 3)")).toBe("Load");
+        console.log("8.4 " + (Date.now()-now))
 
         await expect(await page.innerText(".session-label")).toBe("--no label--");
+        console.log("8.5 " + (Date.now()-now))
 
         // NB this will load the second load link, i.e. the older session, not the current one
         await page.click(":nth-match(.session-load a, 2)");

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -102,7 +102,8 @@ test.describe("Sessions tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)"); // Options tab
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)"); // Fit tab
         await expect(await page.inputValue("#link-data select")).toBe("I");
-        await expect((await page.inputValue(":nth-match(#model-params .row .parameter-input, 1)")).startsWith("0.4925")).toBe(true);
+        expect((await page.inputValue(":nth-match(#model-params .row .parameter-input, 1)")).startsWith("0.4925"))
+            .toBe(true);
         await expect(await page.inputValue(":nth-match(#model-params .row .parameter-input, 2)")).toBe("1");
         await expect(await page.inputValue(":nth-match(#model-params .row .parameter-input, 3)")).toBe("1.5");
         await expect(await page.isChecked(":nth-match(#model-params .row .form-check-input, 1)")).toBeTruthy();
@@ -122,7 +123,7 @@ test.describe("Sessions tests", () => {
         await expectWodinPlotDataSummary(summary4, "R", 1000, 0, 31, 0, 214.52, "lines", "#ff884d", null);
         const summary5 = await page.locator(":nth-match(.wodin-plot-data-summary-series, 5)");
         await expectWodinPlotDataSummary(summary5, "onset", 1000, 0, 31, 0.09, 16.12, "lines", "#cc0044", null);
-        const summary6 = await page.locator(":nth-match(.wodin-plot-data-summary-series, 6)")
+        const summary6 = await page.locator(":nth-match(.wodin-plot-data-summary-series, 6)");
         await expectWodinPlotDataSummary(summary6, "Cases", 32, 0, 31, 0, 13, "markers", null, "#cccc00");
 
         // Check fit plot
@@ -137,7 +138,8 @@ test.describe("Sessions tests", () => {
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)"); // Sensitivity tab
         expect(await page.locator(".wodin-plot-data-summary-series").count()).toBe(56);
         const sensitivitySummary = await page.locator(":nth-match(.wodin-plot-data-summary-series, 1)");
-        await expectWodinPlotDataSummary(sensitivitySummary, "S (D=0.443)", 1000, 0, 31, 154.28, 369, "lines", "#2e5cb8", null);
+        await expectWodinPlotDataSummary(sensitivitySummary, "S (D=0.443)", 1000, 0, 31, 154.28, 369, "lines",
+            "#2e5cb8", null);
         const centralSummary = await page.locator(":nth-match(.wodin-plot-data-summary-series, 51)");
         await expectWodinPlotDataSummary(centralSummary, "S", 1000, 0, 31, 154.64, 369, "lines", "#2e5cb8", null);
         const sensitivityDataSummary = await page.locator(":nth-match(.wodin-plot-data-summary-series, 56)");

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -72,6 +72,8 @@ test.describe("Sessions tests", () => {
         // Reload the page to get fresh session, and give it time to save new session Id
         await page.goto(appUrl);
         console.log("6 " + (Date.now()-now))
+        await page.waitForTimeout(saveSessionTimeout);
+        console.log("6.1"  + (Date.now()-now))
 
         // Get storage state in order to test that something has been written to it - but reading it here also seems
         // to force Playwright to wait long enough for storage values to be available in the next page, so the session

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -18,6 +18,8 @@ test.describe("Sessions tests", () => {
     const { timeout } = PlaywrightConfig;
 
     test("can navigate to Sessions page from navbar, and load a session", async () => {
+        test.setTimeout(120000); // This is a slow test!
+
         // We need to use a browser with persistent context instead of the default incognito browser so that
         // we can use the session ids in local storage
         const userDataDir = os.tmpdir();

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -19,6 +19,7 @@ test.describe("Sessions tests", () => {
 
     test("can navigate to Sessions page from navbar, and load a session", async () => {
         test.setTimeout(120000); // This is a slow test!
+        const now = Date.now();
 
         // We need to use a browser with persistent context instead of the default incognito browser so that
         // we can use the session ids in local storage
@@ -27,6 +28,7 @@ test.describe("Sessions tests", () => {
         const page = await browser.newPage();
 
         await page.goto(appUrl);
+        console.log("1 " + (Date.now()-now))
 
         // change code in this session, which we will later reload and check that we can see the code changes
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
@@ -37,6 +39,7 @@ test.describe("Sessions tests", () => {
             }
         );
 
+        console.log("2 " + (Date.now()-now))
         // compile and re-run
         await page.click("#compile-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
@@ -46,11 +49,13 @@ test.describe("Sessions tests", () => {
         );
         await page.click("#run-btn");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText("", { timeout });
+        console.log("3 " + (Date.now()-now))
 
         // Upload data, link, select variables to vary and run fit
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
         await startModelFit(page, realisticFitData);
         await waitForModelFitCompletion(page);
+        console.log("4 " + (Date.now()-now))
 
         // Run sensitivity
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
@@ -59,21 +64,25 @@ test.describe("Sessions tests", () => {
         expect(hidden).not.toBe(null);
         // 5 * 10 sensitivity traces, 5 central traces, 1 data plot
         expect(await page.locator(".wodin-plot-data-summary-series").count()).toBe(56);
+        console.log("5 " + (Date.now()-now))
 
         // give the page a chance to save the session to back end
         await page.waitForTimeout(saveSessionTimeout);
 
         // Reload the page to get fresh session, and give it time to save new session Id
         await page.goto(appUrl);
+        console.log("6 " + (Date.now()-now))
 
         // Get storage state in order to test that something has been written to it - but reading it here also seems
         // to force Playwright to wait long enough for storage values to be available in the next page, so the session
         // ids can be read by the Sessions page - this is required by CI but not locally
         const storageState = await browser.storageState();
         expect(storageState.origins.length).toBe(1); // check there's something in storage state
+        console.log("7 " + (Date.now()-now))
 
         await page.click("#sessions-menu");
         await page.click("#all-sessions-link");
+        console.log("8 " + (Date.now()-now))
 
         await expect(await page.innerText(".container h2")).toBe("Sessions");
         await expect(await page.innerText(":nth-match(.session-col-header, 1)")).toBe("Saved");
@@ -84,6 +93,7 @@ test.describe("Sessions tests", () => {
 
         // NB this will load the second load link, i.e. the older session, not the current one
         await page.click(":nth-match(.session-load a, 2)");
+        console.log("9 " + (Date.now()-now))
 
         // Check all session values have been rehydrated:
 
@@ -91,6 +101,7 @@ test.describe("Sessions tests", () => {
         await page.waitForTimeout(saveSessionTimeout);
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Data");
         await expect(await page.innerText("#data-upload-success")).toBe(" Uploaded 32 rows and 2 columns");
+        console.log("10 " + (Date.now()-now))
 
         // Check code
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
@@ -99,6 +110,7 @@ test.describe("Sessions tests", () => {
         // wait until there is some text in the code editor
         await page.waitForFunction((selector) => !!document.querySelector(selector)?.textContent, editorSelector);
         await expect(await page.innerText(editorSelector)).toContain("# JUST CHANGE A COMMENT");
+        console.log("11 " + (Date.now()-now))
 
         // Check options
         await page.click(":nth-match(.wodin-left .nav-tabs a, 3)"); // Options tab
@@ -111,6 +123,7 @@ test.describe("Sessions tests", () => {
         await expect(await page.isChecked(":nth-match(#model-params .row .form-check-input, 1)")).toBeTruthy();
         await expect(await page.isChecked(":nth-match(#model-params .row .form-check-input, 2)")).toBeFalsy();
         await expect(await page.isChecked(":nth-match(#model-params .row .form-check-input, 3)")).toBeFalsy();
+        console.log("12 " + (Date.now()-now))
 
         // Check run plot
         await page.click(":nth-match(.wodin-right .nav-tabs a, 1)"); // Run tab
@@ -127,6 +140,7 @@ test.describe("Sessions tests", () => {
         await expectWodinPlotDataSummary(summary5, "onset", 1000, 0, 31, 0.09, 16.12, "lines", "#cc0044", null);
         const summary6 = await page.locator(":nth-match(.wodin-plot-data-summary-series, 6)");
         await expectWodinPlotDataSummary(summary6, "Cases", 32, 0, 31, 0, 13, "markers", null, "#cccc00");
+        console.log("13 " + (Date.now()-now))
 
         // Check fit plot
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)"); // Fit tab
@@ -135,6 +149,7 @@ test.describe("Sessions tests", () => {
         await expectWodinPlotDataSummary(fitSummary1, "I", 1000, 0, 31, 0.3, 7.9, "lines", "#cccc00", null);
         const fitSummary2 = await page.locator(":nth-match(.wodin-plot-data-summary-series, 2)");
         await expectWodinPlotDataSummary(fitSummary2, "Cases", 32, 0, 31, 0, 13, "markers", null, "#cccc00");
+        console.log("14 " + (Date.now()-now))
 
         // Check sensitivity plot - but not every trace!
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)"); // Sensitivity tab
@@ -146,7 +161,9 @@ test.describe("Sessions tests", () => {
         await expectWodinPlotDataSummary(centralSummary, "S", 1000, 0, 31, 154.64, 369, "lines", "#2e5cb8", null);
         const sensitivityDataSummary = await page.locator(":nth-match(.wodin-plot-data-summary-series, 56)");
         await expectWodinPlotDataSummary(sensitivityDataSummary, "Cases", 32, 0, 31, 0, 13, "markers", null, "#cccc00");
+        console.log("15 " + (Date.now()-now))
 
         await browser.close();
+        console.log("16 " + (Date.now()-now))
     });
 });

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -2,12 +2,21 @@ import {
     expect, test, chromium, Page
 } from "@playwright/test";
 import * as os from "os";
-import { writeCode } from "./utils";
+import {
+    writeCode,
+    newFitCode,
+    realisticFitData,
+    startModelFit,
+    waitForModelFitCompletion
+} from "./utils";
+import PlaywrightConfig from "../../playwright.config";
 
-const appUrl = "/apps/day1";
+const appUrl = "/apps/day2";
 const saveSessionTimeout = 3000;
 
 test.describe("Sessions tests", () => {
+    const { timeout } = PlaywrightConfig;
+
     test("can navigate to Sessions page from navbar, and load a session", async () => {
         // We need to use a browser with persistent context instead of the default incognito browser so that
         // we can use the session ids in local storage
@@ -16,14 +25,54 @@ test.describe("Sessions tests", () => {
         const page = await browser.newPage();
 
         await page.goto(appUrl);
+
         // change code in this session, which we will later reload and check that we can see the code changes
-        await writeCode(page, "## NEW CODE FOR LOADED SESSION");
+        console.log("2")
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
+        await writeCode(page, newFitCode);
+        console.log("3")
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
+            "Model code has been updated. Compile code and Run Model to update.", {
+                timeout
+            }
+        );
+
+        // compile and re-run
+        await page.click("#compile-btn");
+        console.log("3.1")
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
+            "Plot is out of date: model code has been recompiled. Run model to update.", {
+                timeout
+            }
+        );
+        console.log("3.2")
+        await page.click("#run-btn");
+        console.log("3.3")
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText("", { timeout });
+        console.log("3.4")
+
+        // Upload data, link, select variables to vary and run fit
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
+        console.log("3.5")
+        await startModelFit(page, realisticFitData);
+        console.log("3.6")
+        await waitForModelFitCompletion(page);
+        console.log("3.7")
+
+        // Run sensitivity
+        await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
+        page.click("#run-sens-btn");
+
+        // TODO: replace this with hidden element check
+        const linesSelector = `.wodin-right .wodin-content .js-plotly-plot .scatterlayer .trace .lines path`;
+        expect((await page.locator(`:nth-match(${linesSelector}, 30)`).getAttribute("d"))!.startsWith("M36")).toBe(true);
+
         // give the page a chance to save the session to back end
         await page.waitForTimeout(saveSessionTimeout);
 
         // Reload the page to get fresh session, and give it time to save new session Id
         await page.goto(appUrl);
-        await page.waitForTimeout(saveSessionTimeout);
+        console.log("4")
 
         // Get storage state in order to test that something has been written to it - but reading it here also seems
         // to force Playwright to wait long enough for storage values to be available in the next page, so the session
@@ -34,6 +83,7 @@ test.describe("Sessions tests", () => {
         await page.click("#sessions-menu");
         await page.click("#all-sessions-link");
 
+        console.log("5")
         await expect(await page.innerText(".container h2")).toBe("Sessions");
         await expect(await page.innerText(":nth-match(.session-col-header, 1)")).toBe("Saved");
         await expect(await page.innerText(":nth-match(.session-col-header, 2)")).toBe("Label");
@@ -41,18 +91,34 @@ test.describe("Sessions tests", () => {
 
         await expect(await page.innerText(".session-label")).toBe("--no label--");
 
-        // NB this will load the second load link, i.e. the older one
-        // If we loaded the most recent (i.e. current session), it would do just do a vue router navigate, not a
-        // reload+rehydrate, so we would not see the placeholder code
+
+        console.log("6")
+
+        // NB this will load the second load link, i.e. the older session, not the current one
         await page.click(":nth-match(.session-load a, 2)");
 
+        console.log("7")
+
+        // Check data
+        await page.waitForTimeout(saveSessionTimeout);
+        await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Data");
+        await expect(await page.innerText("#data-upload-success")).toBe(" Uploaded 32 rows and 2 columns");
+
+        console.log("8")
+
+        // Check code
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
         const editorSelector = ".wodin-left .wodin-content .editor-container .editor-scrollable";
         // wait until there is some text in the code editor
         await page.waitForFunction((selector) => !!document.querySelector(selector)?.textContent, editorSelector);
-
         // Check edited code
-        await expect(await page.innerText(editorSelector)).toBe("## NEW CODE FOR LOADED SESSION");
+        await expect(await page.innerText(editorSelector)).toContain("# JUST CHANGE A COMMENT");
+
+        // Check options
+        console.log("9")
+
+        // Check that run, fit and sensitivity have been run
 
         await browser.close();
     });

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -1,4 +1,4 @@
-import {expect, Page, Locator} from "@playwright/test";
+import { expect, Page, Locator } from "@playwright/test";
 
 export const newFitCode = `# JUST CHANGE A COMMENT
 initial(S) <- N - I_0
@@ -113,8 +113,8 @@ export const waitForModelFitCompletion = async (page: Page) => {
 };
 
 export const expectWodinPlotDataSummary = async (summaryLocator: Locator, name: string, count: number, xMin: number,
-                                           xMax: number, yMin: number, yMax: number, mode: string, lineColor: string | null,
-                                           markerColor: string | null) => {
+    xMax: number, yMin: number, yMax: number, mode: string, lineColor: string | null,
+    markerColor: string | null) => {
     expect(await summaryLocator.getAttribute("name")).toBe(name);
     expect(await summaryLocator.getAttribute("count")).toBe(count.toString());
     const attrXMin = await summaryLocator.getAttribute("x-min") as string;

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -1,4 +1,67 @@
-import { Page } from "@playwright/test";
+import {expect, Page} from "@playwright/test";
+
+export const newFitCode = `# JUST CHANGE A COMMENT
+initial(S) <- N - I_0
+initial(E) <- 0
+initial(I) <- I_0
+initial(R) <- 0
+
+# equations
+deriv(S) <- -beta * S * I / N
+deriv(E) <- beta * S * I / N - gamma * E
+deriv(I) <- gamma * E - sigma * I
+deriv(R) <- sigma * I
+
+# parameter values
+R_0 <- user(1.5)
+L <- user(1)
+D <- user(1)
+I_0 <- 1 # default value
+N <- 370
+
+# convert parameters
+gamma <- 1 / L
+sigma <- 1 / D
+beta <- R_0 * sigma
+
+#Output
+output(onset) <- if(t == 0) I_0 else gamma*E
+`;
+
+export const realisticFitData = `Day,Cases
+0,1
+1,1
+2,0
+3,2
+4,5
+5,3
+6,3
+7,3
+8,6
+9,2
+10,5
+11,9
+12,13
+13,12
+14,13
+15,11
+16,12
+17,6
+18,6
+19,6
+20,3
+21,1
+22,0
+23,2
+24,0
+25,0
+26,0
+27,0
+28,2
+29,0
+30,2
+31,0
+`;
 
 export const uploadCSVData = async (page: Page, data: string) => {
     const file = {
@@ -14,4 +77,37 @@ export const writeCode = async (page: Page, code: string) => {
     await page.press(".monaco-editor textarea", "Delete");
     await page.fill(".monaco-editor textarea", "");
     await page.fill(".monaco-editor textarea", code);
+};
+
+export const startModelFit = async (page: Page, data: string = realisticFitData) => {
+    // Upload data
+    await uploadCSVData(page, data);
+    await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
+
+    // link variables
+    await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+    await expect(await page.innerText("#optimisation")).toBe(
+        "Please link at least one column in order to set target to fit."
+    );
+    const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+    const select1 = await linkContainer.locator(":nth-match(select, 1)");
+    await select1.selectOption("I");
+
+    await expect(await page.innerText("#optimisation label#target-fit-label")).toBe("Cases ~ I");
+
+    // select param to vary
+    await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
+    await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Fit");
+    await expect(await page.innerText("#select-param-msg"))
+        .toBe("Please select at least one parameter to vary during model fit.");
+    await page.click(":nth-match(input.vary-param-check, 1)");
+    await expect(await page.innerText("#select-param-msg")).toBe("");
+
+    // run fit
+    await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Fit");
+    await page.click(".wodin-right .wodin-content div.mt-4 button#fit-btn");
+};
+
+export const waitForModelFitCompletion = async (page: Page) => {
+    await expect(await page.getAttribute(".wodin-plot-container .vue-feather", "data-type")).toBe("check");
 };

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -1,4 +1,4 @@
-import {expect, Page} from "@playwright/test";
+import {expect, Page, Locator} from "@playwright/test";
 
 export const newFitCode = `# JUST CHANGE A COMMENT
 initial(S) <- N - I_0
@@ -110,4 +110,22 @@ export const startModelFit = async (page: Page, data: string = realisticFitData)
 
 export const waitForModelFitCompletion = async (page: Page) => {
     await expect(await page.getAttribute(".wodin-plot-container .vue-feather", "data-type")).toBe("check");
+};
+
+export const expectWodinPlotDataSummary = async (summaryLocator: Locator, name: string, count: number, xMin: number,
+                                           xMax: number, yMin: number, yMax: number, mode: string, lineColor: string | null,
+                                           markerColor: string | null) => {
+    expect(await summaryLocator.getAttribute("name")).toBe(name);
+    expect(await summaryLocator.getAttribute("count")).toBe(count.toString());
+    const attrXMin = await summaryLocator.getAttribute("x-min") as string;
+    expect(parseFloat(attrXMin)).toBeCloseTo(xMin);
+    const attrXMax = await summaryLocator.getAttribute("x-max") as string;
+    expect(parseFloat(attrXMax)).toBeCloseTo(xMax);
+    const attrYMin = await summaryLocator.getAttribute("y-min") as string;
+    expect(parseFloat(attrYMin)).toBeCloseTo(yMin);
+    const attrYMax = await summaryLocator.getAttribute("y-max") as string;
+    expect(parseFloat(attrYMax)).toBeCloseTo(yMax);
+    expect(await summaryLocator.getAttribute("mode")).toBe(mode);
+    expect(await summaryLocator.getAttribute("line-color")).toBe(lineColor);
+    expect(await summaryLocator.getAttribute("marker-color")).toBe(markerColor);
 };

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -1,4 +1,6 @@
 // Mock plotly before import RunTab, which indirectly imports plotly via WodinPlot
+import {OdinFitResult} from "../../../../src/app/types/wrapperTypes";
+
 jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
@@ -16,6 +18,15 @@ describe("FitPlot", () => {
         y: [
             [5, 6, 7],
             [1, 2, 3]
+        ]
+    });
+
+    const mockRunSolution = jest.fn().mockReturnValue({
+        names: ["y", "z"],
+        x: [0, 0.5, 1],
+        y: [
+            [50, 60, 70],
+            [10, 20, 30]
         ]
     });
 
@@ -48,16 +59,39 @@ describe("FitPlot", () => {
         }
     ];
 
-    const getWrapper = (modelFitHasSolution = true, fadePlot = false) => {
+    const expectedRunPlotData = [
+        {
+            mode: "lines",
+            name: "y",
+            x: [0, 0.5, 1],
+            y: [50, 60, 70],
+            line: {
+                color: "#0000ff",
+                width: 2
+            },
+            legendgroup: undefined,
+            showlegend: true
+        },
+        {
+            name: "v",
+            x: [0, 1],
+            y: [10, 20],
+            mode: "markers",
+            type: "scatter",
+            marker: {
+                color: "#0000ff"
+            }
+        }
+    ];
+
+    const getWrapper = (modelFitResult: OdinFitResult | null, fadePlot = false) => {
         const store = new Vuex.Store<FitState>({
             state: {
                 model: {
                     paletteModel: mockPalette
                 },
                 modelFit: {
-                    result: {
-                        solution: modelFitHasSolution ? mockSolution : null
-                    }
+                    result: modelFitResult
                 }
             } as any,
             modules: {
@@ -77,6 +111,14 @@ describe("FitPlot", () => {
                             model: "y"
                         })
                     }
+                },
+                run: {
+                    namespaced: true,
+                    state: {
+                        result: {
+                            solution: mockRunSolution
+                        }
+                    }
                 }
             }
         });
@@ -93,7 +135,7 @@ describe("FitPlot", () => {
     });
 
     it("renders as expected when modelFit has solution", () => {
-        const wrapper = getWrapper();
+        const wrapper = getWrapper({solution: mockSolution} as any);
         const wodinPlot = wrapper.findComponent(WodinOdePlot);
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
@@ -107,8 +149,36 @@ describe("FitPlot", () => {
         });
     });
 
-    it("renders as expected whn modelFit does not have solution", () => {
-        const wrapper = getWrapper(false);
+    it("renders as expected when rehydrating fit from previous session", () => {
+        // We assume we are rehydrating if we have a modelFit result with no error, but no solution either - in that
+        // case we render the run solution
+        const wrapper = getWrapper({
+            error: null,
+            solution: null,
+            inputs: {
+                endTime: 10,
+                link: {
+                    time: "t",
+                    data: "v",
+                    model: "y"
+                }
+            }
+        } as any);
+        const wodinPlot = wrapper.findComponent(WodinOdePlot);
+        expect(wodinPlot.props("fadePlot")).toBe(false);
+        expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
+        expect(wodinPlot.props("endTime")).toBe(10);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockRunSolution]);
+
+        const plotData = wodinPlot.props("plotData");
+        expect(plotData(0, 10, 100)).toStrictEqual(expectedRunPlotData);
+        expect(mockRunSolution).toBeCalledWith({
+            mode: "grid", tStart: 0, tEnd: 10, nPoints: 100
+        });
+    });
+
+    it("renders as expected whn modelFit has not run", () => {
+        const wrapper = getWrapper(null, false);
         const wodinPlot = wrapper.findComponent(WodinOdePlot);
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
@@ -121,7 +191,7 @@ describe("FitPlot", () => {
     });
 
     it("fades plot when fadePlot prop is true", () => {
-        const wrapper = getWrapper(true, false);
+        const wrapper = getWrapper({solution: mockSolution} as any, false);
         expect(wrapper.findComponent(WodinOdePlot).props("fadePlot")).toBe(false);
     });
 });

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -1,6 +1,4 @@
 // Mock plotly before import RunTab, which indirectly imports plotly via WodinPlot
-import {OdinFitResult} from "../../../../src/app/types/wrapperTypes";
-
 jest.mock("plotly.js", () => {});
 
 /* eslint-disable import/first */
@@ -10,6 +8,7 @@ import { FitState } from "../../../../src/app/store/fit/state";
 import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 import WodinOdePlot from "../../../../src/app/components/WodinOdePlot.vue";
 import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
+import { OdinFitResult } from "../../../../src/app/types/wrapperTypes";
 
 describe("FitPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({
@@ -135,7 +134,7 @@ describe("FitPlot", () => {
     });
 
     it("renders as expected when modelFit has solution", () => {
-        const wrapper = getWrapper({solution: mockSolution} as any);
+        const wrapper = getWrapper({ solution: mockSolution } as any);
         const wodinPlot = wrapper.findComponent(WodinOdePlot);
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been fitted.");
@@ -191,7 +190,7 @@ describe("FitPlot", () => {
     });
 
     it("fades plot when fadePlot prop is true", () => {
-        const wrapper = getWrapper({solution: mockSolution} as any, false);
+        const wrapper = getWrapper({ solution: mockSolution } as any, false);
         expect(wrapper.findComponent(WodinOdePlot).props("fadePlot")).toBe(false);
     });
 });

--- a/app/static/tests/unit/components/wodinOdePlot.test.ts
+++ b/app/static/tests/unit/components/wodinOdePlot.test.ts
@@ -25,7 +25,27 @@ describe("WodinOdePlot", () => {
     }
     (global.ResizeObserver as any) = mockResizeObserver;
 
-    const mockPlotData = [{ x: [1, 2], y: [3, 4] }];
+    const mockPlotData = [
+        {
+            name: "test markers",
+            x: [1, 2],
+            y: [3, 4],
+            mode: "markers",
+            marker: {
+                color: "#ff0000"
+            }
+
+        },
+        {
+            name: "test lines",
+            x: [0, 10, 20],
+            y: [9, 7, 8],
+            mode: "lines",
+            line: {
+                color: "#ff00ff"
+            }
+        }
+    ];
     const mockPlotDataFn = jest.fn().mockReturnValue(mockPlotData);
     const defaultProps = {
         fadePlot: false,
@@ -98,6 +118,34 @@ describe("WodinOdePlot", () => {
         expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
         const { relayout } = wrapper.vm as any;
         expect(mockOn.mock.calls[0][1]).toBe(relayout);
+    });
+
+    it("renders hidden data summary elements", async () => {
+        const wrapper = getWrapper();
+        mockPlotElementOn(wrapper);
+
+        await wrapper.setProps({ redrawWatches: [{} as any] });
+        const summaryContainer = wrapper.find(".wodin-plot-data-summary");
+        const seriesSummaries = summaryContainer.findAll(".wodin-plot-data-summary-series");
+        expect(seriesSummaries.length).toBe(2);
+        const summary1 = seriesSummaries.at(0)!;
+        expect(summary1.attributes("name")).toBe("test markers");
+        expect(summary1.attributes("count")).toBe("2");
+        expect(summary1.attributes("x-min")).toBe("1");
+        expect(summary1.attributes("x-max")).toBe("2");
+        expect(summary1.attributes("y-min")).toBe("3");
+        expect(summary1.attributes("y-max")).toBe("4");
+        expect(summary1.attributes("mode")).toBe("markers");
+        expect(summary1.attributes("marker-color")).toBe("#ff0000");
+        const summary2 = seriesSummaries.at(1)!;
+        expect(summary2.attributes("name")).toBe("test lines");
+        expect(summary2.attributes("count")).toBe("3");
+        expect(summary2.attributes("x-min")).toBe("0");
+        expect(summary2.attributes("x-max")).toBe("20");
+        expect(summary2.attributes("y-min")).toBe("7");
+        expect(summary2.attributes("y-max")).toBe("9");
+        expect(summary2.attributes("mode")).toBe("lines");
+        expect(summary2.attributes("line-color")).toBe("#ff00ff");
     });
 
     it("does not draw run plot if base data is null", async () => {

--- a/app/static/tests/unit/components/wodinSession.test.ts
+++ b/app/static/tests/unit/components/wodinSession.test.ts
@@ -3,13 +3,11 @@ import { RouterView } from "vue-router";
 import Vuex from "vuex";
 import WodinSession from "../../../src/app/components/WodinSession.vue";
 import { AppStateAction } from "../../../src/app/store/appState/actions";
-import { mockBasicState, mockModelState } from "../../mocks";
-import { ModelAction } from "../../../src/app/store/model/actions";
+import { mockBasicState } from "../../mocks";
 import { BasicState } from "../../../src/app/store/basic/state";
 
 describe("WodinSession", () => {
     const mockInitialise = jest.fn();
-    const mockFetchOdinRunner = jest.fn();
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -20,15 +18,6 @@ describe("WodinSession", () => {
             state: mockBasicState({ appName }),
             actions: {
                 [AppStateAction.Initialise]: mockInitialise
-            },
-            modules: {
-                model: {
-                    namespaced: true,
-                    state: mockModelState(),
-                    actions: {
-                        [ModelAction.FetchOdinRunner]: mockFetchOdinRunner
-                    }
-                }
             }
         });
 
@@ -50,9 +39,8 @@ describe("WodinSession", () => {
         expect(wrapper.findComponent(RouterView).exists()).toBe(true);
     });
 
-    it("dispatches actions on mount", () => {
+    it("dispatches Initialise action on mount", () => {
         getWrapper();
-        expect(mockFetchOdinRunner).toHaveBeenCalledTimes(1);
         expect(mockInitialise).toHaveBeenCalledTimes(1);
         expect(mockInitialise.mock.calls[0][1]).toStrictEqual({ appName: "testApp", loadSessionId: "session1" });
     });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -6,8 +6,16 @@ import {
     SensitivityScaleType,
     SensitivityVariationType
 } from "../../src/app/store/sensitivity/state";
-import { serialiseState } from "../../src/app/serialise";
+import {deserialiseState, serialiseState} from "../../src/app/serialise";
 import { FitState } from "../../src/app/store/fit/state";
+import {
+    mockCodeState,
+    mockFitDataState,
+    mockModelFitState,
+    mockModelState,
+    mockRunState,
+    mockSensitivityState
+} from "../mocks";
 
 describe("serialise", () => {
     const codeState = {
@@ -178,7 +186,8 @@ describe("serialise", () => {
         compileRequired: true,
         odinModelResponse: modelState.odinModelResponse,
         hasOdin: true,
-        odinModelCodeError: modelState.odinModelCodeError
+        odinModelCodeError: modelState.odinModelCodeError,
+        paletteModel: modelState.paletteModel
     };
     const expectedRun = {
         runRequired: {
@@ -333,5 +342,44 @@ describe("serialise", () => {
             modelFit: { ...expectedModelFit, result: null }
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
+    });
+
+    it("deserialises as expected", () => {
+        const serialised = {
+            openVisualisationTab: VisualisationTab.Fit,
+            code: mockCodeState(),
+            model: mockModelState(),
+            run: mockRunState(),
+            sensitivity: mockSensitivityState(),
+            fitData: mockFitDataState(),
+            modelFit: mockModelFitState()
+        } as any;
+
+        const target = {
+            sessionId: "123",
+            appType: AppType.Fit,
+            config: {},
+            openVisualisationTab: VisualisationTab.Run,
+            code: {},
+            model: {},
+            run: {},
+            sensitivity: {},
+            fitData: {},
+            modelFit: {}
+        } as any;
+
+        deserialiseState(target, serialised);
+        expect(target).toStrictEqual({
+            sessionId: "123",
+            appType: AppType.Fit,
+            config: {},
+            openVisualisationTab: VisualisationTab.Fit,
+            code: mockCodeState(),
+            model: mockModelState(),
+            run: mockRunState(),
+            sensitivity: mockSensitivityState(),
+            fitData: mockFitDataState(),
+            modelFit: mockModelFitState()
+        });
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -6,7 +6,7 @@ import {
     SensitivityScaleType,
     SensitivityVariationType
 } from "../../src/app/store/sensitivity/state";
-import {deserialiseState, serialiseState} from "../../src/app/serialise";
+import { deserialiseState, serialiseState } from "../../src/app/serialise";
 import { FitState } from "../../src/app/store/fit/state";
 import {
     mockCodeState,

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -92,7 +92,7 @@ describe("AppState actions", () => {
         expect(commit.mock.calls[2][0]).toBe(`code/${CodeMutation.SetCurrentCode}`);
     });
 
-    it("Initialise fetches config and commits default code if any, if no loadSessionId", async () => {
+    it("Initialise fetches config, commits any default and fetches runner, if no loadSessionId", async () => {
         const config = {
             basicProp: "testValue",
             defaultCode: ["line1", "line2"],
@@ -120,7 +120,9 @@ describe("AppState actions", () => {
         expect(commit.mock.calls[3][0]).toBe(`run/${RunMutation.SetEndTime}`);
         expect(commit.mock.calls[3][1]).toStrictEqual(101);
 
-        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.DefaultModel}`);
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.DefaultModel}`);
     });
 
     it("Initialise fetches config and commits error", async () => {

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -33,7 +33,7 @@ describe("AppState actions", () => {
         mockAxios.reset();
     });
 
-    it("Initialise fetches config and commits result", async () => {
+    it("Initialise fetches config and commits result, and fetches odin runner", async () => {
         const config = {
             basicProp: "testValue",
             defaultCode: [],
@@ -66,8 +66,8 @@ describe("AppState actions", () => {
         expect(commit.mock.calls[3][0]).toBe(`run/${RunMutation.SetEndTime}`);
         expect(commit.mock.calls[3][1]).toStrictEqual(101);
 
-        // no code model fetch as defaultCode is empty
-        expect(dispatch).not.toBeCalled();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
     });
 
     it("does not commit endtime if not given in fetched config", async () => {

--- a/app/static/tests/unit/store/model/actions.test.ts
+++ b/app/static/tests/unit/store/model/actions.test.ts
@@ -6,7 +6,7 @@ import { actions, ModelAction } from "../../../../src/app/store/model/actions";
 import { ModelMutation, mutations } from "../../../../src/app/store/model/mutations";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { AppType } from "../../../../src/app/store/appState/state";
-import { RunAction, actions as runActions } from "../../../../src/app/store/run/actions";
+import { actions as runActions } from "../../../../src/app/store/run/actions";
 import { FitDataAction } from "../../../../src/app/store/fitData/actions";
 import { ModelFitAction } from "../../../../src/app/store/modelFit/actions";
 import { RunMutation, mutations as runMutations } from "../../../../src/app/store/run/mutations";
@@ -248,6 +248,21 @@ describe("Model actions", () => {
         const commit = jest.fn();
         (actions[ModelAction.CompileModel] as any)({ commit, state, rootState });
         expect(commit.mock.calls.length).toBe(0);
+    });
+
+    it("compile model on rehydrate only compiles the model", () => {
+        const state = {
+            odinModelResponse: {
+                model: "1+2"
+            }
+        };
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        (actions[ModelAction.CompileModelOnRehydrate] as any)({ commit, state, rootState });
+        expect(commit.mock.calls.length).toBe(1);
+        expect(commit.mock.calls[0][0]).toBe(ModelMutation.SetOdin);
+        expect(commit.mock.calls[0][1]).toBe(3);
+        expect(dispatch).not.toHaveBeenCalled();
     });
 
     // This one needs some work as we don't kick off the run after

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -172,4 +172,45 @@ describe("Sensitivity actions", () => {
 
         expect(dispatch).toHaveBeenCalledWith("run/RunModel", null, { root: true });
     });
+
+    it("run sensitivity on rehydrate uses parameters from result", () => {
+        const mockResultBatchPars = {};
+        const rootState = {
+            model: mockModelState,
+            run: mockRunState
+        };
+        const state = {
+            result: {
+                inputs: {
+                    pars: mockResultBatchPars
+                }
+            }
+        };
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+
+        (actions[SensitivityAction.RunSensitivityOnRehydrate] as any)({
+            rootState, getters, commit, dispatch, state
+        });
+
+        expect(commit).toHaveBeenCalledTimes(2);
+        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetResult);
+        expect(commit.mock.calls[0][1]).toStrictEqual({
+            inputs: { endTime: 99, pars: mockResultBatchPars },
+            batch: mockBatch,
+            error: null
+        });
+        expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetUpdateRequired);
+        expect(commit.mock.calls[1][1]).toStrictEqual({
+            endTimeChanged: false,
+            modelChanged: false,
+            parameterValueChanged: false,
+            sensitivityOptionsChanged: false
+        });
+
+        expect(mockRunner.batchRun).toHaveBeenCalledWith(rootState.model.odin, mockResultBatchPars, 0, 99, {});
+
+        expect(dispatch).not.toHaveBeenCalled();
+    });
 });

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -5,9 +5,9 @@ import {
 import { SessionsMutation } from "../../../../src/app/store/sessions/mutations";
 import { localStorageManager } from "../../../../src/app/localStorageManager";
 import { ErrorsMutation } from "../../../../src/app/store/errors/mutations";
-import {ModelAction} from "../../../../src/app/store/model/actions";
-import {RunAction} from "../../../../src/app/store/run/actions";
-import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import { ModelAction } from "../../../../src/app/store/model/actions";
+import { RunAction } from "../../../../src/app/store/run/actions";
+import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 
 describe("SessionsActions", () => {
     const getSessionIdsSpy = jest.spyOn(localStorageManager, "getSessionIds")
@@ -18,7 +18,8 @@ describe("SessionsActions", () => {
         mockAxios.reset();
     });
 
-    const getSessionData = (hasOdin: boolean, compileRequired: boolean, runHasResult: boolean, sensitivityHasResult: boolean) => {
+    const getSessionData = (hasOdin: boolean, compileRequired: boolean,
+        runHasResult: boolean, sensitivityHasResult: boolean) => {
         return {
             code: {
                 currentCode: ["some saved code"]
@@ -54,16 +55,16 @@ describe("SessionsActions", () => {
         expect(dispatch).toHaveBeenCalledTimes(4);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
         expect(dispatch.mock.calls[1][1]).toBe(null);
-        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[2][0]).toBe(`run/${RunAction.RunModelOnRehydrate}`);
         expect(dispatch.mock.calls[2][1]).toBe(null);
-        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[3][0]).toBe(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`);
         expect(dispatch.mock.calls[3][1]).toBe(null);
-        expect(dispatch.mock.calls[3][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[3][2]).toStrictEqual({ root: true });
     });
 
     it("Rehydrate does not compile or run if no odin model", async () => {
@@ -80,7 +81,7 @@ describe("SessionsActions", () => {
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
     });
 
     it("Rehydrate does not compile or run if compile required is true", async () => {
@@ -97,7 +98,7 @@ describe("SessionsActions", () => {
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
     });
 
     it("Rehydrate does not run model if run has no result", async () => {
@@ -114,13 +115,13 @@ describe("SessionsActions", () => {
         expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
         expect(dispatch.mock.calls[1][1]).toBe(null);
-        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[2][0]).toBe(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`);
         expect(dispatch.mock.calls[2][1]).toBe(null);
-        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({ root: true });
     });
 
     it("Rehydrate does not run sensitivity if sensitivity has no result", async () => {
@@ -137,13 +138,13 @@ describe("SessionsActions", () => {
         expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
         expect(dispatch.mock.calls[1][1]).toBe(null);
-        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({ root: true });
         expect(dispatch.mock.calls[2][0]).toBe(`run/${RunAction.RunModelOnRehydrate}`);
         expect(dispatch.mock.calls[2][1]).toBe(null);
-        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({ root: true });
     });
 
     it("GetSessions fetches and commits session metadata", async () => {

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -1,12 +1,13 @@
 import { actions, SessionsAction } from "../../../../src/app/store/sessions/actions";
-import { CodeMutation } from "../../../../src/app/store/code/mutations";
 import {
     mockAxios, mockBasicState, mockFailure, mockSuccess
 } from "../../../mocks";
 import { SessionsMutation } from "../../../../src/app/store/sessions/mutations";
 import { localStorageManager } from "../../../../src/app/localStorageManager";
 import { ErrorsMutation } from "../../../../src/app/store/errors/mutations";
-import { CodeAction } from "../../../../src/app/store/code/actions";
+import {ModelAction} from "../../../../src/app/store/model/actions";
+import {RunAction} from "../../../../src/app/store/run/actions";
+import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
 
 describe("SessionsActions", () => {
     const getSessionIdsSpy = jest.spyOn(localStorageManager, "getSessionIds")
@@ -17,12 +18,30 @@ describe("SessionsActions", () => {
         mockAxios.reset();
     });
 
-    it("Rehydrate fetches session data and updates code", async () => {
-        const mockSessionData = {
+    const getSessionData = (hasOdin: boolean, compileRequired: boolean, runHasResult: boolean, sensitivityHasResult: boolean) => {
+        return {
             code: {
                 currentCode: ["some saved code"]
+            },
+            model: {
+                hasOdin,
+                compileRequired
+            },
+            run: {
+                result: {
+                    hasResult: runHasResult
+                }
+            },
+            sensitivity: {
+                result: {
+                    hasResult: sensitivityHasResult
+                }
             }
         };
+    };
+
+    it("Rehydrate fetches session data and reruns model and sensitivity if have result", async () => {
+        const mockSessionData = getSessionData(true, false, true, true);
         mockAxios.onGet("/apps/testApp/sessions/1234")
             .reply(200, mockSuccess(mockSessionData));
 
@@ -30,11 +49,101 @@ describe("SessionsActions", () => {
         const dispatch = jest.fn();
         const rootState = { appName: "testApp" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
+        expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
+        expect(commit).toHaveBeenCalledTimes(0);
+        expect(dispatch).toHaveBeenCalledTimes(4);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[0][1]).toBe(null);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
+        expect(dispatch.mock.calls[1][1]).toBe(null);
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][0]).toBe(`run/${RunAction.RunModelOnRehydrate}`);
+        expect(dispatch.mock.calls[2][1]).toBe(null);
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[3][0]).toBe(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`);
+        expect(dispatch.mock.calls[3][1]).toBe(null);
+        expect(dispatch.mock.calls[3][2]).toStrictEqual({root: true});
+    });
+
+    it("Rehydrate does not compile or run if no odin model", async () => {
+        const mockSessionData = getSessionData(false, false, true, true);
+        mockAxios.onGet("/apps/testApp/sessions/1234")
+            .reply(200, mockSuccess(mockSessionData));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const rootState = { appName: "testApp" } as any;
+        await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
+        expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
         expect(commit).toHaveBeenCalledTimes(0);
         expect(dispatch).toHaveBeenCalledTimes(1);
-        expect(dispatch.mock.calls[0][0]).toBe(`code/${CodeAction.UpdateCode}`);
-        expect(dispatch.mock.calls[0][1]).toStrictEqual(["some saved code"]);
-        expect(dispatch.mock.calls[0][2]).toStrictEqual({ root: true });
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[0][1]).toBe(null);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+    });
+
+    it("Rehydrate does not compile or run if compile required is true", async () => {
+        const mockSessionData = getSessionData(true, true, true, true);
+        mockAxios.onGet("/apps/testApp/sessions/1234")
+            .reply(200, mockSuccess(mockSessionData));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const rootState = { appName: "testApp" } as any;
+        await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
+        expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
+        expect(commit).toHaveBeenCalledTimes(0);
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[0][1]).toBe(null);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+    });
+
+    it("Rehydrate does not run model if run has no result", async () => {
+        const mockSessionData = getSessionData(true, false, false, true);
+        mockAxios.onGet("/apps/testApp/sessions/1234")
+            .reply(200, mockSuccess(mockSessionData));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const rootState = { appName: "testApp" } as any;
+        await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
+        expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
+        expect(commit).toHaveBeenCalledTimes(0);
+        expect(dispatch).toHaveBeenCalledTimes(3);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[0][1]).toBe(null);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
+        expect(dispatch.mock.calls[1][1]).toBe(null);
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][0]).toBe(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`);
+        expect(dispatch.mock.calls[2][1]).toBe(null);
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
+    });
+
+    it("Rehydrate does not run sensitivity if sensitivity has no result", async () => {
+        const mockSessionData = getSessionData(true, false, true, false);
+        mockAxios.onGet("/apps/testApp/sessions/1234")
+            .reply(200, mockSuccess(mockSessionData));
+
+        const commit = jest.fn();
+        const dispatch = jest.fn();
+        const rootState = { appName: "testApp" } as any;
+        await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
+        expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
+        expect(commit).toHaveBeenCalledTimes(0);
+        expect(dispatch).toHaveBeenCalledTimes(3);
+        expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
+        expect(dispatch.mock.calls[0][1]).toBe(null);
+        expect(dispatch.mock.calls[0][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[1][0]).toBe(`model/${ModelAction.CompileModelOnRehydrate}`);
+        expect(dispatch.mock.calls[1][1]).toBe(null);
+        expect(dispatch.mock.calls[1][2]).toStrictEqual({root: true});
+        expect(dispatch.mock.calls[2][0]).toBe(`run/${RunAction.RunModelOnRehydrate}`);
+        expect(dispatch.mock.calls[2][1]).toBe(null);
+        expect(dispatch.mock.calls[2][2]).toStrictEqual({root: true});
     });
 
     it("GetSessions fetches and commits session metadata", async () => {


### PR DESCRIPTION
This branch restores all session data and plots when load session from Sessions page. It re-runs model (Run tab) and sensitivity if these had previously been run. ModelFit is not re-run (we don't want to re-fit and change parameter values), but model fit is plotted from the model run solution if rehydration is detected. 

This uses the `result.inputs` values in the serialised state to rehydrate model runs from the actual inputs which were previously used, not the current values in the state (which may have changed without re-running). If compile was required when the session was last saved, the model is assumed to be stale, and is not re-run. 

To test:
- open day 1 or day 2 app and make changes e.g. code changes, upload data, fit model 
- reload the app to create a new current session
- browse to All Sessions from the Sessions menu
- click on the load icon for the second session in the list (i.e. the latest session which is not the current one)
- You should see that your session is loaded with all data, parameter values etc, and plots are rendered as expected

Key changes:
- `Rehydrate` action deserialises the loaded session state into the store, and where appropriate, recompiles, re-runs model and re-runs sensitivity to rebuild models to their state when session was last saved
- `derialise` method in `serialise` module -similar to load in HINT,  this overwrites a target AppState with serialised state values
- fetch of `OdinRunner` handled separately when rehydrating so it doesn't get removed by deserialisation
- compile, run and sensitivity actions now have `..OnRehydrate` versions which only take the basic actions required to build the solutions etc, without the additional steps which happen when not rehydrating to ensure the rest of the state is updated to accommodate the action's changes e.g. setting `compileRequired` or updating parameters
- `FitPlot` detects that session is rehydrated, so it should plot from the model run solution (by checking if model fit has a `result` and no `error` but also no `solution` - which is not serialised)

Known issue:
- open visualisation tab is not restored - this is because we just haven't implemented 2-way binding for that yet. (There's a [ticket for this]([url](https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3658)))

This branch also includes plotted data summaries in `WodinOdePlot` - this adds hidden elements with attributes containing summary values of plotted data, so that we can test the plotted data in the e2e tests without needing to rifle through plotly's svg elements. For each plotted series we create a hidden element with class `.wodin-plot-data-summary-series` and attributes:
- name
- count (number of data points)
- x-min
- x-max
- y-min
- y-max
- mode (line or markers)
- line-color (if relevant)
- marker-color (if relevant)

Big line count for this changeset, but a lot of it is moving things around, e.g. moving common code for actions for rehydrate, and common e2e test code. 