### PR TITLE
mrc-3347 Improve Errors Alert placement and style

### DIFF
--- a/app/static/src/app/components/ErrorsAlert.vue
+++ b/app/static/src/app/components/ErrorsAlert.vue
@@ -1,17 +1,16 @@
 <template>
     <div>
         <div v-if="errors.length > 0"
-             class="alert alert-danger alert-dismissible fade show"
+             class="alert alert-danger text-danger alert-dismissible fade show"
              role="alert">
+            <button type="button" class="btn-close float-end" aria-label="Close" @click="dismissErrors">
+            </button>
             <strong>{{errors.length > 1 ? "Errors occurred:" : "An error occurred:"}}</strong>
-            <ul>
+            <ul class="mb-0">
                 <li v-for="(error, idx) in errors" :key="idx">
                     {{ error.detail || error.error }}
                 </li>
             </ul>
-            <button type="button" class="close" aria-label="Close" @click="dismissErrors">
-                <span aria-hidden="true">&times;</span>
-            </button>
         </div>
     </div>
 </template>

--- a/app/static/src/app/components/WodinApp.vue
+++ b/app/static/src/app/components/WodinApp.vue
@@ -6,6 +6,7 @@
                   <loading-spinner size="lg"></loading-spinner>
                   <h2 id="loading-message">Loading application...</h2>
                 </div>
+                <errors-alert></errors-alert>
                 <wodin-panels v-if="!loading" >
                     <template v-slot:left>
                       <slot name="left"></slot>
@@ -14,7 +15,6 @@
                       <slot name="right"></slot>
                     </template>
                 </wodin-panels>
-                <errors-alert></errors-alert>
             </div>
         </div>
     </div>

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container">
     <div class="row">
+      <errors-alert></errors-alert>
       <h2>Sessions</h2>
     </div>
     <template v-if="sessionsMetadata">
@@ -48,10 +49,12 @@ import VueFeather from "vue-feather";
 import { RouterLink } from "vue-router";
 import { SessionsAction } from "../../store/sessions/actions";
 import userMessages from "../../userMessages";
+import ErrorsAlert from "../ErrorsAlert.vue";
 
 export default defineComponent({
     name: "SessionsPage",
     components: {
+        ErrorsAlert,
         VueFeather,
         RouterLink
     },

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -43,3 +43,7 @@ $brand: #479fb6;
   justify-content: center;
   text-align: center;
 }
+
+.alert-danger {
+  background-color: #fff;
+}

--- a/app/static/tests/unit/components/errorsAlert.test.ts
+++ b/app/static/tests/unit/components/errorsAlert.test.ts
@@ -37,7 +37,8 @@ describe("ErrorsAlert", () => {
     it("renders as expected with one error", () => {
         const wrapper = getWrapper([{ error: "TEST_CODE", detail: "Test Error Message" }]);
         const alert = wrapper.find(".alert");
-        expect(alert.classes()).toStrictEqual(["alert", "alert-danger", "alert-dismissible", "fade", "show"]);
+        expect(alert.classes())
+            .toStrictEqual(["alert", "alert-danger", "text-danger", "alert-dismissible", "fade", "show"]);
         expect(alert.attributes("role")).toBe("alert");
         expect(alert.find("strong").text()).toBe("An error occurred:");
         const listItems = alert.findAll("ul li");
@@ -45,9 +46,9 @@ describe("ErrorsAlert", () => {
         expect(listItems.at(0)?.text()).toBe("Test Error Message");
 
         const closeButton = alert.find("button");
-        expect(closeButton.classes()).toStrictEqual(["close"]);
+        expect(closeButton.classes()).toStrictEqual(["btn-close", "float-end"]);
         expect(closeButton.attributes("aria-label")).toBe("Close");
-        expect(closeButton.text()).toBe("×");
+        expect(closeButton.text()).toBe("");
     });
 
     it("renders as expected with multiple errors", () => {

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import VueFeather from "vue-feather";
 import { RouterLink } from "vue-router";
 import SessionsPage from "../../../../src/app/components/sessions/SessionsPage.vue";
+import ErrorsAlert from "../../../../src/app/components/ErrorsAlert.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { mockBasicState } from "../../../mocks";
 import { SessionsAction } from "../../../../src/app/store/sessions/actions";
@@ -62,6 +63,7 @@ describe("SessionsPage", () => {
         expect(session2Cells.at(1)!.text()).toBe("--no label--");
         expect(session2Cells.at(2)!.find("a").attributes("href")).toBe("/apps/testApp?sessionId=def");
         expect(session2Cells.at(2)!.find("a").findComponent(VueFeather).props("type")).toBe("upload");
+        expect(wrapper.findComponent(ErrorsAlert).exists()).toBe(true);
     });
 
     it("shows loading message when session metadata is null in store", () => {


### PR DESCRIPTION
This branch improves the placement and styling of the errors alert which displays generic unexpected errors, typically those which occur when there is a problem with communicating with the back end (so not expected errors caused by user interaction e.g. compilation error, which are shown in the appropriate part of the UI). 

Before:
![image](https://user-images.githubusercontent.com/44669576/193289138-d6eb4477-e079-4a8d-b2c0-a47e09205cff.png)

After:
![image](https://user-images.githubusercontent.com/44669576/193289007-0a7191cd-5d3e-4980-86eb-04031e2e4e47.png)

Changes:
- move the alert to the top of the page so you can actually see it!
- add the alert to the Sessions page so comms errors are visible there too
- avoid x button wrapping onto next line
- improve look by including correct button class, making text colour consistent with the other error text, and using white background rather than bootstrap default pink, which clashes nastily with the brand teal

As noted on the ticket, I believe I've seen instances of the alert where no error message was displayed, but I wasn't able to reproduce this. Let me know if you can!

Example way to get error messages to show: after running dependencies and app, use `docker stop [container id]` to stop the odin.api container, then load app, change code or browse to Sessions page. 