### PR TITLE
mrc-3752 Stop application crash when error during async controller method

### DIFF
--- a/app/server/src/apiService.ts
+++ b/app/server/src/apiService.ts
@@ -1,4 +1,4 @@
-import {NextFunction, Request, Response} from "express";
+import { NextFunction, Request, Response } from "express";
 import axios, { AxiosResponse } from "axios";
 import { AppLocals } from "./types";
 

--- a/app/server/src/apiService.ts
+++ b/app/server/src/apiService.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import {NextFunction, Request, Response} from "express";
 import axios, { AxiosResponse } from "axios";
 import { AppLocals } from "./types";
 
@@ -11,7 +11,7 @@ export class APIService {
 
     private readonly _next: Function;
 
-    constructor(req: Request, res: Response, next: Function) {
+    constructor(req: Request, res: Response, next: NextFunction) {
         this._req = req;
         this._res = res;
         this._next = next;
@@ -64,4 +64,4 @@ export class APIService {
     };
 }
 
-export const api = (req: Request, res: Response, next: Function) => new APIService(req, res, next);
+export const api = (req: Request, res: Response, next: NextFunction) => new APIService(req, res, next);

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -11,10 +11,10 @@ export class AppsController {
             const {
                 configReader, appsPath, wodinConfig, wodinVersion
             } = req.app.locals as AppLocals;
-            const {appName} = req.params;
+            const { appName } = req.params;
             // client can pass either sessionId or share (friendly id) parameter to identify session to reload
             let sessionId = req.query.sessionId as string | undefined | null;
-            const {share} = req.query;
+            const { share } = req.query;
 
             let shareNotFound = null;
             if (share) {
@@ -48,7 +48,7 @@ export class AppsController {
                     404,
                     ErrorType.NOT_FOUND,
                     "app-not-found",
-                    {appName}
+                    { appName }
                 );
             }
         });

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -3,51 +3,54 @@ import { AppLocals } from "../types";
 import { ErrorType } from "../errors/errorType";
 import { WodinWebError } from "../errors/wodinWebError";
 import { getSessionStore } from "../db/sessionStore";
+import asyncControllerHandler from "../errors/asyncControllerHandler";
 
 export class AppsController {
-    static getApp = async (req: Request, res: Response) => {
-        const {
-            configReader, appsPath, wodinConfig, wodinVersion
-        } = req.app.locals as AppLocals;
-        const { appName } = req.params;
-        // client can pass either sessionId or share (friendly id) parameter to identify session to reload
-        let sessionId = req.query.sessionId as string | undefined | null;
-        const { share } = req.query;
+    static getApp = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const {
+                configReader, appsPath, wodinConfig, wodinVersion
+            } = req.app.locals as AppLocals;
+            const {appName} = req.params;
+            // client can pass either sessionId or share (friendly id) parameter to identify session to reload
+            let sessionId = req.query.sessionId as string | undefined | null;
+            const {share} = req.query;
 
-        let shareNotFound = null;
-        if (share) {
-            const store = getSessionStore(req);
-            sessionId = await store.getSessionIdFromFriendlyId(share as string);
+            let shareNotFound = null;
+            if (share) {
+                const store = getSessionStore(req);
+                sessionId = await store.getSessionIdFromFriendlyId(share as string);
 
-            if (!sessionId) {
-                shareNotFound = share;
+                if (!sessionId) {
+                    shareNotFound = share;
+                }
             }
-        }
 
-        const config = configReader.readConfigFile(appsPath, `${appName}.config.json`) as any;
-        if (config) {
-            const baseUrl = wodinConfig.baseUrl.replace(/\/$/, "");
-            const view = `${config.appType}-app`;
-            // TODO: validate config against schema for app type
-            const viewOptions = {
-                appName,
-                baseUrl,
-                title: `${config.title} - ${wodinConfig.courseTitle}`,
-                appTitle: config.title,
-                courseTitle: wodinConfig.courseTitle,
-                wodinVersion,
-                loadSessionId: sessionId || "",
-                shareNotFound: shareNotFound || ""
-            };
-            res.render(view, viewOptions);
-        } else {
-            throw new WodinWebError(
-                `App not found: ${appName}`,
-                404,
-                ErrorType.NOT_FOUND,
-                "app-not-found",
-                { appName }
-            );
-        }
+            const config = configReader.readConfigFile(appsPath, `${appName}.config.json`) as any;
+            if (config) {
+                const baseUrl = wodinConfig.baseUrl.replace(/\/$/, "");
+                const view = `${config.appType}-app`;
+                // TODO: validate config against schema for app type
+                const viewOptions = {
+                    appName,
+                    baseUrl,
+                    title: `${config.title} - ${wodinConfig.courseTitle}`,
+                    appTitle: config.title,
+                    courseTitle: wodinConfig.courseTitle,
+                    wodinVersion,
+                    loadSessionId: sessionId || "",
+                    shareNotFound: shareNotFound || ""
+                };
+                res.render(view, viewOptions);
+            } else {
+                throw new WodinWebError(
+                    `App not found: ${appName}`,
+                    404,
+                    ErrorType.NOT_FOUND,
+                    "app-not-found",
+                    {appName}
+                );
+            }
+        });
     };
 }

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import {NextFunction, Request, Response} from "express";
 import { AppLocals } from "../types";
 import { ErrorType } from "../errors/errorType";
 import { WodinWebError } from "../errors/wodinWebError";
@@ -6,7 +6,7 @@ import { getSessionStore } from "../db/sessionStore";
 import asyncControllerHandler from "../errors/asyncControllerHandler";
 
 export class AppsController {
-    static getApp = async (req: Request, res: Response, next: Function) => {
+    static getApp = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const {
                 configReader, appsPath, wodinConfig, wodinVersion

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -1,4 +1,4 @@
-import {NextFunction, Request, Response} from "express";
+import { NextFunction, Request, Response } from "express";
 import { AppLocals } from "../types";
 import { ErrorType } from "../errors/errorType";
 import { WodinWebError } from "../errors/wodinWebError";

--- a/app/server/src/controllers/odinController.ts
+++ b/app/server/src/controllers/odinController.ts
@@ -1,4 +1,4 @@
-import {NextFunction, Request, Response} from "express";
+import { NextFunction, Request, Response } from "express";
 import { api } from "../apiService";
 
 export class OdinController {

--- a/app/server/src/controllers/odinController.ts
+++ b/app/server/src/controllers/odinController.ts
@@ -1,23 +1,23 @@
-import { Request, Response } from "express";
+import {NextFunction, Request, Response} from "express";
 import { api } from "../apiService";
 
 export class OdinController {
-    static getRunnerOde = async (req: Request, res: Response, next: Function) => {
+    static getRunnerOde = async (req: Request, res: Response, next: NextFunction) => {
         await api(req, res, next)
             .get("/support/runner-ode");
     };
 
-    static getRunnerDiscrete = async (req: Request, res: Response, next: Function) => {
+    static getRunnerDiscrete = async (req: Request, res: Response, next: NextFunction) => {
         await api(req, res, next)
             .get("/support/runner-discrete");
     };
 
-    static postModel = async (req: Request, res: Response, next: Function) => {
+    static postModel = async (req: Request, res: Response, next: NextFunction) => {
         await api(req, res, next)
             .post("/compile", req.body);
     };
 
-    static getVersions = async (req: Request, res: Response, next: Function) => {
+    static getVersions = async (req: Request, res: Response, next: NextFunction) => {
         await api(req, res, next)
             .get("/");
     };

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,4 +1,4 @@
-import {NextFunction, Request, Response} from "express";
+import { NextFunction, Request, Response } from "express";
 import { SessionMetadata } from "../types";
 import { getSessionStore } from "../db/sessionStore";
 import { ErrorType } from "../errors/errorType";

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import {NextFunction, Request, Response} from "express";
 import { SessionMetadata } from "../types";
 import { getSessionStore } from "../db/sessionStore";
 import { ErrorType } from "../errors/errorType";
@@ -18,7 +18,7 @@ export const serialiseSession = (session: string | null, res: Response) => {
 };
 
 export class SessionsController {
-    static postSession = async (req: Request, res: Response, next: Function) => {
+    static postSession = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const { id } = req.params;
             const store = getSessionStore(req);
@@ -27,7 +27,7 @@ export class SessionsController {
         });
     };
 
-    static getSessionsMetadata = async (req: Request, res: Response, next: Function) => {
+    static getSessionsMetadata = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const sessionIdsString = req.query.sessionIds as string;
             let metadata: SessionMetadata[] = [];
@@ -40,7 +40,7 @@ export class SessionsController {
         });
     };
 
-    static postSessionLabel = async (req: Request, res: Response, next: Function) => {
+    static postSessionLabel = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const { id } = req.params;
             const store = getSessionStore(req);
@@ -49,7 +49,7 @@ export class SessionsController {
         });
     };
 
-    static getSession = async (req: Request, res: Response, next: Function) => {
+    static getSession = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const { id } = req.params;
             const store = getSessionStore(req);
@@ -58,7 +58,7 @@ export class SessionsController {
         });
     };
 
-    static generateFriendlyId = async (req: Request, res: Response, next: Function) => {
+    static generateFriendlyId = async (req: Request, res: Response, next: NextFunction) => {
         await asyncControllerHandler(next, async () => {
             const { id } = req.params;
             const store = getSessionStore(req);

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -3,6 +3,7 @@ import { SessionMetadata } from "../types";
 import { getSessionStore } from "../db/sessionStore";
 import { ErrorType } from "../errors/errorType";
 import { jsonResponseError, jsonResponseSuccess, jsonStringResponseSuccess } from "../jsonResponse";
+import asyncControllerHandler from "../errors/asyncControllerHandler";
 
 export const serialiseSession = (session: string | null, res: Response) => {
     if (session === null) {
@@ -17,42 +18,52 @@ export const serialiseSession = (session: string | null, res: Response) => {
 };
 
 export class SessionsController {
-    static postSession = async (req: Request, res: Response) => {
-        const { id } = req.params;
-        const store = getSessionStore(req);
-        await store.saveSession(id, req.body as string);
-        res.end();
-    };
-
-    static getSessionsMetadata = async (req: Request, res: Response) => {
-        const sessionIdsString = req.query.sessionIds as string;
-        let metadata: SessionMetadata[] = [];
-        if (sessionIdsString) {
-            const sessionIds = sessionIdsString.split(",");
+    static postSession = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const { id } = req.params;
             const store = getSessionStore(req);
-            metadata = await store.getSessionsMetadata(sessionIds);
-        }
-        jsonResponseSuccess(metadata, res);
+            await store.saveSession(id, req.body as string);
+            res.end();
+        });
     };
 
-    static postSessionLabel = async (req: Request, res: Response) => {
-        const { id } = req.params;
-        const store = getSessionStore(req);
-        await store.saveSessionLabel(id, req.body as string);
-        res.end();
+    static getSessionsMetadata = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const sessionIdsString = req.query.sessionIds as string;
+            let metadata: SessionMetadata[] = [];
+            if (sessionIdsString) {
+                const sessionIds = sessionIdsString.split(",");
+                const store = getSessionStore(req);
+                metadata = await store.getSessionsMetadata(sessionIds);
+            }
+            jsonResponseSuccess(metadata, res);
+        });
     };
 
-    static getSession = async (req: Request, res: Response) => {
-        const { id } = req.params;
-        const store = getSessionStore(req);
-        const session = await store.getSession(id);
-        serialiseSession(session, res);
+    static postSessionLabel = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const { id } = req.params;
+            const store = getSessionStore(req);
+            await store.saveSessionLabel(id, req.body as string);
+            res.end();
+        });
     };
 
-    static generateFriendlyId = async (req: Request, res: Response) => {
-        const { id } = req.params;
-        const store = getSessionStore(req);
-        const friendly = await store.generateFriendlyId(id);
-        jsonResponseSuccess(friendly, res);
+    static getSession = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const { id } = req.params;
+            const store = getSessionStore(req);
+            const session = await store.getSession(id);
+            serialiseSession(session, res);
+        });
+    };
+
+    static generateFriendlyId = async (req: Request, res: Response, next: Function) => {
+        await asyncControllerHandler(next, async () => {
+            const { id } = req.params;
+            const store = getSessionStore(req);
+            const friendly = await store.generateFriendlyId(id);
+            jsonResponseSuccess(friendly, res);
+        });
     };
 }

--- a/app/server/src/errors/asyncControllerHandler.ts
+++ b/app/server/src/errors/asyncControllerHandler.ts
@@ -1,6 +1,8 @@
 // This method should be used to wrap any async controller methods to ensure error handling is applied
 // (not required for controller methods which only use apiService, which already handles errors)
-export default async (next: Function, method: Function) => {
+import { NextFunction } from "express";
+
+export default async (next: Function, method: NextFunction) => {
     try {
         await method();
     } catch (error) {

--- a/app/server/src/errors/asyncControllerHandler.ts
+++ b/app/server/src/errors/asyncControllerHandler.ts
@@ -1,4 +1,4 @@
-// This method should be used to wrap any async controller methods to ensure error handling is appliedy
+// This method should be used to wrap any async controller methods to ensure error handling is applied
 // (not required for controller methods which only use apiService, which already handles errors)
 export default async (next: Function, method: Function) => {
     try {

--- a/app/server/src/errors/asyncControllerHandler.ts
+++ b/app/server/src/errors/asyncControllerHandler.ts
@@ -1,4 +1,5 @@
-// This method should be used to wrap any async controller methods to ensure error handling is applied
+// This method should be used to wrap any async controller methods to ensure error handling is appliedy
+// (not required for controller methods which only use apiService, which already handles errors)
 export default async (next: Function, method: Function) => {
     try {
         await method();

--- a/app/server/src/errors/asyncControllerHandler.ts
+++ b/app/server/src/errors/asyncControllerHandler.ts
@@ -1,0 +1,8 @@
+// This method should be used to wrap any async controller methods to ensure error handling is applied
+export default async (next: Function, method: Function) => {
+    try {
+        await method();
+    } catch (error) {
+        next(error);
+    }
+};

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -63,7 +63,7 @@ describe("appsController", () => {
     it("renders view with app config", () => {
         const appConfig = { title: "testTitle", appType: "testType" };
         const request = getMockRequest(appConfig, "1234", undefined);
-        AppsController.getApp(request, mockResponse);
+        AppsController.getApp(request, mockResponse, jest.fn());
 
         expect(mockRender).toBeCalledTimes(1);
         expect(mockRender.mock.calls[0][0]).toBe("testType-app");
@@ -82,7 +82,7 @@ describe("appsController", () => {
 
     it("sets loadSessionId to be empty when not in query string", () => {
         const request = getMockRequest({ title: "testTitle", appType: "testType" }, undefined, undefined);
-        AppsController.getApp(request, mockResponse);
+        AppsController.getApp(request, mockResponse, jest.fn());
 
         expect(mockRender.mock.calls[0][1]).toStrictEqual({
             appName: "test",
@@ -98,7 +98,7 @@ describe("appsController", () => {
 
     it("gets session id from share parameter when provided", async () => {
         const request = getMockRequest({ title: "testTitle", appType: "testType" }, undefined, "tiny-mouse");
-        await AppsController.getApp(request, mockResponse);
+        await AppsController.getApp(request, mockResponse, jest.fn());
 
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(request);
@@ -120,7 +120,7 @@ describe("appsController", () => {
     it("sets shareNotFound value when share parameter does not exist in db", async () => {
         sessionIdFromFriendlyId = null;
         const request = getMockRequest({ title: "testTitle", appType: "testType" }, undefined, "tiny-mouse");
-        await AppsController.getApp(request, mockResponse);
+        await AppsController.getApp(request, mockResponse, jest.fn());
 
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockRender).toHaveBeenCalledTimes(1);
@@ -136,7 +136,7 @@ describe("appsController", () => {
         });
     });
 
-    it("throws expected error when no config", async () => {
+    it("throws and handles expected error when no config", async () => {
         const request = getMockRequest(null, "12345", undefined);
         const expectedErr = new WodinWebError(
             "App not found: test",
@@ -145,14 +145,17 @@ describe("appsController", () => {
             "app-not-found",
             { appName: "test" }
         );
-        await expect(AppsController.getApp(request, mockResponse)).rejects.toThrow(expectedErr);
+        const next = jest.fn();
+        await AppsController.getApp(request, mockResponse, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next.mock.calls[0][0]).toStrictEqual(expectedErr);
         expect(mockRender).not.toHaveBeenCalled();
     });
 
     it("removes trailing slash from baseUrl", async () => {
         const wodinConfig = { baseUrl: "http://localhost:3000/instance/" };
         const request = getMockRequest({ title: "testTitle", appType: "testType" }, "1234", undefined, wodinConfig);
-        await AppsController.getApp(request, mockResponse);
+        await AppsController.getApp(request, mockResponse, jest.fn());
         expect(mockRender.mock.calls[0][1].baseUrl).toBe("http://localhost:3000/instance");
     });
 });

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -32,14 +32,23 @@ describe("SessionsController", () => {
         jest.clearAllMocks();
     });
 
+    const testError = { message: "test error" };
+
     it("can save session", async () => {
-        await SessionsController.postSession(req, res);
+        await SessionsController.postSession(req, res, jest.fn());
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(req);
         expect(mockSessionStore.saveSession).toHaveBeenCalledTimes(1);
         expect(mockSessionStore.saveSession.mock.calls[0][0]).toBe("1234");
         expect(mockSessionStore.saveSession.mock.calls[0][1]).toBe("testBody");
         expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("postSession handles error", async () => {
+        mockSessionStore.saveSession.mockImplementation(() => { throw testError; });
+        const next = jest.fn();
+        await SessionsController.postSession(req, res, next);
+        expect(next).toHaveBeenCalledWith(testError);
     });
 
     it("can get session metadata", async () => {
@@ -49,7 +58,7 @@ describe("SessionsController", () => {
                 sessionIds: "1234,5678"
             }
         };
-        await SessionsController.getSessionsMetadata(metadataReq, res);
+        await SessionsController.getSessionsMetadata(metadataReq, res, jest.fn());
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(metadataReq);
         expect(mockSessionStore.getSessionsMetadata).toHaveBeenCalledTimes(1);
@@ -59,8 +68,21 @@ describe("SessionsController", () => {
         expect(res.end).toHaveBeenCalledTimes(1);
     });
 
+    it("getSessionMetadata handles error", async () => {
+        mockSessionStore.getSessionsMetadata.mockImplementation(() => { throw testError; });
+        const next = jest.fn();
+        const metadataReq = {
+            ...req,
+            query: {
+                sessionIds: "1234,5678"
+            }
+        };
+        await SessionsController.getSessionsMetadata(metadataReq, res, next);
+        expect(next).toHaveBeenCalledWith(testError);
+    });
+
     it("can get empty session metadata with missing ids parameter", async () => {
-        await SessionsController.getSessionsMetadata(req, res);
+        await SessionsController.getSessionsMetadata(req, res, jest.fn());
         expect(mockGetSessionStore).not.toHaveBeenCalled();
         expect(res.header).toHaveBeenCalledWith("Content-Type", "application/json");
         expect(res.end).toHaveBeenCalledTimes(1);
@@ -83,12 +105,19 @@ describe("SessionsController", () => {
             body: "some label"
         } as any;
 
-        SessionsController.postSessionLabel(labelReq, res);
+        SessionsController.postSessionLabel(labelReq, res, jest.fn());
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(labelReq);
         expect(mockSessionStore.saveSessionLabel).toHaveBeenCalledTimes(1);
         expect(mockSessionStore.saveSessionLabel.mock.calls[0][0]).toBe("1234");
         expect(mockSessionStore.saveSessionLabel.mock.calls[0][1]).toBe("some label");
+    });
+
+    it("postSessionLabel handles error", async () => {
+        mockSessionStore.saveSessionLabel.mockImplementation(() => { throw testError; });
+        const next = jest.fn();
+        await SessionsController.postSessionLabel(req, res, next);
+        expect(next).toHaveBeenCalledWith(testError);
     });
 
     it("can fetch session", () => {
@@ -106,11 +135,18 @@ describe("SessionsController", () => {
                 id: "1234"
             }
         } as any;
-        SessionsController.getSession(sessionReq, res);
+        SessionsController.getSession(sessionReq, res, jest.fn());
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(sessionReq);
         expect(mockSessionStore.getSession).toHaveBeenCalledTimes(1);
         expect(mockSessionStore.getSession.mock.calls[0][0]).toBe("1234");
+    });
+
+    it("getSession handles error", async () => {
+        mockSessionStore.getSession.mockImplementation(() => { throw testError; });
+        const next = jest.fn();
+        await SessionsController.getSession(req, res, next);
+        expect(next).toHaveBeenCalledWith(testError);
     });
 
     it("can generate friendly ids", () => {
@@ -128,11 +164,18 @@ describe("SessionsController", () => {
                 id: "1234"
             }
         } as any;
-        SessionsController.generateFriendlyId(sessionReq, res);
+        SessionsController.generateFriendlyId(sessionReq, res, jest.fn());
         expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(sessionReq);
         expect(mockSessionStore.generateFriendlyId).toHaveBeenCalledTimes(1);
         expect(mockSessionStore.generateFriendlyId.mock.calls[0][0]).toBe("1234");
+    });
+
+    it("generateFriendlyId handles error", async () => {
+        mockSessionStore.generateFriendlyId.mockImplementation(() => { throw testError; });
+        const next = jest.fn();
+        await SessionsController.generateFriendlyId(req, res, next);
+        expect(next).toHaveBeenCalledWith(testError);
     });
 });
 

--- a/app/server/tests/errors/asyncControllerHandler.test.ts
+++ b/app/server/tests/errors/asyncControllerHandler.test.ts
@@ -1,0 +1,19 @@
+import asyncControllerHandler from "../../src/errors/asyncControllerHandler";
+
+describe("asyncControllerHandler", () => {
+    it("calls method", async () => {
+        const method = jest.fn();
+        const next = jest.fn();
+        await asyncControllerHandler(next, method);
+        expect(method).toHaveBeenCalledTimes(1);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("handles error by calling next", async () => {
+        const error = { message: "test error" };
+        const method = jest.fn().mockImplementation(() => { throw error; });
+        const next = jest.fn();
+        await asyncControllerHandler(next, method);
+        expect(next).toHaveBeenCalledWith(error);
+    });
+});

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -75,4 +75,10 @@ test.describe("Index tests", () => {
     test("can download day 3 sample file", async ({ page }) => {
         await testDownloadFile("files/day3/sample1.csv", "sample3-1.csv", "3,3\n", page);
     });
+
+    test("browsing to non-existent app shows 404 page", async ({page}) => {
+        await page.goto("/apps/day4");
+        await expect(await page.title()).toBe("Page Not Found");
+        await expect(await page.innerText(".container")).toContain("Application \"day4\" is not configured");
+    });
 });

--- a/app/static/tests/e2e/index.etest.ts
+++ b/app/static/tests/e2e/index.etest.ts
@@ -76,7 +76,7 @@ test.describe("Index tests", () => {
         await testDownloadFile("files/day3/sample1.csv", "sample3-1.csv", "3,3\n", page);
     });
 
-    test("browsing to non-existent app shows 404 page", async ({page}) => {
+    test("browsing to non-existent app shows 404 page", async ({ page }) => {
         await page.goto("/apps/day4");
         await expect(await page.title()).toBe("Page Not Found");
         await expect(await page.innerText(".container")).toContain("Application \"day4\" is not configured");


### PR DESCRIPTION
This fixes entire application crashing when a non-existent app was requested, e.g. http://localhost:3000/apps/day4

Async handlers do not automatically use the express application's error handler when they throw, but need to explicitly call `next`.  (as descibed [here](https://reflectoring.io/express-error-handling/).)

This branch adds a wrapper method, `asyncControllerHandler` which does this - any async controller methods should use this wrapper *except* if they just use `apiService` to call out to an external service (as `odinController` does) since `apiService` already handles errors in this way.  The wrapper has been applied to `appsController` (which was causing this bug) and `sessionsController`. 

To test, browse to http://localhost:3000/apps/day4 - should see a Page Not Found html response, and should be able to subsequently browse to apps which do exist. 
