### PR TITLE
mrc-3718 fix e2e tabs test

### DIFF
--- a/app/static/src/app/components/header/VersionMenu.vue
+++ b/app/static/src/app/components/header/VersionMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="navbar-text">
+    <div class="navbar-text navbar-version">
         <drop-down :text="`WODIN v${wodinVersion}`">
             <template v-slot:items>
                 <li v-for="(version, name, index) in versions" :key="index">


### PR DESCRIPTION
Fixes another failing e2e following the Playwright config improvement which now means all the tests actually get run reliably!

This one was failing because a class which the e2e test was checking for had been removed from the versions menu item. 