### PR TITLE
Refactor to use new return types

### DIFF
--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -93,8 +93,9 @@ export default defineComponent({
         // it will be replaced by full stochastic run plot in the next ticket
         const stochasticResultSummary = computed(() => {
             if (isStochastic.value) {
-                const seriesSet = store.state.run.resultDiscrete?.seriesSet;
-                return seriesSet ? `Stochastic series count: ${seriesSet.values.length}`
+                const solution = store.state.run.resultDiscrete?.solution;
+                const times = {mode: "grid", times: [0]};
+                return solution ? `Stochastic series count: ${solution(times).values.length}`
                     : "Stochastic model has not run";
             }
             return "";

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -94,7 +94,7 @@ export default defineComponent({
         const stochasticResultSummary = computed(() => {
             if (isStochastic.value) {
                 const solution = store.state.run.resultDiscrete?.solution;
-                const times = {mode: "grid", times: [0]};
+                const times = { mode: "grid", times: [0] };
                 return solution ? `Stochastic series count: ${solution(times).values.length}`
                     : "Stochastic model has not run";
             }

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -94,7 +94,7 @@ export default defineComponent({
         const stochasticResultSummary = computed(() => {
             if (isStochastic.value) {
                 const solution = store.state.run.resultDiscrete?.solution;
-                const times = { mode: "grid", times: [0] };
+                const times = { mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 };
                 return solution ? `Stochastic series count: ${solution(times).values.length}`
                     : "Stochastic model has not run";
             }

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -94,7 +94,12 @@ export default defineComponent({
         const stochasticResultSummary = computed(() => {
             if (isStochastic.value) {
                 const solution = store.state.run.resultDiscrete?.solution;
-                const times = { mode: "grid", tStart: 0, tEnd: 10, nPoints: 11 };
+                const times = {
+                    mode: "grid",
+                    tStart: 0,
+                    tEnd: 10,
+                    nPoints: 11
+                };
                 return solution ? `Stochastic series count: ${solution(times).values.length}`
                     : "Stochastic model has not run";
             }

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -21,7 +21,7 @@ export const config = {
 
 export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
     const idx = s.values.findIndex((el) => el.name === name);
-    const y = s.values[idx].y;
+    const { y } = s.values[idx];
     return {
         x: s.x,
         values: [{ name, y }]

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -20,11 +20,11 @@ export const config = {
 };
 
 export function filterSeriesSet(s: OdinSeriesSet, name: string): OdinSeriesSet {
-    const idx = s.names.indexOf(name);
+    const idx = s.values.findIndex((el) => el.name === name);
+    const y = s.values[idx].y;
     return {
-        names: [s.names[idx]],
         x: s.x,
-        y: [s.y[idx]]
+        values: [{ name, y }]
     };
 }
 
@@ -52,17 +52,17 @@ export function odinToPlotly(s: OdinSeriesSet, palette: Palette, options: Partia
         ...options
     };
 
-    return s.y.map(
-        (el: number[], i: number): Partial<PlotData> => ({
+    return s.values.map(
+        (el): Partial<PlotData> => ({
             mode: "lines",
             line: {
-                color: palette[s.names[i]],
+                color: palette[el.name],
                 width: plotlyOptions.lineWidth
             },
-            name: s.names[i],
+            name: el.name,
             x: s.x,
-            y: s.y[i],
-            legendgroup: plotlyOptions.includeLegendGroup ? s.names[i] : undefined,
+            y: el.y,
+            legendgroup: plotlyOptions.includeLegendGroup ? el.name : undefined,
             showlegend: plotlyOptions.showLegend
         })
     );

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -41,7 +41,7 @@ function serialiseSolutionResult(result: OdinRunResultOde | OdinFitResult | null
 function serialiseDiscreteResult(result: OdinRunResultDiscrete | null): SerialisedRunResult | null {
     return result ? {
         inputs: result.inputs,
-        hasResult: !!result.seriesSet,
+        hasResult: !!result.solution,
         error: result.error
     } : null;
 }

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -41,15 +41,15 @@ const runDiscreteModel = (parameterValues: OdinUserType, startTime: number, endT
     if (rootState.model.odinRunnerDiscrete) {
         const payload : OdinRunResultDiscrete = {
             inputs: { endTime, parameterValues },
-            seriesSet: null,
+            solution: null,
             error: null
         };
 
         try {
             const dt = rootState.model.odinModelResponse!.metadata!.dt || 0.1;
-            const seriesSet = rootState.model.odinRunnerDiscrete.wodinRunDiscrete(rootState.model.odin!,
+            const solution = rootState.model.odinRunnerDiscrete.wodinRunDiscrete(rootState.model.odin!,
                 parameterValues, startTime, endTime, dt, 5); // TODO; get number of replicates from state
-            payload.seriesSet = seriesSet;
+            payload.solution = solution;
         } catch (e) {
             payload.error = {
                 error: userMessages.errors.wodinRunError,

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -68,10 +68,14 @@ export interface OdinModelResponse{
 }
 
 // This is Odin's SeriesSet
+export interface OdinSeriesSetValues {
+    name: string;
+    y: number[];
+}
+
 export type OdinSeriesSet = {
-    names: string[];
     x: number[];
-    y: number[][];
+    values: OdinSeriesSetValues[];
 }
 
 export interface TimeGrid {
@@ -86,8 +90,10 @@ export interface TimeGiven {
     times: number[];
 }
 
+export type Times = TimeGrid | TimeGiven;
+
 // This is Odin's InterpolatedSolution
-export type OdinSolution = (times: TimeGrid | TimeGiven) => OdinSeriesSet;
+export type OdinSolution = (times: Times) => OdinSeriesSet;
 
 export interface OdinFitData {
     time: number[],

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -194,13 +194,15 @@ export interface DiscreteSeriesSet {
     values: DiscreteSeriesValues[];
 }
 
+export type FilteredDiscreteSolution = (times: Times) => DiscreteSeriesSet;
+
 export interface OdinRunnerDiscrete {
     wodinRunDiscrete: (odin: Odin, // this is vague enough to work at present
                        pars: OdinUserType, // this will always be ok
                        timeStart: number,
                        timeEnd: number,
                        dt: number,
-                       nParticles: number) => DiscreteSeriesSet;
+                       nParticles: number) => FilteredDiscreteSolution;
 }
 
 export interface SessionMetadata {

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -67,7 +67,7 @@ export interface OdinModelResponse{
     error?: OdinModelResponseError
 }
 
-// This is Odin's SeriesSet
+// This is Odin's SeriesSetValues and SeriesSet
 export interface OdinSeriesSetValues {
     name: string;
     y: number[];

--- a/app/static/src/app/types/wrapperTypes.ts
+++ b/app/static/src/app/types/wrapperTypes.ts
@@ -1,6 +1,7 @@
 import {
     Batch,
-    BatchPars, DiscreteSeriesSet,
+    BatchPars,
+    FilteredDiscreteSolution,
     OdinSolution,
     OdinUserType,
     WodinError
@@ -20,7 +21,7 @@ export interface OdinRunResultOde {
 
 export interface OdinRunResultDiscrete {
     inputs: OdinRunInputs;
-    seriesSet: DiscreteSeriesSet | null;
+    solution: FilteredDiscreteSolution | null;
     error: WodinError | null;
 }
 

--- a/app/static/src/app/wodinExcelDownload.ts
+++ b/app/static/src/app/wodinExcelDownload.ts
@@ -35,11 +35,12 @@ export class WodinExcelDownload {
     private static _generateModelledOutput(solutionOutput: OdinSeriesSet, nonTimeColumns: string[],
         fitData: FitData | null) {
         const outputData = [];
-        outputData.push(["t", ...solutionOutput.names, ...nonTimeColumns]); // headers
+        const names = solutionOutput.values.map((el) => el.name);
+        outputData.push(["t", ...names, ...nonTimeColumns]); // headers
         solutionOutput.x.forEach((x: number, xIdx: number) => {
             outputData.push([
                 x,
-                ...solutionOutput.names.map((name: string, nameIdx: number) => solutionOutput.y[nameIdx][xIdx]),
+                ...solutionOutput.values.map((el) => el.y[xIdx]),
                 ...nonTimeColumns.map((column: string) => (fitData as FitData)[xIdx][column])
             ]);
         });

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -12,20 +12,18 @@ import { OdinFitResult } from "../../../../src/app/types/wrapperTypes";
 
 describe("FitPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({
-        names: ["y", "z"],
         x: [0, 0.5, 1],
-        y: [
-            [5, 6, 7],
-            [1, 2, 3]
+        values: [
+            { name: "y", y: [5, 6, 7] },
+            { name: "z", y: [1, 2, 3] }
         ]
     });
 
     const mockRunSolution = jest.fn().mockReturnValue({
-        names: ["y", "z"],
         x: [0, 0.5, 1],
-        y: [
-            [50, 60, 70],
-            [10, 20, 30]
+        values: [
+            { name: "y", y: [50, 60, 70] },
+            { name: "z", y: [10, 20, 30] }
         ]
     });
 

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -13,7 +13,10 @@ describe("RunPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({
         names: ["S", "I"],
         x: [0, 1],
-        y: [[3, 4], [5, 6]]
+        values: [
+            { name: "S", y: [3, 4] },
+            { name: "I", y: [5, 6] }
+        ]
     });
     const mockResult = {
         inputs: {},

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -19,7 +19,7 @@ import ActionRequiredMessage from "../../../../src/app/components/ActionRequired
 import DownloadOutput from "../../../../src/app/components/DownloadOutput.vue";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
 import { StochasticState } from "../../../../src/app/store/stochastic/state";
-import { OdinRunnerDiscrete } from "../../../../src/app/types/responseTypes";
+import { DiscreteSeriesSet, OdinRunnerDiscrete } from "../../../../src/app/types/responseTypes";
 import { OdinRunResultDiscrete } from "../../../../src/app/types/wrapperTypes";
 import { ModelGetter } from "../../../../src/app/store/model/getters";
 
@@ -131,13 +131,14 @@ describe("RunTab", () => {
     });
 
     it("shows placeholder when app is stochastic and has run", () => {
+        const series = {
+            values: [
+                { name: "series 1" },
+                { name: "series 2" }
+            ]
+        } as DiscreteSeriesSet;
         const wrapper = getStochasticWrapper({}, {
-            seriesSet: {
-                values: [
-                    { name: "series 1" },
-                    { name: "series 2" }
-                ]
-            } as any
+            solution: (time: any) => series
         });
         expect(wrapper.find("#stochastic-run-placeholder").text()).toBe("Stochastic series count: 2");
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -34,9 +34,11 @@ describe("SensitivitySummaryPlot", () => {
     const mockSetPlotTime = jest.fn();
 
     const mockData = {
-        names: ["S", "I"],
         x: [1, 1.1],
-        y: [[10, 10.1], [20, 19.9]]
+        values: [
+            { name: "S", y: [10, 10.1] },
+            { name: "I", y: [20, 19.9] }
+        ]
     };
 
     const mockValueAtTime = jest.fn().mockReturnValue(mockData);

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -10,29 +10,26 @@ import { BasicState } from "../../../../src/app/store/basic/state";
 import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 
 const mockSln1 = jest.fn().mockReturnValue({
-    names: ["y", "z"],
     x: [0, 0.5, 1],
-    y: [
-        [5, 6, 7],
-        [1, 2, 3]
+    values: [
+        { name: "y", y: [5, 6, 7] },
+        { name: "z", y: [1, 2, 3] }
     ]
 });
 
 const mockSln2 = jest.fn().mockReturnValue({
-    names: ["y", "z"],
     x: [0, 0.5, 1],
-    y: [
-        [50, 60, 70],
-        [10, 20, 30]
+    values: [
+        { name: "y", y: [50, 60, 70] },
+        { name: "z", y: [10, 20, 30] }
     ]
 });
 
 const mockCentralSln = jest.fn().mockReturnValue({
-    names: ["y", "z"],
     x: [0, 0.5, 1],
-    y: [
-        [15, 16, 17],
-        [11, 12, 13]
+    values: [
+        { name: "y", y: [15, 16, 17] },
+        { name: "z", y: [11, 12, 13] }
     ]
 });
 

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -11,9 +11,11 @@ describe("odinToPlotly", () => {
     };
 
     const series = {
-        names: ["a", "b"],
         x: [0, 1],
-        y: [[30, 40], [50, 60]]
+        values: [
+            { name: "a", y: [30, 40] },
+            { name: "b", y: [50, 60] }
+        ]
     };
 
     it("uses default options", () => {

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -78,7 +78,7 @@ describe("serialise", () => {
                 parameterValues: { alpha: 3.3 },
                 endTime: 5
             },
-            seriesSet: { values: "test series set" } as any,
+            solution: jest.fn(),
             error: { error: "run discrete error", detail: "run discrete error detail" }
         },
         userDownloadFileName: "",
@@ -312,7 +312,7 @@ describe("serialise", () => {
                 },
                 resultDiscrete: {
                     ...runState.resultDiscrete,
-                    seriesSet: null
+                    solution: null
                 }
             },
             sensitivity: {

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -100,7 +100,7 @@ describe("Run actions", () => {
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResultDiscrete);
         expect(commit.mock.calls[0][1]).toEqual({
             inputs: { parameterValues, endTime: 99 },
-            seriesSet: "test discrete result",
+            solution: "test discrete result",
             error: null
         });
     });
@@ -215,7 +215,7 @@ describe("Run actions", () => {
                 error: "An error occurred while running the model"
             }
         };
-        const expectedResult = stochastic ? { ...resultShared, seriesSet: null } : { ...resultShared, solution: null };
+        const expectedResult = stochastic ? { ...resultShared, solution: null } : { ...resultShared, solution: null };
         expect(commit.mock.calls[0][1]).toStrictEqual(expectedResult);
     };
 
@@ -286,7 +286,7 @@ describe("Run actions", () => {
             expect(commit.mock.calls[0][0]).toBe(RunMutation.SetResultDiscrete);
             expect(commit.mock.calls[0][1]).toEqual({
                 inputs: { parameterValues, endTime: 99 },
-                seriesSet: "test discrete result",
+                solution: "test discrete result",
                 error: null
             });
         } else {

--- a/app/static/tests/unit/wodinExcelDowload.test.ts
+++ b/app/static/tests/unit/wodinExcelDowload.test.ts
@@ -26,12 +26,11 @@ import { WodinExcelDownload } from "../../src/app/wodinExcelDownload";
 
 const mockSolution = jest.fn().mockImplementation((options) => {
     const x = options.mode === "grid" ? [options.tStart, options.tEnd] : options.times;
-    const names = ["A", "B"];
-    const y = [
-        x.map((xVal: number) => 1 + xVal),
-        x.map((xVal: number) => 10 * xVal)
+    const values = [
+        { name: "A", y: x.map((xVal: number) => 1 + xVal) },
+        { name: "B", y: x.map((xVal: number) => 10 * xVal) }
     ];
-    return { x, names, y };
+    return { x, values };
 });
 
 describe("WodinExcelDownload", () => {

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=odin-api-mrc-3745
+ODIN_API_BRANCH=main
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ODIN_API_BRANCH=main
+ODIN_API_BRANCH=odin-api-mrc-3745
 
 docker pull mrcide/odin.api:$ODIN_API_BRANCH
 docker run -d --name odin.api --rm -p 8001:8001 mrcide/odin.api:$ODIN_API_BRANCH


### PR DESCRIPTION
Uses https://github.com/mrc-ide/odin.api/pull/16, https://github.com/mrc-ide/odin/pull/278 - the underlying js code changes in https://github.com/mrc-ide/odin-js/pull/21, https://github.com/mrc-ide/dust-js/pull/11 are merged, some coordination required to merge.

Unpin branch in dependencies script before merge

Does not yet include changes to work with https://github.com/mrc-ide/wodin/pull/116