### PR TITLE
Fix url used to control redis server

### DIFF
--- a/app/server/src/server/server.ts
+++ b/app/server/src/server/server.ts
@@ -43,8 +43,8 @@ const defaultCodeReader = new AppFileReader(`${pathResolved}/defaultCode`, "R");
 const appHelpReader = new AppFileReader(`${pathResolved}/help`, "md");
 
 const redis = redisConnection(
-    wodinConfig.redisURL,
-    () => { throw Error(`Failed to connect to redis server ${wodinConfig.redisURL}`); }
+    wodinConfig.redisUrl,
+    () => { throw Error(`Failed to connect to redis server ${wodinConfig.redisUrl}`); }
 );
 
 // Make app locals available to controllers

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -8,7 +8,7 @@ export interface WodinConfig {
     port: number,
     baseUrl: string,
     odinAPI: string,
-    redisURL: string,
+    redisUrl: string,
     appsPath: string
 }
 

--- a/config/wodin.config.json
+++ b/config/wodin.config.json
@@ -5,5 +5,5 @@
     "appsPath": "apps",
     "baseUrl": "http://localhost:3000",
     "odinAPI": "http://localhost:8001",
-    "redisURL": "redis://localhost:6379"
+    "redisUrl": "redis://localhost:6379"
 }


### PR DESCRIPTION
We had redisURL and baseUrl floating around, all very confusing. 

We'll have to update some configurations after merge, but deploy is broken anyway (I know why).

This is seen working in the wodin-proxy PR: https://github.com/mrc-ide/wodin-proxy/pull/1