### PR TITLE
Fix logic in sensitivity update

### DIFF
--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -53,6 +53,7 @@ export default defineComponent({
                 if (store.state.model.compileRequired) {
                     return userMessages.sensitivity.compileRequiredForUpdate;
                 }
+                console.log(sensitivityUpdateRequired.value);
                 if (anyTrue(sensitivityUpdateRequired.value)) {
                     return sensitivityUpdateRequiredExplanation(sensitivityUpdateRequired.value);
                 }

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -53,7 +53,6 @@ export default defineComponent({
                 if (store.state.model.compileRequired) {
                     return userMessages.sensitivity.compileRequiredForUpdate;
                 }
-                console.log(sensitivityUpdateRequired.value);
                 if (anyTrue(sensitivityUpdateRequired.value)) {
                     return sensitivityUpdateRequiredExplanation(sensitivityUpdateRequired.value);
                 }

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -3,6 +3,7 @@ import { FitState } from "../fit/state";
 import { ModelFitState } from "./state";
 import { ModelFitMutation } from "./mutations";
 import { RunMutation } from "../run/mutations";
+import { SensitivityMutation } from "../sensitivity/mutations";
 import { ModelFitGetter } from "./getters";
 import { FitDataGetter } from "../fitData/getters";
 import { allTrue } from "../../utils";
@@ -80,6 +81,12 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             error: null
         };
         commit(`run/${RunMutation.SetResult}`, runResult, { root: true });
+        // For the sensitivity we need to let it know that we've
+        // updated the parameters and so it is most likely that the
+        // current set of sensitivity data is out of date (this is not
+        // the case for the main run of course because the parameters
+        // have been set alongside the result).
+        commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, { parameterValueChanged: true }, { root: true });
 
         if (result.converged) {
             commit(ModelFitMutation.SetFitting, false);

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -356,4 +356,20 @@ test.describe("Wodin App model fit tests", () => {
             .toContain("Sum of squares:");
         await expect(await page.innerText("#fit-cancelled-msg")).toBe("Model fit was cancelled before converging");
     });
+
+    test.only("can mark sensitivity as out of date after fit", async ({ page }) => {
+        await startModelFit(page);
+        await page.click(".wodin-right .wodin-content div.mt-4 button#cancel-fit-btn");
+        // Open sensitivity tab
+        await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
+        // // Run sensitivity
+        await page.click("#run-sens-btn");
+        // // Back to fit tab
+        await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
+        await reRunFit(page);
+        // // Back to sensitivity tab
+        await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
+        await expect(await page.innerText(".action-required-msg"))
+            .toBe("Plot is out of date: parameters have been changed. Run sensitivity to update.");
+    });
 });

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -362,12 +362,12 @@ test.describe("Wodin App model fit tests", () => {
         await page.click(".wodin-right .wodin-content div.mt-4 button#cancel-fit-btn");
         // Open sensitivity tab
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
-        // // Run sensitivity
+        // Run sensitivity
         await page.click("#run-sens-btn");
-        // // Back to fit tab
+        // Back to fit tab
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
         await reRunFit(page);
-        // // Back to sensitivity tab
+        // Back to sensitivity tab
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");
         await expect(await page.innerText(".action-required-msg"))
             .toBe("Plot is out of date: parameters have been changed. Run sensitivity to update.");

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -6,6 +6,7 @@ import {
 import { actions, ModelFitAction } from "../../../../src/app/store/modelFit/actions";
 import { ModelMutation } from "../../../../src/app/store/model/mutations";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
+import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 
 describe("ModelFit actions", () => {
     const mockSimplex = {} as any;
@@ -129,7 +130,7 @@ describe("ModelFit actions", () => {
 
         setTimeout(() => {
             expect(simplex.step).toHaveBeenCalledTimes(1);
-            expect(commit).toHaveBeenCalledTimes(3);
+            expect(commit).toHaveBeenCalledTimes(4);
             expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetResult);
             expect(commit.mock.calls[0][1]).toBe(result);
             expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
@@ -142,6 +143,9 @@ describe("ModelFit actions", () => {
                 error: null
             });
             expect(commit.mock.calls[2][2]).toStrictEqual({ root: true });
+            expect(commit.mock.calls[3][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
+            expect(commit.mock.calls[3][1]).toStrictEqual({ parameterValueChanged: true });
+            expect(commit.mock.calls[3][2]).toStrictEqual({ root: true });
 
             expect(dispatch).toHaveBeenCalledTimes(1);
             expect(dispatch.mock.calls[0][0]).toBe(ModelFitAction.FitModelStep);
@@ -169,12 +173,13 @@ describe("ModelFit actions", () => {
 
         setTimeout(() => {
             expect(simplex.step).toHaveBeenCalledTimes(1);
-            expect(commit).toHaveBeenCalledTimes(4);
+            expect(commit).toHaveBeenCalledTimes(5);
             expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetResult);
             expect(commit.mock.calls[1][0]).toBe(`run/${RunMutation.SetParameterValues}`);
             expect(commit.mock.calls[2][0]).toBe(`run/${RunMutation.SetResult}`);
-            expect(commit.mock.calls[3][0]).toBe(ModelFitMutation.SetFitting);
-            expect(commit.mock.calls[3][1]).toBe(false);
+            expect(commit.mock.calls[3][0]).toBe(`sensitivity/${SensitivityMutation.SetUpdateRequired}`);
+            expect(commit.mock.calls[4][0]).toBe(ModelFitMutation.SetFitting);
+            expect(commit.mock.calls[4][1]).toBe(false);
 
             expect(dispatch).not.toHaveBeenCalled();
             done();


### PR DESCRIPTION
See ticket for the issue and instructions to replicate. This was a regression that probably used to work ok because we changed how we kept track of sensitivity being in/out of date and because we changed how the fit sets the parameters/solution back into the state. The fix is simple enough though

As this has definitely broken before I've added a simple e2e test