### PR TITLE
mrc-3573 Set Title in app pages

### DIFF
--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -16,6 +16,7 @@ export class AppsController {
             // TODO: validate config against schema for app type
             const viewOptions = {
                 appName,
+                title: `${wodinConfig.courseTitle} - ${config.title}`,
                 appTitle: config.title,
                 courseTitle: wodinConfig.courseTitle,
                 wodinVersion,

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -16,7 +16,7 @@ export class AppsController {
             // TODO: validate config against schema for app type
             const viewOptions = {
                 appName,
-                title: `${wodinConfig.courseTitle} - ${config.title}`,
+                title: `${config.title} - ${wodinConfig.courseTitle}`,
                 appTitle: config.title,
                 courseTitle: wodinConfig.courseTitle,
                 wodinVersion,

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -60,6 +60,7 @@ describe("appsController", () => {
 
         expect(mockRender.mock.calls[0][1]).toStrictEqual({
             appName: "test",
+            title: "Test Course Title - testTitle",
             appTitle: "testTitle",
             courseTitle: "Test Course Title",
             wodinVersion: "1.2.3",

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -45,6 +45,7 @@ describe("appsController", () => {
         expect(mockRender.mock.calls[0][0]).toBe("testType-app");
         expect(mockRender.mock.calls[0][1]).toStrictEqual({
             appName: "test",
+            title: "Test Course Title - testTitle",
             appTitle: "testTitle",
             courseTitle: "Test Course Title",
             wodinVersion: "1.2.3",

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -45,7 +45,7 @@ describe("appsController", () => {
         expect(mockRender.mock.calls[0][0]).toBe("testType-app");
         expect(mockRender.mock.calls[0][1]).toStrictEqual({
             appName: "test",
-            title: "Test Course Title - testTitle",
+            title: "testTitle - Test Course Title",
             appTitle: "testTitle",
             courseTitle: "Test Course Title",
             wodinVersion: "1.2.3",
@@ -60,7 +60,7 @@ describe("appsController", () => {
 
         expect(mockRender.mock.calls[0][1]).toStrictEqual({
             appName: "test",
-            title: "Test Course Title - testTitle",
+            title: "testTitle - Test Course Title",
             appTitle: "testTitle",
             courseTitle: "Test Course Title",
             wodinVersion: "1.2.3",

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -25,7 +25,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day1']");
 
-        await expect(await page.title()).toBe("WODIN Example - Day 1 - Basic Model");
+        await expect(await page.title()).toBe("Day 1 - Basic Model - WODIN Example");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 1 - Basic Model");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
     });
@@ -34,7 +34,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day2']");
 
-        await expect(await page.title()).toBe("WODIN Example - Day 2 - Model Fit");
+        await expect(await page.title()).toBe("Day 2 - Model Fit - WODIN Example");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 2 - Model Fit");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Data");
     });
@@ -43,7 +43,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day3']");
 
-        await expect(await page.title()).toBe("WODIN Example - Day 3 - Stochastic Model");
+        await expect(await page.title()).toBe("Day 3 - Stochastic Model - WODIN Example");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 3 - Stochastic Model");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
     });

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -25,6 +25,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day1']");
 
+        await expect(await page.title()).toBe("WODIN Example - Day 1 - Basic Model");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 1 - Basic Model");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
     });
@@ -33,6 +34,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day2']");
 
+        await expect(await page.title()).toBe("WODIN Example - Day 2 - Model Fit");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 2 - Model Fit");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Data");
     });
@@ -41,6 +43,7 @@ test.describe("Index tests", () => {
         await page.goto("/");
         await page.click("a[href='apps/day3']");
 
+        await expect(await page.title()).toBe("WODIN Example - Day 3 - Stochastic Model");
         await expect(await page.innerText("nav .navbar-app")).toBe("Day 3 - Stochastic Model");
         await expect(await page.innerText(".wodin-left .nav-tabs .active")).toBe("Code");
     });


### PR DESCRIPTION
The views were already trying to set page title from the `title` prop passed to then, but that had got missed out somewhere along the way. This reinstates the `title` prop and sets it to `[course title] - [app title]`