### PR TITLE
mrc-3717 Fix stochastic app bug, and update e2e tests

### DIFF
--- a/app/static/src/app/stochastic.ts
+++ b/app/static/src/app/stochastic.ts
@@ -13,5 +13,5 @@ const app = createApp({ components: { WodinSession, AppHeader } });
 app.use(store);
 app.mount("#app");
 
-const router = initialiseRouter(StochasticApp, store.state.appName!, store.state.appName!);
+const router = initialiseRouter(StochasticApp, store.state.appName!, store.state.baseUrl!);
 app.use(router);

--- a/app/static/tests/e2e/download.etest.ts
+++ b/app/static/tests/e2e/download.etest.ts
@@ -5,7 +5,7 @@ test.describe("Download tests", () => {
         await page.goto("/apps/day2");
         await page.click("#download-btn");
         await expect(await page.inputValue("#download-file-name input")).toContain("day2-run");
-        await page.fill("#download-file-name input", "test-download.xlsx");
+        await page.fill("#download-file-name input", "test-download");
 
         const [download] = await Promise.all([
             // Start waiting for the download

--- a/app/static/tests/e2e/tabs.etest.ts
+++ b/app/static/tests/e2e/tabs.etest.ts
@@ -7,7 +7,7 @@ test.describe("Wodin App tabs tests", () => {
 
     test("renders header", async ({ page }) => {
         expect(await page.innerText("nav a.navbar-brand")).toBe("WODIN Example");
-        expect(await page.getAttribute("nav a.navbar-brand", "href")).toBe("/");
+        expect(await page.getAttribute("nav a.navbar-brand", "href")).toBe("http://localhost:3000");
         expect(await page.innerText("nav .navbar-app")).toBe("Day 1 - Basic Model");
         expect(await page.innerText("nav .navbar-version")).toMatch(/^WODIN v[0-9].[0-9].[0-9]$/);
     });


### PR DESCRIPTION
Main build is broken because of failing browser tests - I think these are tests which perhaps weren't running reliably before Lekan fixed up the browser tests in a recently merged in branch.

Two e2e tests hadn't been updated for behaviour changes, and there was one bug, which meant stochastic app wasn't being loaded (failing in router because passing wrong value for baseUrl parameter). 