### PR TITLE
Don't truncate labels

### DIFF
--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -62,6 +62,7 @@ export function odinToPlotly(s: OdinSeriesSet, palette: Palette, options: Partia
             name: el.name,
             x: s.x,
             y: el.y,
+            hoverlabel: { namelength: -1 },
             legendgroup: plotlyOptions.includeLegendGroup ? el.name : undefined,
             showlegend: plotlyOptions.showLegend
         })

--- a/app/static/tests/unit/components/fit/fitPlot.test.ts
+++ b/app/static/tests/unit/components/fit/fitPlot.test.ts
@@ -41,6 +41,7 @@ describe("FitPlot", () => {
                 color: "#0000ff",
                 width: 2
             },
+            hoverlabel: { namelength: -1 },
             legendgroup: undefined,
             showlegend: true
         },
@@ -66,6 +67,7 @@ describe("FitPlot", () => {
                 color: "#0000ff",
                 width: 2
             },
+            hoverlabel: { namelength: -1 },
             legendgroup: undefined,
             showlegend: true
         },

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -74,6 +74,7 @@ describe("RunPlot", () => {
                 name: "S",
                 x: [0, 1],
                 y: [3, 4],
+                hoverlabel: { namelength: -1 },
                 showlegend: true,
                 legendgroup: undefined
             },
@@ -86,6 +87,7 @@ describe("RunPlot", () => {
                 name: "I",
                 x: [0, 1],
                 y: [5, 6],
+                hoverlabel: { namelength: -1 },
                 showlegend: true,
                 legendgroup: undefined
             }
@@ -206,6 +208,7 @@ describe("RunPlot", () => {
                 name: "S",
                 x: [0, 1],
                 y: [3, 4],
+                hoverlabel: { namelength: -1 },
                 showlegend: true,
                 legendgroup: undefined
             },
@@ -218,6 +221,7 @@ describe("RunPlot", () => {
                 name: "I",
                 x: [0, 1],
                 y: [5, 6],
+                hoverlabel: { namelength: -1 },
                 showlegend: true,
                 legendgroup: undefined
             },

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -117,6 +117,7 @@ describe("SensitivitySummaryPlot", () => {
                 name: "S",
                 x: [1, 1.1],
                 y: [10, 10.1],
+                hoverlabel: { namelength: -1 },
                 legendgroup: undefined,
                 showlegend: true
             },
@@ -129,6 +130,7 @@ describe("SensitivitySummaryPlot", () => {
                 name: "I",
                 x: [1, 1.1],
                 y: [20, 19.9],
+                hoverlabel: { namelength: -1 },
                 legendgroup: undefined,
                 showlegend: true
             }

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -48,6 +48,7 @@ const expectedPlotData = [
         name: "y (alpha=1.111)",
         x: [0, 0.5, 1],
         y: [5, 6, 7],
+        hoverlabel: { namelength: -1 },
         showlegend: false,
         legendgroup: "y"
     },
@@ -60,6 +61,7 @@ const expectedPlotData = [
         name: "z (alpha=1.111)",
         x: [0, 0.5, 1],
         y: [1, 2, 3],
+        hoverlabel: { namelength: -1 },
         showlegend: false,
         legendgroup: "z"
     },
@@ -73,6 +75,7 @@ const expectedPlotData = [
         name: "y (alpha=2.222)",
         x: [0, 0.5, 1],
         y: [50, 60, 70],
+        hoverlabel: { namelength: -1 },
         showlegend: false,
         legendgroup: "y"
     },
@@ -85,6 +88,7 @@ const expectedPlotData = [
         name: "z (alpha=2.222)",
         x: [0, 0.5, 1],
         y: [10, 20, 30],
+        hoverlabel: { namelength: -1 },
         showlegend: false,
         legendgroup: "z"
     },
@@ -98,6 +102,7 @@ const expectedPlotData = [
         name: "y",
         x: [0, 0.5, 1],
         y: [15, 16, 17],
+        hoverlabel: { namelength: -1 },
         showlegend: true,
         legendgroup: "y"
     },
@@ -110,6 +115,7 @@ const expectedPlotData = [
         name: "z",
         x: [0, 0.5, 1],
         y: [11, 12, 13],
+        hoverlabel: { namelength: -1 },
         showlegend: true,
         legendgroup: "z"
     }

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -29,6 +29,7 @@ describe("odinToPlotly", () => {
                 name: "a",
                 x: [0, 1],
                 y: [30, 40],
+                hoverlabel: { namelength: -1 },
                 legendgroup: undefined,
                 showlegend: true
             },
@@ -41,6 +42,7 @@ describe("odinToPlotly", () => {
                 name: "b",
                 x: [0, 1],
                 y: [50, 60],
+                hoverlabel: { namelength: -1 },
                 legendgroup: undefined,
                 showlegend: true
             }
@@ -64,6 +66,7 @@ describe("odinToPlotly", () => {
                 name: "a",
                 x: [0, 1],
                 y: [30, 40],
+                hoverlabel: { namelength: -1 },
                 legendgroup: "a",
                 showlegend: false
             },
@@ -76,6 +79,7 @@ describe("odinToPlotly", () => {
                 name: "b",
                 x: [0, 1],
                 y: [50, 60],
+                hoverlabel: { namelength: -1 },
                 legendgroup: "b",
                 showlegend: false
             }


### PR DESCRIPTION
Fixes issue noticed by Romain, hover labels are truncated.

For a test case, try running this code, with a long parameter name:

```
# variables
deriv(S) <-  - beta * S * I / N
deriv(I) <- beta * S * I / N - sigma_long_name * I
deriv(R) <- sigma_long_name * I
# initial conditions
initial(S) <- N - I0
initial(I) <- I0
initial(R) <- 0
# parameters
N <- user(1e6)
I0 <- user(1)
beta <- user(4)
sigma_long_name <- user(2)
```

then in sensitivity set that to be the parameter that varies. You should see labels like `(<x>, <y>) S (sigma_l....` (e.g., in the version deployed at https://wodin-dev.dide.ic.ac.uk/apps/day1/ ). With this fix we get the long label `(<x> <y>) S (sigma_long_name=10)`