### PR TITLE
mrc-3425 Option for log scale y axis on plots

### DIFF
--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -116,7 +116,7 @@ export default defineComponent({
                     const layout = {
                         margin,
                         yaxis: {
-                          type: yAxisType.value
+                            type: yAxisType.value
                         },
                         xaxis: { title: "Time" }
                     };

--- a/app/static/src/app/components/options/GraphSettings.vue
+++ b/app/static/src/app/components/options/GraphSettings.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="container">
+    <div id="log-scale-y-axis" class="row my-2">
+      <div class="col-5">
+        <label class="col-form-label">Log scale y axis</label>
+      </div>
+      <div class="col-6">
+        <input type="checkbox" class="form-check-input" style="vertical-align:bottom;" v-model="logScaleYAxis">
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import { useStore } from "vuex";
+import { GraphSettingsMutation } from "../../store/graphSettings/mutations";
+
+export default defineComponent({
+    name: "GraphSettings",
+    setup() {
+        const store = useStore();
+        const logScaleYAxis = computed({
+            get() {
+                return store.state.graphSettings.logScaleYAxis;
+            },
+            set(newValue) {
+                store.commit(`graphSettings/${GraphSettingsMutation.SetLogScaleYAxis}`, newValue);
+            }
+        });
+
+        return {
+            logScaleYAxis
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -13,6 +13,9 @@
         <vertical-collapse v-if="fitTabIsOpen" title="Optimisation" collapse-id="optimisation">
           <optimisation-options></optimisation-options>
         </vertical-collapse>
+        <vertical-collapse title="Graph Settings" collapse-id="graph-settings">
+          <graph-settings></graph-settings>
+        </vertical-collapse>
     </div>
 </template>
 
@@ -26,6 +29,7 @@ import LinkData from "./LinkData.vue";
 import SensitivityOptions from "./SensitivityOptions.vue";
 import OptimisationOptions from "./OptimisationOptions.vue";
 import { AppType, VisualisationTab } from "../../store/appState/state";
+import GraphSettings from "./GraphSettings.vue";
 
 export default {
     name: "OptionsTab",
@@ -35,7 +39,8 @@ export default {
         ParameterValues,
         RunOptions,
         SensitivityOptions,
-        VerticalCollapse
+        VerticalCollapse,
+        GraphSettings
     },
     setup() {
         const store = useStore();

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -65,7 +65,8 @@ export default defineComponent({
         });
 
         const yAxisSettings = computed(() => {
-            const logScale = store.state.graphSettings.logScaleYAxis && plotSettings.value.plotType !== SensitivityPlotType.TimeAtExtreme;
+            const isNotTimePlot = plotSettings.value.plotType !== SensitivityPlotType.TimeAtExtreme;
+            const logScale = store.state.graphSettings.logScaleYAxis && isNotTimePlot;
             const type = logScale ? "log" : "linear" as AxisType;
             return { type };
         });

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -14,7 +14,7 @@
 import {
     computed, defineComponent, onMounted, onUnmounted, ref, watch
 } from "vue";
-import { newPlot, Plots } from "plotly.js-basic-dist-min";
+import { AxisType, newPlot, Plots } from "plotly.js-basic-dist-min";
 import { useStore } from "vuex";
 import {
     fadePlotStyle, margin, config, odinToPlotly
@@ -39,6 +39,11 @@ export default defineComponent({
         const batch = computed(() => store.state.sensitivity.result?.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
+
+        const yAxisType = computed(() => {
+            return store.state.graphSettings.logScaleYAxis && plotSettings.value.plotType !== SensitivityPlotType.TimeAtExtreme
+                ? "log" : "-" as AxisType;
+        });
 
         const verifyValidEndTime = () => {
             // update plot settings' end time to be valid before we use it
@@ -83,7 +88,10 @@ export default defineComponent({
             if (hasPlotData.value) {
                 const el = plot.value as unknown;
                 const layout = {
-                    margin
+                    margin,
+                    yaxis: {
+                        type: yAxisType.value
+                    }
                 };
                 newPlot(el as HTMLElement, plotData.value, layout, config);
                 resizeObserver = new ResizeObserver(resize);
@@ -93,7 +101,7 @@ export default defineComponent({
 
         onMounted(drawPlot);
 
-        watch(plotData, drawPlot);
+        watch([plotData, yAxisType], drawPlot);
 
         onUnmounted(() => {
             if (resizeObserver) {

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -13,6 +13,7 @@ import {
     SerialisedSensitivityState,
     SerialisedRunResult
 } from "./types/serialisationTypes";
+import { GraphSettingsState } from "./store/graphSettings/state";
 
 function serialiseCode(code: CodeState) : CodeState {
     return {
@@ -94,13 +95,18 @@ function serialiseModelFit(modelFit: ModelFitState) {
     };
 }
 
+export const serialiseGraphSettings = (state: GraphSettingsState) => {
+    return { ...state };
+};
+
 export const serialiseState = (state: AppState) => {
     const result: SerialisedAppState = {
         openVisualisationTab: state.openVisualisationTab,
         code: serialiseCode(state.code),
         model: serialiseModel(state.model),
         run: serialiseRun(state.run),
-        sensitivity: serialiseSensitivity(state.sensitivity)
+        sensitivity: serialiseSensitivity(state.sensitivity),
+        graphSettings: serialiseGraphSettings(state.graphSettings)
     };
 
     if (state.appType === AppType.Fit) {

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -4,6 +4,7 @@ import { RunState } from "../run/state";
 import { AppConfig } from "../../types/responseTypes";
 import { SensitivityState } from "../sensitivity/state";
 import { VersionsState } from "../versions/state";
+import { GraphSettingsState } from "../graphSettings/state";
 
 export enum AppType {
     Basic = "basic",
@@ -32,5 +33,6 @@ export interface AppState {
     model: ModelState
     run: RunState
     sensitivity: SensitivityState,
+    graphSettings: GraphSettingsState,
     versions: VersionsState
 }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -12,6 +12,7 @@ import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
+import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -42,7 +43,8 @@ export const storeOptions: StoreOptions<BasicState> = {
         code,
         sensitivity,
         sessions,
-        versions
+        versions,
+        graphSettings
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -14,6 +14,7 @@ import { logMutations, persistState } from "../plugins";
 import { newSessionId } from "../../utils";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
+import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -46,7 +47,8 @@ export const storeOptions: StoreOptions<FitState> = {
         modelFit,
         sensitivity,
         sessions,
-        versions
+        versions,
+        graphSettings
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/store/graphSettings/graphSettings.ts
+++ b/app/static/src/app/store/graphSettings/graphSettings.ts
@@ -1,0 +1,12 @@
+import { GraphSettingsState } from "./state";
+import { mutations } from "./mutations";
+
+export const defaultState: GraphSettingsState = {
+    logScaleYAxis: false
+};
+
+export const graphSettings = {
+    namespaced: true,
+    state: defaultState,
+    mutations
+};

--- a/app/static/src/app/store/graphSettings/mutations.ts
+++ b/app/static/src/app/store/graphSettings/mutations.ts
@@ -1,0 +1,12 @@
+import { MutationTree } from "vuex";
+import { GraphSettingsState } from "./state";
+
+export enum GraphSettingsMutation {
+    SetLogScaleYAxis = "SetLogScaleYAxis"
+}
+
+export const mutations: MutationTree<GraphSettingsState> = {
+    [GraphSettingsMutation.SetLogScaleYAxis](state: GraphSettingsState, payload: boolean) {
+        state.logScaleYAxis = payload;
+    }
+};

--- a/app/static/src/app/store/graphSettings/state.ts
+++ b/app/static/src/app/store/graphSettings/state.ts
@@ -1,0 +1,3 @@
+export interface GraphSettingsState {
+    logScaleYAxis: boolean
+}

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -12,6 +12,7 @@ import { newSessionId } from "../../utils";
 import { logMutations, persistState } from "../plugins";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
+import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -42,7 +43,8 @@ export const storeOptions: StoreOptions<StochasticState> = {
         run,
         sensitivity,
         sessions,
-        versions
+        versions,
+        graphSettings
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -11,6 +11,7 @@ import { VisualisationTab } from "../store/appState/state";
 import { CodeState } from "../store/code/state";
 import { FitDataState } from "../store/fitData/state";
 import { Palette } from "../palette";
+import { GraphSettingsState } from "../store/graphSettings/state";
 
 export interface SerialisedRunResult {
     inputs: OdinRunInputs | OdinFitInputs,
@@ -62,6 +63,7 @@ export interface SerialisedAppState {
     model: SerialisedModelState,
     run: SerialisedRunState,
     sensitivity: SerialisedSensitivityState,
+    graphSettings: GraphSettingsState,
     fitData?: FitDataState,
-    modelFit?: SerialisedModelFitState
+    modelFit?: SerialisedModelFitState,
 }

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -184,4 +184,15 @@ test.describe("Options Tab tests", () => {
         // Verify parameters have been reset to default value
         await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
     });
+
+    test("can change graph setting for log scale y axis", async ({ page }) => {
+        await expect(await page.innerText(":nth-match(.collapse-title, 3)")).toContain("Graph Settings");
+        await page.locator("#log-scale-y-axis input").click();
+        // should update y axis tick
+        const tickSelector = ":nth-match(.plotly .ytick text, 2)";
+        await expect(await page.innerHTML(tickSelector)).toBe("10n");
+        // change back to linear
+        await page.locator("#log-scale-y-axis input").click();
+        await expect(await page.innerHTML(tickSelector)).toBe("0.2M");
+    });
 });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -20,6 +20,7 @@ import {
     SensitivityVariationType
 } from "../src/app/store/sensitivity/state";
 import { VersionsState } from "../src/app/store/versions/state";
+import { GraphSettingsState } from "../src/app/store/graphSettings/state";
 
 export const mockAxios = new MockAdapter(axios);
 
@@ -95,6 +96,13 @@ export const mockVersionsState = (states: Partial<VersionsState> = {}): Versions
     };
 };
 
+export const mockGraphSettingsState = (state: Partial<GraphSettingsState> = {}): GraphSettingsState => {
+    return {
+        logScaleYAxis: false,
+        ...state
+    };
+};
+
 export const mockFitDataState = (state:Partial<FitDataState> = {}): FitDataState => {
     return {
         data: null,
@@ -157,6 +165,7 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
         run: mockRunState(),
         sensitivity: mockSensitivityState(),
         versions: mockVersionsState(),
+        graphSettings: mockGraphSettingsState(),
         ...state
     };
 };
@@ -203,6 +212,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         sensitivity: mockSensitivityState(),
         modelFit: mockModelFitState(),
         versions: mockVersionsState(),
+        graphSettings: mockGraphSettingsState(),
         ...state
     };
 };
@@ -227,6 +237,7 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
         run: mockRunState(),
         sensitivity: mockSensitivityState(),
         versions: mockVersionsState(),
+        graphSettings: mockGraphSettingsState(),
         ...state
     };
 };

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -56,6 +56,12 @@ describe("BasicApp", () => {
                     state: {
                         errors: []
                     }
+                },
+                graphSettings: {
+                    namespaced: true,
+                    state: {
+                        logScaleYAxis: false
+                    }
                 }
             }
         });

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -17,7 +17,7 @@ import { mount } from "@vue/test-utils";
 import HelpTab from "../../../../src/app/components/help/HelpTab.vue";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockModelState, mockSensitivityState } from "../../../mocks";
+import {mockBasicState, mockGraphSettingsState, mockModelState, mockSensitivityState} from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";
@@ -59,9 +59,7 @@ describe("BasicApp", () => {
                 },
                 graphSettings: {
                     namespaced: true,
-                    state: {
-                        logScaleYAxis: false
-                    }
+                    state: mockGraphSettingsState()
                 }
             }
         });

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -17,7 +17,9 @@ import { mount } from "@vue/test-utils";
 import HelpTab from "../../../../src/app/components/help/HelpTab.vue";
 import BasicApp from "../../../../src/app/components/basic/BasicApp.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {mockBasicState, mockGraphSettingsState, mockModelState, mockSensitivityState} from "../../../mocks";
+import {
+    mockBasicState, mockGraphSettingsState, mockModelState, mockSensitivityState
+} from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import OptionsTab from "../../../../src/app/components/options/OptionsTab.vue";

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -73,6 +73,12 @@ describe("FitApp", () => {
                     state: {
                         errors: []
                     }
+                },
+                graphSettings:{
+                    namespaced: true,
+                    state: {
+                        logScaleYAxis: false
+                    }
                 }
             }
         });

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -74,7 +74,7 @@ describe("FitApp", () => {
                         errors: []
                     }
                 },
-                graphSettings:{
+                graphSettings: {
                     namespaced: true,
                     state: {
                         logScaleYAxis: false

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -19,7 +19,7 @@ import FitApp from "../../../../src/app/components/fit/FitApp.vue";
 import { FitState } from "../../../../src/app/store/fit/state";
 import { AppStateAction } from "../../../../src/app/store/appState/actions";
 import {
-    mockFitDataState, mockFitState, mockModelFitState, mockModelState, mockSensitivityState
+    mockFitDataState, mockFitState, mockGraphSettingsState, mockModelFitState, mockModelState, mockSensitivityState
 } from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
@@ -76,9 +76,7 @@ describe("FitApp", () => {
                 },
                 graphSettings: {
                     namespaced: true,
-                    state: {
-                        logScaleYAxis: false
-                    }
+                    state: mockGraphSettingsState()
                 }
             }
         });

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -33,6 +33,12 @@ describe("Fit Tab", () => {
                         compileRequired
                     }
                 },
+                graphSettings: {
+                    namespaced: true,
+                    state: {
+                        logScaleYAxis: false
+                    },
+                },
                 modelFit: {
                     namespaced: true,
                     state: {

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -10,7 +10,7 @@ import { FitState } from "../../../../src/app/store/fit/state";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
 import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
-import {mockFitState, mockGraphSettingsState} from "../../../mocks";
+import { mockFitState, mockGraphSettingsState } from "../../../mocks";
 
 describe("Fit Tab", () => {
     const getWrapper = (

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -37,7 +37,7 @@ describe("Fit Tab", () => {
                     namespaced: true,
                     state: {
                         logScaleYAxis: false
-                    },
+                    }
                 },
                 modelFit: {
                     namespaced: true,

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -10,7 +10,7 @@ import { FitState } from "../../../../src/app/store/fit/state";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
 import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
-import { mockFitState } from "../../../mocks";
+import {mockFitState, mockGraphSettingsState} from "../../../mocks";
 
 describe("Fit Tab", () => {
     const getWrapper = (
@@ -35,9 +35,7 @@ describe("Fit Tab", () => {
                 },
                 graphSettings: {
                     namespaced: true,
-                    state: {
-                        logScaleYAxis: false
-                    }
+                    state: mockGraphSettingsState()
                 },
                 modelFit: {
                     namespaced: true,

--- a/app/static/tests/unit/components/options/graphSettings.test.ts
+++ b/app/static/tests/unit/components/options/graphSettings.test.ts
@@ -1,0 +1,49 @@
+import Vuex from "vuex";
+import { shallowMount } from "@vue/test-utils";
+import { BasicState } from "../../../../src/app/store/basic/state";
+import GraphSettings from "../../../../src/app/components/options/GraphSettings.vue";
+import { GraphSettingsMutation } from "../../../../src/app/store/graphSettings/mutations";
+
+describe("GraphSettings", () => {
+    const mockSetLogScaleYAxis = jest.fn();
+
+    const getWrapper = (logScaleYAxis = true) => {
+        const store = new Vuex.Store<BasicState>({
+            modules: {
+                graphSettings: {
+                    namespaced: true,
+                    state: {
+                        logScaleYAxis
+                    } as any,
+                    mutations: {
+                        [GraphSettingsMutation.SetLogScaleYAxis]: mockSetLogScaleYAxis
+                    }
+                }
+            }
+        });
+        return shallowMount(GraphSettings, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("label").text()).toBe("Log scale y axis");
+        expect(wrapper.find("input").attributes("type")).toBe("checkbox");
+        expect((wrapper.find("input").element as HTMLInputElement).checked).toBe(true);
+    });
+
+    it("commits change to log scale y axis setting", async () => {
+        const wrapper = getWrapper(false);
+        expect((wrapper.find("input").element as HTMLInputElement).checked).toBe(false);
+        await wrapper.find("input").setValue(true);
+        expect(mockSetLogScaleYAxis).toHaveBeenCalledTimes(1);
+        expect(mockSetLogScaleYAxis.mock.calls[0][1]).toBe(true);
+    });
+});

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -12,6 +12,7 @@ import SensitivityOptions from "../../../../src/app/components/options/Sensitivi
 import OptimisationOptions from "../../../../src/app/components/options/OptimisationOptions.vue";
 import { mockModelState, mockRunState } from "../../../mocks";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
+import GraphSettings from "../../../../src/app/components/options/GraphSettings.vue";
 
 describe("OptionsTab", () => {
     const getWrapper = (store: Store<any>) => {
@@ -50,7 +51,7 @@ describe("OptionsTab", () => {
         });
         const wrapper = getWrapper(store);
         const collapses = wrapper.findAllComponents(VerticalCollapse);
-        expect(collapses.length).toBe(2);
+        expect(collapses.length).toBe(3);
         expect(collapses.at(0)!.props("title")).toBe("Model Parameters");
         expect(collapses.at(0)!.props("collapseId")).toBe("model-params");
         const paramValues = collapses.at(0)!.findComponent(ParameterValues);
@@ -58,6 +59,9 @@ describe("OptionsTab", () => {
         expect(collapses.at(1)!.props("title")).toBe("Run Options");
         expect(collapses.at(1)!.props("collapseId")).toBe("run-options");
         expect(collapses.at(1)!.findComponent(RunOptions).exists()).toBe(true);
+        expect(collapses.at(2)!.props("title")).toBe("Graph Settings");
+        expect(collapses.at(2)!.props("collapseId")).toBe("graph-settings");
+        expect(collapses.at(2)!.findComponent(GraphSettings).exists()).toBe(true);
         expect(wrapper.find("#reset-params-btn").exists()).toBe(true);
         expect(wrapper.find("#reset-params-btn").text()).toBe("Reset");
     });

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -154,7 +154,7 @@ describe("OptionsTab", () => {
         expect(collapses.at(2)!.findComponent(RunOptions).exists()).toBe(true);
         expect(collapses.at(3)!.props("title")).toBe("Optimisation");
         expect(collapses.at(3)!.props("collapseId")).toBe("optimisation");
-        expect(collapses.at(3)!.findComponent(OptimisationOptions).exists()).toBe(true)
+        expect(collapses.at(3)!.findComponent(OptimisationOptions).exists()).toBe(true);
         expect(collapses.at(4)!.props("title")).toBe("Graph Settings");
         expect(collapses.at(4)!.props("collapseId")).toBe("graph-settings");
         expect(collapses.at(4)!.findComponent(GraphSettings).exists()).toBe(true);

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -36,6 +36,9 @@ describe("OptionsTab", () => {
         },
         sensitivity: {
             paramSettings: {}
+        },
+        graphSettings: {
+            logScaleYAxis: false
         }
     } as any;
 
@@ -46,6 +49,9 @@ describe("OptionsTab", () => {
                 openVisualisationTab: VisualisationTab.Run,
                 run: {
                     parameterValues: { param1: 1, param2: 2.2 }
+                },
+                graphSettings: {
+                    logScaleYAxis: false
                 }
             } as any
         });
@@ -71,7 +77,10 @@ describe("OptionsTab", () => {
         const store = new Vuex.Store<BasicState>({
             state: {
                 appType: AppType.Basic,
-                openVisualisationTab: VisualisationTab.Run
+                openVisualisationTab: VisualisationTab.Run,
+                graphSettings: {
+                    logScaleYAxis: false
+                }
             } as any,
             modules: {
                 run: {
@@ -123,13 +132,16 @@ describe("OptionsTab", () => {
                 },
                 fitData: {
                     columnToFit: null
+                },
+                graphSettings: {
+                    logScaleYAxis: false
                 }
             } as any
         });
         const wrapper = getWrapper(store);
 
         const collapses = wrapper.findAllComponents(VerticalCollapse);
-        expect(collapses.length).toBe(4);
+        expect(collapses.length).toBe(5);
         expect(collapses.at(0)!.props("title")).toBe("Link");
         expect(collapses.at(0)!.props("collapseId")).toBe("link-data");
         expect(collapses.at(0)!.findComponent(LinkData).exists()).toBe(true);
@@ -142,7 +154,10 @@ describe("OptionsTab", () => {
         expect(collapses.at(2)!.findComponent(RunOptions).exists()).toBe(true);
         expect(collapses.at(3)!.props("title")).toBe("Optimisation");
         expect(collapses.at(3)!.props("collapseId")).toBe("optimisation");
-        expect(collapses.at(3)!.findComponent(OptimisationOptions).exists()).toBe(true);
+        expect(collapses.at(3)!.findComponent(OptimisationOptions).exists()).toBe(true)
+        expect(collapses.at(4)!.props("title")).toBe("Graph Settings");
+        expect(collapses.at(4)!.props("collapseId")).toBe("graph-settings");
+        expect(collapses.at(4)!.findComponent(GraphSettings).exists()).toBe(true);
         expect(wrapper.find("#reset-params-btn").exists()).toBe(true);
         expect(wrapper.find("#reset-params-btn").text()).toBe("Reset");
     });

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -307,11 +307,11 @@ describe("SensitivitySummaryPlot", () => {
 
     it("draws y axis on log scale if graph setting log scale is true and plot type is not time at extreme", () => {
         const wrapper = getWrapper(true, defaultPlotSettings, false, defaultParamSettings, true);
-        expectDataToHaveBeenPlotted(wrapper, {yaxis: { type: "log" }});
+        expectDataToHaveBeenPlotted(wrapper, { yaxis: { type: "log" } });
     });
 
     it("draws y axis on lines scale if graph setting log scale is true but plot type is time at extreme", () => {
-        const plotSettings = {...defaultPlotSettings, plotType: SensitivityPlotType.TimeAtExtreme};
+        const plotSettings = { ...defaultPlotSettings, plotType: SensitivityPlotType.TimeAtExtreme };
         const wrapper = getWrapper(true, plotSettings, false, defaultParamSettings, true);
         expectDataToHaveBeenPlotted(wrapper);
     });

--- a/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
+++ b/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
@@ -15,7 +15,7 @@ import Vuex from "vuex";
 import { mount } from "@vue/test-utils";
 import StochasticApp from "../../../../src/app/components/stochastic/StochasticApp.vue";
 import { StochasticState } from "../../../../src/app/store/stochastic/state";
-import {mockGraphSettingsState, mockStochasticState} from "../../../mocks";
+import { mockGraphSettingsState, mockStochasticState } from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import CodeTab from "../../../../src/app/components/code/CodeTab.vue";

--- a/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
+++ b/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
@@ -15,7 +15,7 @@ import Vuex from "vuex";
 import { mount } from "@vue/test-utils";
 import StochasticApp from "../../../../src/app/components/stochastic/StochasticApp.vue";
 import { StochasticState } from "../../../../src/app/store/stochastic/state";
-import { mockStochasticState } from "../../../mocks";
+import {mockGraphSettingsState, mockStochasticState} from "../../../mocks";
 import WodinApp from "../../../../src/app/components/WodinApp.vue";
 import WodinPanels from "../../../../src/app/components/WodinPanels.vue";
 import CodeTab from "../../../../src/app/components/code/CodeTab.vue";
@@ -54,9 +54,7 @@ describe("StochasticApp", () => {
                 },
                 graphSettings: {
                     namespaced: true,
-                    state: {
-                        logScaleYAxis: false
-                    }
+                    state: mockGraphSettingsState()
                 }
             }
         });

--- a/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
+++ b/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
@@ -51,6 +51,12 @@ describe("StochasticApp", () => {
                     actions: {
                         [ModelAction.FetchOdinRunner]: jest.fn()
                     }
+                },
+                graphSettings: {
+                    namespaced: true,
+                    state: {
+                        logScaleYAxis: false
+                    }
                 }
             }
         });

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -12,9 +12,9 @@ jest.mock("plotly.js-basic-dist-min", () => ({
 import { shallowMount, VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import * as plotly from "plotly.js-basic-dist-min";
-import WodinPlot from "../../../src/app/components/WodinPlot.vue";
-import {BasicState} from "../../../src/app/store/basic/state";
 import Vuex, { Store } from "vuex";
+import WodinPlot from "../../../src/app/components/WodinPlot.vue";
+import { BasicState } from "../../../src/app/store/basic/state";
 
 describe("WodinPlot", () => {
     const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -1,4 +1,5 @@
 // Mock the import of plotly so we can mock Plotly methods
+
 jest.mock("plotly.js-basic-dist-min", () => ({
     newPlot: jest.fn(),
     react: jest.fn(),
@@ -12,6 +13,8 @@ import { shallowMount, VueWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import * as plotly from "plotly.js-basic-dist-min";
 import WodinPlot from "../../../src/app/components/WodinPlot.vue";
+import {BasicState} from "../../../src/app/store/basic/state";
+import Vuex, { Store } from "vuex";
 
 describe("WodinPlot", () => {
     const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
@@ -55,9 +58,22 @@ describe("WodinPlot", () => {
         placeholderMessage: "No data available"
     };
 
-    const getWrapper = (props = {}) => {
+    const getStore = (graphSettingsLogScaleYAxis = false) => {
+        return new Vuex.Store<BasicState>({
+            state: {
+                graphSettings: {
+                    logScaleYAxis: graphSettingsLogScaleYAxis
+                }
+            } as any
+        });
+    };
+
+    const getWrapper = (props = {}, store: Store<BasicState> = getStore()) => {
         return shallowMount(WodinPlot, {
-            props: { ...defaultProps, ...props }
+            props: { ...defaultProps, ...props },
+            global: {
+                plugins: [store]
+            }
         });
     };
 
@@ -92,8 +108,12 @@ describe("WodinPlot", () => {
     });
 
     it("renders slot content", () => {
+        const store = getStore();
         const wrapper = shallowMount(WodinPlot, {
             props: defaultProps,
+            global: {
+                plugins: [store]
+            },
             slots: {
                 default: "<h3>test slot content</h3>"
             }
@@ -115,7 +135,8 @@ describe("WodinPlot", () => {
         expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(mockPlotData);
         expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({
             margin: { t: 25 },
-            xaxis: { title: "Time" }
+            xaxis: { title: "Time" },
+            yaxis: { type: "linear" }
         });
 
         expect(mockOn.mock.calls[0][0]).toBe("plotly_relayout");
@@ -175,7 +196,7 @@ describe("WodinPlot", () => {
         margin: { t: 25 },
         uirevision: "true",
         xaxis: { autorange: true, title: "Time" },
-        yaxis: { autorange: true }
+        yaxis: { autorange: true, type: "linear" }
     };
 
     it("relayout reruns plotData and calls react if not autorange", async () => {
@@ -316,5 +337,47 @@ describe("WodinPlot", () => {
         wrapper.setProps({ redrawWatches: [{} as any] });
         await nextTick();
         expect(wrapper.find(".plot-placeholder").exists()).toBe(false);
+    });
+
+    it("renders y axis log scale if graph setting is set", async () => {
+        const store = getStore(true);
+        const wrapper = getWrapper({}, store);
+        mockPlotElementOn(wrapper);
+
+        wrapper.setProps({ redrawWatches: [{} as any] });
+        await nextTick();
+        expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual({
+            margin: { t: 25 },
+            xaxis: { title: "Time" },
+            yaxis: { type: "log" }
+        });
+    });
+
+    it("relayout uses graph settings log scale y axis value", async () => {
+        const store = getStore(true);
+        const wrapper = getWrapper({}, store);
+        mockPlotElementOn(wrapper);
+
+        wrapper.setProps({ redrawWatches: [{} as any] });
+        await nextTick();
+
+        const relayoutEvent = {
+            "xaxis.autorange": false,
+            "xaxis.range[0]": 2,
+            "xaxis.range[1]": 7
+        };
+
+        const { relayout } = wrapper.vm as any;
+        await relayout(relayoutEvent);
+
+        const divElement = wrapper.find("div.plot").element;
+        expect(mockPlotlyReact.mock.calls.length).toBe(1);
+        expect(mockPlotlyReact.mock.calls[0][0]).toBe(divElement);
+        expect(mockPlotlyReact.mock.calls[0][1]).toStrictEqual(mockPlotData);
+        const expectedLogScaleLayout = {
+            ...expectedLayout,
+            yaxis: { autorange: true, type: "log" }
+        };
+        expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLogScaleLayout);
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -10,7 +10,7 @@ import { deserialiseState, serialiseState } from "../../src/app/serialise";
 import { FitState } from "../../src/app/store/fit/state";
 import {
     mockCodeState,
-    mockFitDataState,
+    mockFitDataState, mockGraphSettingsState,
     mockModelFitState,
     mockModelState,
     mockRunState,
@@ -188,7 +188,8 @@ describe("serialise", () => {
         model: modelState,
         run: runState,
         sensitivity: sensitivityState,
-        versions: { versions: null }
+        versions: { versions: null },
+        graphSettings: { logScaleYAxis: true }
     };
 
     const fitState: FitState = {
@@ -208,7 +209,8 @@ describe("serialise", () => {
         sensitivity: sensitivityState,
         fitData: fitDataState,
         modelFit: modelFitState,
-        versions: { versions: null }
+        versions: { versions: null },
+        graphSettings: { logScaleYAxis: true }
     };
 
     const expectedCode = { currentCode: ["some code"] };
@@ -258,6 +260,10 @@ describe("serialise", () => {
         }
     };
 
+    const expectedGraphSettings = {
+        logScaleYAxis: true
+    };
+
     const expectedFitData = {
         data: fitDataState.data,
         columns: ["time", "cases"],
@@ -294,7 +300,8 @@ describe("serialise", () => {
             code: expectedCode,
             model: expectedModel,
             run: expectedRun,
-            sensitivity: expectedSensitivity
+            sensitivity: expectedSensitivity,
+            graphSettings: expectedGraphSettings
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
@@ -308,7 +315,8 @@ describe("serialise", () => {
             run: expectedRun,
             sensitivity: expectedSensitivity,
             fitData: expectedFitData,
-            modelFit: expectedModelFit
+            modelFit: expectedModelFit,
+            graphSettings: expectedGraphSettings
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
@@ -361,7 +369,8 @@ describe("serialise", () => {
             modelFit: {
                 ...expectedModelFit,
                 result: { ...expectedModelFit.result, hasResult: false }
-            }
+            },
+            graphSettings: expectedGraphSettings
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
@@ -383,7 +392,8 @@ describe("serialise", () => {
             run: { ...expectedRun, resultOde: null, resultDiscrete: null },
             sensitivity: { ...expectedSensitivity, result: null },
             fitData: expectedFitData,
-            modelFit: { ...expectedModelFit, result: null }
+            modelFit: { ...expectedModelFit, result: null },
+            graphSettings: expectedGraphSettings
         };
         expect(JSON.parse(serialised)).toStrictEqual(expected);
     });
@@ -397,7 +407,8 @@ describe("serialise", () => {
             sensitivity: mockSensitivityState(),
             fitData: mockFitDataState(),
             modelFit: mockModelFitState(),
-            versions: mockVersionsState()
+            versions: mockVersionsState(),
+            graphSettings: mockGraphSettingsState()
         } as any;
 
         const target = {
@@ -411,7 +422,8 @@ describe("serialise", () => {
             sensitivity: {},
             fitData: {},
             modelFit: {},
-            versions: null
+            versions: null,
+            graphSettings: {}
         } as any;
 
         deserialiseState(target, serialised);
@@ -426,7 +438,8 @@ describe("serialise", () => {
             sensitivity: mockSensitivityState(),
             fitData: mockFitDataState(),
             modelFit: mockModelFitState(),
-            versions: mockVersionsState()
+            versions: mockVersionsState(),
+            graphSettings: mockGraphSettingsState()
         });
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -16,6 +16,7 @@ import {
     mockRunState,
     mockSensitivityState, mockVersionsState
 } from "../mocks";
+import { defaultState as defaultGraphSettingsState } from "../../src/app/store/graphSettings/graphSettings";
 
 describe("serialise", () => {
     const codeState = {
@@ -441,5 +442,40 @@ describe("serialise", () => {
             versions: mockVersionsState(),
             graphSettings: mockGraphSettingsState()
         });
+    });
+
+    it("deserialises default graph settings when undefined in serialised state", () => {
+        // serialised state with no graph settings
+        const serialised = {
+            openVisualisationTab: VisualisationTab.Fit,
+            code: mockCodeState(),
+            model: mockModelState(),
+            run: mockRunState(),
+            sensitivity: mockSensitivityState(),
+            fitData: mockFitDataState(),
+            modelFit: mockModelFitState(),
+            versions: mockVersionsState()
+        } as any;
+
+        // target state with default graph settings - as module will initialise to
+        const target = {
+            sessionId: "123",
+            appType: AppType.Fit,
+            config: {},
+            openVisualisationTab: VisualisationTab.Run,
+            code: {},
+            model: {},
+            run: {},
+            sensitivity: {},
+            fitData: {},
+            modelFit: {},
+            versions: null,
+            graphSettings: defaultGraphSettingsState
+        } as any;
+        // sanity check
+        expect(target.graphSettings.logScaleYAxis).toBe(false);
+
+        deserialiseState(target, serialised);
+        expect(target.graphSettings.logScaleYAxis).toBe(false);
     });
 });

--- a/app/static/tests/unit/store/graphSettings/mutations.test.ts
+++ b/app/static/tests/unit/store/graphSettings/mutations.test.ts
@@ -1,0 +1,9 @@
+import { mutations } from "../../../../src/app/store/graphSettings/mutations";
+
+describe("GraphSettings mutations", () => {
+    it("sets logScaleYAxis", () => {
+        const state = { logScaleYAxis: false };
+        mutations.SetLogScaleYAxis(state, true);
+        expect(state.logScaleYAxis).toBe(true);
+    });
+});


### PR DESCRIPTION
This branch adds 'Graph Settings' as a new section on the Options tab. Currently the only graph setting is the option to plot values on the y axis with log scale. Setting this value will use log scale for all plots on all tabs, except for Sensitivity summary plots, when the plot type is 'Time at value's min/max' (since it does not make sense to plot Tme on log scale). 

This setting is currently false by default for all apps, but we may make default value configurable in future. 
There are likely to be further graph settings in the future, so the `graphSettings' module will be less empty than this initial version. 