### PR TITLE
mrc-3749 Fix wandering Download button

### DIFF
--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -36,7 +36,7 @@ export default defineComponent({
         const plot = ref<null | HTMLElement>(null); // Picks up the element with 'plot' ref in the template
         const placeholderMessage = userMessages.sensitivity.notRunYet;
 
-        const batch = computed(() => store.state.sensitivity.result.batch);
+        const batch = computed(() => store.state.sensitivity.result?.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
 

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -40,6 +40,14 @@ $grey: #ccc;
   color: #0d6efd !important;
 }
 
+.wodin-plot-container, .summary-plot-container {
+  position: relative;
+}
+
+.plot {
+  height: 450px;
+}
+
 .plot-placeholder {
   width: 100%;
   height: 450px;
@@ -48,6 +56,8 @@ $grey: #ccc;
   align-items: center;
   justify-content: center;
   text-align: center;
+  position: absolute;
+  top: 0;
 }
 
 .alert-danger {


### PR DESCRIPTION
The bug with the Download button disappearing/floating upwards was caused, I think, by plotly resetting the height of its div element when redrawing on zoom, and the DOM being somehow unable to catch up. This was fixed by setting that element to have a fixed height of 450px (perhaps not ideal, but that's what's we've been getting anyway as plotly's default) - this is set in a class which is applied to both `WodinPlot` and `SensitivitySummaryPlot`. 

However, this caused another issue: because the plot div now has fixed full height, that meant that the placeholder (shown when there is no plot data), placed after the plot div in the DOM, would be shown with a big plot-sized gap above it. Various attempts to hide the plot div, or temporarily set its height to 0 caused the same sorts of problems we started with. So instead, I've made the placeholder be absolutely positioned when shown.