### PR TITLE
Overrideable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build front end changes only for a given app type run, `./scripts/build-front
 
 WODIN is deployable via an npm package: https://www.npmjs.com/package/wodin
 
-To run an instance of WODIN with custom configuration, install the package and use `npx wodin --config=/path/to/config`
+To run an instance of WODIN with custom configuration, install the package and use `npx wodin /path/to/config`
 
 The path provided in the `config` argument should be an absolute path to a root config folder containing the following: 
 

--- a/app/server/README.md
+++ b/app/server/README.md
@@ -2,6 +2,6 @@
 
 The wodin package provides access to WODIN functionality through npm. WODIN lets you create web interfaces for [odin](https://github.com/mrc-ide/odin).
 
-To run an instance of WODIN with custom configuration, install the package and run `npx wodin --config=/path/to/config` 
+To run an instance of WODIN with custom configuration, install the package and run `npx wodin /path/to/config`
 
 See the [source repository](https://github.com/mrc-ide/wodin) for full details on how to configure WODIN. 

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -8,15 +8,16 @@
       "name": "wodin",
       "version": "0.2.0",
       "dependencies": {
+        "@types/docopt": "^0.6.33",
         "axios": "^0.27.2",
         "body-parser": "^1.20.0",
         "compression": "^1.7.4",
+        "docopt": "^0.6.2",
         "express": "^4.17.2",
         "hbs": "^4.2.0",
         "ioredis": "^5.2.2",
         "morgan": "^1.10.0",
         "uid": "^2.0.0",
-        "yargs": "^17.4.0",
         "zoo-ids": "^2.0.0"
       },
       "bin": {
@@ -1210,6 +1211,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/docopt": {
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/@types/docopt/-/docopt-0.6.33.tgz",
+      "integrity": "sha512-FfbIS7UZwte9X1Vr6ENnwEnBOJSjQ0Cr+z1pGNvR4l+bs4U0i4NQIEeIsCvBcLoWmA5xuK1TXYJyZ9qRdF0jhQ=="
+    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -1795,6 +1801,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1803,6 +1810,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2301,6 +2309,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2335,6 +2344,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2345,7 +2355,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2647,6 +2658,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2706,7 +2725,8 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -2771,6 +2791,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3742,6 +3763,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -4344,6 +4366,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6136,6 +6159,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6463,6 +6487,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6502,6 +6527,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7214,6 +7240,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7281,6 +7308,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -7291,23 +7319,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/yargs": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
-      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -7315,14 +7326,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/zoo-ids": {
@@ -8245,6 +8248,11 @@
         "@types/node": "*"
       }
     },
+    "@types/docopt": {
+      "version": "0.6.33",
+      "resolved": "https://registry.npmjs.org/@types/docopt/-/docopt-0.6.33.tgz",
+      "integrity": "sha512-FfbIS7UZwte9X1Vr6ENnwEnBOJSjQ0Cr+z1pGNvR4l+bs4U0i4NQIEeIsCvBcLoWmA5xuK1TXYJyZ9qRdF0jhQ=="
+    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -8667,12 +8675,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -9056,6 +9066,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -9083,6 +9094,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -9090,7 +9102,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -9341,6 +9354,11 @@
         "path-type": "^4.0.0"
       }
     },
+    "docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw=="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -9387,7 +9405,8 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -9436,7 +9455,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -10179,7 +10199,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -10585,7 +10606,8 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -11930,7 +11952,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "resolve": {
       "version": "1.22.0",
@@ -12167,6 +12190,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12197,6 +12221,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -12710,6 +12735,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12756,34 +12782,14 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "yargs": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
-      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "dependencies": {
-        "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
-        }
-      }
     },
     "yargs-parser": {
       "version": "20.2.9",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -5,7 +5,7 @@
   "main": "dist/server.js",
   "scripts": {
     "build": "tsc",
-    "serve": "node dist/server/server.js --config=../../config",
+    "serve": "node dist/server/server.js ../../config",
     "test": "jest -c jest.config.js",
     "integration-test": "jest -c jest.config.integration.js",
     "lint": "eslint src tests --ext .ts,.js",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -14,15 +14,16 @@
   },
   "bin": "./dist/server.js",
   "dependencies": {
+    "@types/docopt": "^0.6.33",
     "axios": "^0.27.2",
     "body-parser": "^1.20.0",
     "compression": "^1.7.4",
+    "docopt": "^0.6.2",
     "express": "^4.17.2",
     "hbs": "^4.2.0",
     "ioredis": "^5.2.2",
     "morgan": "^1.10.0",
     "uid": "^2.0.0",
-    "yargs": "^17.4.0",
     "zoo-ids": "^2.0.0"
   },
   "devDependencies": {

--- a/app/server/src/configReader.ts
+++ b/app/server/src/configReader.ts
@@ -3,9 +3,11 @@ import * as path from "path";
 
 export class ConfigReader {
     rootDir: string;
+    options: Object;
 
-    constructor(rootDir: string) {
+    constructor(rootDir: string, options: Object) {
         this.rootDir = rootDir;
+        this.options = options;
     }
 
     readConfigFile(...filePath: string[]): Object | null {
@@ -13,7 +15,7 @@ export class ConfigReader {
         const filename = path.join(...fullPath);
         if (fs.existsSync(filename)) {
             const configText = fs.readFileSync(filename, { encoding: "utf-8" });
-            return JSON.parse(configText);
+            return { ...JSON.parse(configText), ...this.options };
         }
         return null;
     }

--- a/app/server/src/configReader.ts
+++ b/app/server/src/configReader.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 
 export class ConfigReader {
     rootDir: string;
+
     overrides: Object;
 
     constructor(rootDir: string, overrides: Object = {}) {

--- a/app/server/src/configReader.ts
+++ b/app/server/src/configReader.ts
@@ -3,11 +3,11 @@ import * as path from "path";
 
 export class ConfigReader {
     rootDir: string;
-    options: Object;
+    overrides: Object;
 
-    constructor(rootDir: string, options: Object) {
+    constructor(rootDir: string, overrides: Object = {}) {
         this.rootDir = rootDir;
-        this.options = options;
+        this.overrides = overrides;
     }
 
     readConfigFile(...filePath: string[]): Object | null {
@@ -15,7 +15,7 @@ export class ConfigReader {
         const filename = path.join(...fullPath);
         if (fs.existsSync(filename)) {
             const configText = fs.readFileSync(filename, { encoding: "utf-8" });
-            return { ...JSON.parse(configText), ...this.options };
+            return { ...JSON.parse(configText), ...this.overrides };
         }
         return null;
     }

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -21,8 +21,8 @@ const parseArgInteger = (arg: string | null, name: string): Perhaps<number> => {
     if (!arg.match(/^[0-9]+$/)) {
         throw Error(`Expected an integer for ${name}`);
     }
-    return parseInt(arg);
-}
+    return parseInt(arg, 10);
+};
 
 export const processArgs = (argv: string[] = process.argv) => {
     const opts = docopt(doc, { argv: argv.slice(2), version, exit: false });

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -13,25 +13,23 @@ const { docopt } = require("docopt");
 
 type Option = string | undefined;
 
-const dropUndefined = (options: Record<string, Option>): Record<string, string> => {
-    return Object.fromEntries(options.entries.filter((o) => o !== undefined));
+const dropUndefined = (options: Record<string, Option>) => {
+    return Object.fromEntries(Object.entries(options).filter((o) => o !== undefined));
 }
 
 export const processArgs = (opts: any) => {
-    const configPath = path.resolve(opts["<path>"] as string);
-    const options = dropUndefined({
+    const path = opts["<path>"] as string;
+    const overrides = dropUndefined({
         baseUrl: opts["--base-url"] as Option,
         odinApi: opts["--odin-api"] as Option,
         redisUrl: opts["--redis-url"] as Option
     });
-    return { configPath, options };
+    return { path, overrides };
 }
 
 const options = processArgs(docopt(doc, { version }));
 
 console.log("Command line configuration");
-options.entries.forEach((entry) => {
-    console.log(`  * ${entry[0]}: ${entry[1]}`);
-});
+console.log(options);
 
 module.exports = { options };

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -8,8 +8,8 @@ Options:
   --redis-url=URL  Url to find Redis
 `;
 
-const { version } = require("../version");
 const { docopt } = require("docopt");
+const { version } = require("../version");
 
 type Option = string | null;
 
@@ -23,4 +23,4 @@ export const processArgs = (argv: string[] = process.argv) => {
     };
     const overrides = Object.fromEntries(Object.entries(given).filter((o) => o[1] !== null));
     return { path, overrides };
-}
+};

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -8,28 +8,19 @@ Options:
   --redis-url=URL  Url to find Redis
 `;
 
-const { version } = require("./version");
+const { version } = require("../version");
 const { docopt } = require("docopt");
 
-type Option = string | undefined;
+type Option = string | null;
 
-const dropUndefined = (options: Record<string, Option>) => {
-    return Object.fromEntries(Object.entries(options).filter((o) => o !== undefined));
-}
-
-export const processArgs = (opts: any) => {
+export const processArgs = (argv: string[] = process.argv) => {
+    const opts = docopt(doc, { argv: argv.slice(2), version, exit: false });
     const path = opts["<path>"] as string;
-    const overrides = dropUndefined({
+    const given = {
         baseUrl: opts["--base-url"] as Option,
         odinApi: opts["--odin-api"] as Option,
         redisUrl: opts["--redis-url"] as Option
-    });
+    };
+    const overrides = Object.fromEntries(Object.entries(given).filter((o) => o[1] !== null));
     return { path, overrides };
 }
-
-const options = processArgs(docopt(doc, { version }));
-
-console.log("Command line configuration");
-console.log(options);
-
-module.exports = { options };

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -1,14 +1,37 @@
-const yargs = require("yargs/yargs");
-const path = require("path");
-const { hideBin } = require("yargs/helpers");
+const doc = `
+Usage:
+  server [options] <path>
 
-const { argv } = yargs(hideBin(process.argv));
-const configPathGiven = argv.config;
-if (!configPathGiven) {
-    throw new Error("Please provide a 'config' argument specifying path to the config folder");
+Options:
+  --base-url=URL   Base url for app
+  --odin-api=URL   Url to find odin api
+  --redis-url=URL  Url to find Redis
+`;
+
+const { version } = require("./version");
+const { docopt } = require("docopt");
+
+type Option = string | undefined;
+
+const dropUndefined = (options: Record<string, Option>): Record<string, string> => {
+    return Object.fromEntries(options.entries.filter((o) => o !== undefined));
 }
-const configPath = path.resolve(configPathGiven);
 
-console.log(`Config path: ${configPathGiven} (${configPath})`);
+export const processArgs = (opts: any) => {
+    const configPath = path.resolve(opts["<path>"] as string);
+    const options = dropUndefined({
+        baseUrl: opts["--base-url"] as Option,
+        odinApi: opts["--odin-api"] as Option,
+        redisUrl: opts["--redis-url"] as Option
+    });
+    return { configPath, options };
+}
 
-module.exports = { configPath };
+const options = processArgs(docopt(doc, { version }));
+
+console.log("Command line configuration");
+options.entries.forEach((entry) => {
+    console.log(`  * ${entry[0]}: ${entry[1]}`);
+});
+
+module.exports = { options };

--- a/app/server/src/server/args.ts
+++ b/app/server/src/server/args.ts
@@ -6,20 +6,32 @@ Options:
   --base-url=URL   Base url for app
   --odin-api=URL   Url to find odin api
   --redis-url=URL  Url to find Redis
+  --port=PORT      Port to serve on
 `;
 
 const { docopt } = require("docopt");
 const { version } = require("../version");
 
-type Option = string | null;
+type Perhaps<T> = T | null;
+
+const parseArgInteger = (arg: string | null, name: string): Perhaps<number> => {
+    if (arg === null) {
+        return null;
+    }
+    if (!arg.match(/^[0-9]+$/)) {
+        throw Error(`Expected an integer for ${name}`);
+    }
+    return parseInt(arg);
+}
 
 export const processArgs = (argv: string[] = process.argv) => {
     const opts = docopt(doc, { argv: argv.slice(2), version, exit: false });
     const path = opts["<path>"] as string;
     const given = {
-        baseUrl: opts["--base-url"] as Option,
-        odinApi: opts["--odin-api"] as Option,
-        redisUrl: opts["--redis-url"] as Option
+        baseUrl: opts["--base-url"] as Perhaps<string>,
+        odinApi: opts["--odin-api"] as Perhaps<string>,
+        redisUrl: opts["--redis-url"] as Perhaps<string>,
+        port: parseArgInteger(opts["--port"], "port")
     };
     const overrides = Object.fromEntries(Object.entries(given).filter((o) => o[1] !== null));
     return { path, overrides };

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -9,6 +9,7 @@ import { handleError } from "../errors/handleError";
 import { initialiseLogging } from "../logging";
 import { redisConnection } from "../redis";
 import { version as wodinVersion } from "../version";
+import { processArgs } from "./args";
 
 const express = require("express");
 const path = require("path");
@@ -22,17 +23,17 @@ app.use(compression({ level: 9 })); // Use best compression
 const rootDir = path.resolve(path.join(__dirname, "../.."));
 
 // Get command line args
-const { options } = require("./args");
+const options = processArgs();
 
 // Global config
-const { configPath, overrides } = options;
-const configReader = new ConfigReader(configPath, overrides);
+const pathResolved = path.resolve(options.path);
+const configReader = new ConfigReader(pathResolved, options.overrides);
 const wodinConfig = configReader.readConfigFile("wodin.config.json") as WodinConfig;
 const {
     port, appsPath, baseUrl, odinAPI
 } = wodinConfig;
-const defaultCodeReader = new AppFileReader(`${configPath}/defaultCode`, "R");
-const appHelpReader = new AppFileReader(`${configPath}/help`, "md");
+const defaultCodeReader = new AppFileReader(`${options.path}/defaultCode`, "R");
+const appHelpReader = new AppFileReader(`${options.path}/help`, "md");
 
 const redis = redisConnection(
     wodinConfig.redisURL,
@@ -43,7 +44,7 @@ const redis = redisConnection(
 Object.assign(app.locals, {
     appsPath,
     baseUrl,
-    configPath,
+    configPath: options.path,
     configReader,
     defaultCodeReader,
     appHelpReader,
@@ -55,8 +56,8 @@ Object.assign(app.locals, {
 
 // Static content
 app.use(express.static(path.join(rootDir, "public")));
-app.use("/files", express.static(path.join(configPath, "files")));
-app.use("/help", express.static(path.join(configPath, "help")));
+app.use("/files", express.static(path.join(options.path, "files")));
+app.use("/help", express.static(path.join(options.path, "help")));
 
 // Views
 registerViews(app, rootDir);

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -28,6 +28,13 @@ const options = processArgs();
 // Global config
 const pathResolved = path.resolve(options.path);
 const configReader = new ConfigReader(pathResolved, options.overrides);
+
+console.log(`Reading config from ${pathResolved} (${options.path})`);
+if (Object.keys(options.overrides).length > 0) {
+    console.log("Applying configuration overrides:");
+    console.log(options.overrides);
+}
+
 const wodinConfig = configReader.readConfigFile("wodin.config.json") as WodinConfig;
 const {
     port, appsPath, baseUrl, odinAPI

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -25,7 +25,8 @@ const rootDir = path.resolve(path.join(__dirname, "../.."));
 const { options } = require("./args");
 
 // Global config
-const configReader = new ConfigReader(options);
+const { configPath, overrides } = options;
+const configReader = new ConfigReader(configPath, overrides);
 const wodinConfig = configReader.readConfigFile("wodin.config.json") as WodinConfig;
 const {
     port, appsPath, baseUrl, odinAPI

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -39,8 +39,8 @@ const wodinConfig = configReader.readConfigFile("wodin.config.json") as WodinCon
 const {
     port, appsPath, baseUrl, odinAPI
 } = wodinConfig;
-const defaultCodeReader = new AppFileReader(`${options.path}/defaultCode`, "R");
-const appHelpReader = new AppFileReader(`${options.path}/help`, "md");
+const defaultCodeReader = new AppFileReader(`${pathResolved}/defaultCode`, "R");
+const appHelpReader = new AppFileReader(`${pathResolved}/help`, "md");
 
 const redis = redisConnection(
     wodinConfig.redisURL,
@@ -51,7 +51,7 @@ const redis = redisConnection(
 Object.assign(app.locals, {
     appsPath,
     baseUrl,
-    configPath: options.path,
+    configPath: pathResolved,
     configReader,
     defaultCodeReader,
     appHelpReader,
@@ -63,8 +63,8 @@ Object.assign(app.locals, {
 
 // Static content
 app.use(express.static(path.join(rootDir, "public")));
-app.use("/files", express.static(path.join(options.path, "files")));
-app.use("/help", express.static(path.join(options.path, "help")));
+app.use("/files", express.static(path.join(pathResolved, "files")));
+app.use("/help", express.static(path.join(pathResolved, "help")));
 
 // Views
 registerViews(app, rootDir);

--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -22,10 +22,10 @@ app.use(compression({ level: 9 })); // Use best compression
 const rootDir = path.resolve(path.join(__dirname, "../.."));
 
 // Get command line args
-const { configPath } = require("./args");
+const { options } = require("./args");
 
 // Global config
-const configReader = new ConfigReader(configPath);
+const configReader = new ConfigReader(options);
 const wodinConfig = configReader.readConfigFile("wodin.config.json") as WodinConfig;
 const {
     port, appsPath, baseUrl, odinAPI

--- a/app/server/tests/server/args.test.ts
+++ b/app/server/tests/server/args.test.ts
@@ -23,12 +23,14 @@ describe("args", () => {
         const argv = ["node", "/wodinPath",
             "--base-url", "http://example.com/wodin",
             "--redis-url=redis:6379",
+            "--port=1234",
             "/testConfig"];
         const args = processArgs(argv);
         expect(args.path).toBe("/testConfig");
         expect(args.overrides).toStrictEqual({
             baseUrl: "http://example.com/wodin",
-            redisUrl: "redis:6379"
+            redisUrl: "redis:6379",
+            port: 1234
         });
     });
 
@@ -39,5 +41,10 @@ describe("args", () => {
         expect(args.overrides).toStrictEqual({
             odinApi: "api"
         });
+    });
+
+    it("requires that port is an integer", () => {
+        process.argv = ["node", "wodin", "--port=one", "somepath"];
+        expect(() => processArgs()).toThrow("Expected an integer for port");
     });
 });

--- a/app/server/tests/server/args.test.ts
+++ b/app/server/tests/server/args.test.ts
@@ -8,12 +8,12 @@ describe("args", () => {
 
     it("throws error if no config path arg", () => {
         const argv = ["node", "/wodinPath"];
-        expect(() => { processArgs(argv) })
+        expect(() => { processArgs(argv); })
             .toThrow("Usage:");
     });
 
     it("returns config path arg", () => {
-        const argv = process.argv = ["node", "/wodinPath", "/testConfig"];
+        const argv = ["node", "/wodinPath", "/testConfig"];
         const args = processArgs(argv);
         expect(args.path).toBe("/testConfig");
         expect(args.overrides).toStrictEqual({});
@@ -21,9 +21,9 @@ describe("args", () => {
 
     it("collects overrides", () => {
         const argv = ["node", "/wodinPath",
-                      "--base-url", "http://example.com/wodin",
-                      "--redis-url=redis:6379",
-                      "/testConfig"];
+            "--base-url", "http://example.com/wodin",
+            "--redis-url=redis:6379",
+            "/testConfig"];
         const args = processArgs(argv);
         expect(args.path).toBe("/testConfig");
         expect(args.overrides).toStrictEqual({
@@ -39,5 +39,5 @@ describe("args", () => {
         expect(args.overrides).toStrictEqual({
             odinApi: "api"
         });
-    })
+    });
 });

--- a/docker/browser_tests
+++ b/docker/browser_tests
@@ -23,7 +23,7 @@ remove_containers
 
 ## main app
 docker pull $TAG_SHA
-docker run --rm -d --name wodin --network=host $TAG_SHA
+docker run --rm -d --name wodin --network=host $TAG_SHA /wodin/config
 
 ## run the tests
 docker run --rm --name wodin-playwright --network=host \

--- a/docker/wodin
+++ b/docker/wodin
@@ -1,10 +1,2 @@
 #!/usr/bin/env bash
-if [ "$#" -eq 0 ]; then
-    CONFIG=/wodin/config
-elif [ "$#" -eq 1 ]; then
-    CONFIG=$1
-else
-    echo "Usage wodin [<config.json>]"
-    exit 1
-fi
-node /wodin/app/server/dist/server/server.js --config $CONFIG
+node /wodin/app/server/dist/server/server.js $*


### PR DESCRIPTION
This PR reworks the command line processing to allow overriding of elements in config. I've swapped out `yargs` for `docopt` because we use that elsewhere and it's generally ok. I've also reworked `args.ts` to be side-effect free and fall back on `process.argv` using the same pattern we do in R packages.

The only usage difference is that `--config=path` becomes the positional argument `path`, with this change made as it's required and this is more conventional. I can roll that back easily enough if needed.

Once this is merged there may be some small tweaks required to deployment scripts, but anything using docker will work out the box