### PR TITLE
mrc-3906 Only show code tab content when app is configured

### DIFF
--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="code-tab">
+    <div v-if="appIsConfigured" class="code-tab">
         <code-editor/>
         <button class="btn btn-primary mt-2" id="compile-btn" :disabled="!codeIsValid" @click="compile">Compile</button>
         <div class="mt-2" id="code-status">
@@ -45,9 +45,11 @@ export default defineComponent({
         const iconClass = computed(() => (codeIsValid.value ? "text-success" : "text-danger"));
         const allVariables = computed<string[]>(() => store.state.model.odinModelResponse?.metadata?.variables || []);
         const showSelectedVariables = computed(() => allVariables.value.length && !store.state.model.compileRequired);
+        const appIsConfigured = computed(() => store.state.configured);
         const compile = () => store.dispatch(`model/${ModelAction.CompileModel}`);
 
         return {
+            appIsConfigured,
             codeIsValid,
             validMsg,
             validIcon,

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -55,7 +55,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
 
         if (response) {
             if (loadSessionId) {
-                // Fetch and rehydrate session datas
+                // Fetch and rehydrate session data
                 await dispatch(`sessions/${SessionsAction.Rehydrate}`, loadSessionId);
             } else {
                 await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, { root: true });
@@ -64,6 +64,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                 if (response.data.endTime) {
                     commit(`run/${RunMutation.SetEndTime}`, response.data.endTime, { root: true });
                 }
+                commit(AppStateMutation.SetConfigured);
                 if (state.code.currentCode.length) {
                     // Fetch and run model for default code
                     await dispatch(`model/${ModelAction.DefaultModel}`);

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -11,7 +11,6 @@ export enum AppStateMutation {
     SetQueuedStateUpload = "SetQueuedStateUpload",
     SetStateUploadInProgress = "SetStateUploadInProgress",
     SetSessionLabel = "SetSessionLabel",
-
     SetConfigured = "SetConfigured"
 }
 

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -10,7 +10,9 @@ export enum AppStateMutation {
     ClearQueuedStateUpload = "ClearQueuedStateUpload",
     SetQueuedStateUpload = "SetQueuedStateUpload",
     SetStateUploadInProgress = "SetStateUploadInProgress",
-    SetSessionLabel = "SetSessionLabel"
+    SetSessionLabel = "SetSessionLabel",
+
+    SetConfigured = "SetConfigured"
 }
 
 export const StateUploadMutations = [
@@ -49,5 +51,9 @@ export const appStateMutations: MutationTree<AppState> = {
 
     [AppStateMutation.SetSessionLabel](state: AppState, payload: null | string) {
         state.sessionLabel = payload;
+    },
+
+    [AppStateMutation.SetConfigured](state: AppState) {
+        state.configured = true;
     }
 };

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -34,5 +34,6 @@ export interface AppState {
     run: RunState
     sensitivity: SensitivityState,
     graphSettings: GraphSettingsState,
-    versions: VersionsState
+    versions: VersionsState,
+    configured: boolean // true if configuration has been loaded or rehydrated and defaults set
 }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -27,7 +27,8 @@ const defaultState: () => any = () => {
         appsPath: null,
         config: null,
         queuedStateUploadIntervalId: -1,
-        stateUploadInProgress: false
+        stateUploadInProgress: false,
+        configured: false
     };
 };
 

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -29,7 +29,8 @@ const defaultState: () => any = () => {
         appsPath: null,
         config: null,
         queuedStateUploadIntervalId: -1,
-        stateUploadInProgress: false
+        stateUploadInProgress: false,
+        configured: false
     };
 };
 

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -40,7 +40,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
     },
 
     async [SessionsAction.Rehydrate](context, sessionId: string) {
-        const { rootState, dispatch } = context;
+        const { rootState, commit, dispatch } = context;
         const { appName, appsPath } = rootState;
         const url = `/${appsPath}/${appName}/sessions/${sessionId}`;
         const response = await api(context)
@@ -52,6 +52,7 @@ export const actions: ActionTree<SessionsState, AppState> = {
             const sessionData = response.data as SerialisedAppState;
 
             deserialiseState(rootState, sessionData);
+            commit(AppStateMutation.SetConfigured, null, { root: true });
 
             const rootOption = { root: true };
             await dispatch(`model/${ModelAction.FetchOdinRunner}`, null, rootOption);

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -27,7 +27,8 @@ const defaultState: () => any = () => {
         appsPath: null,
         config: null,
         queuedStateUploadIntervalId: -1,
-        stateUploadInProgress: false
+        stateUploadInProgress: false,
+        configured: false
     };
 };
 

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -168,6 +168,7 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
         sensitivity: mockSensitivityState(),
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
+        configured: false,
         ...state
     };
 };
@@ -215,6 +216,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         modelFit: mockModelFitState(),
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
+        configured: false,
         ...state
     };
 };
@@ -240,6 +242,7 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
         sensitivity: mockSensitivityState(),
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
+        configured: false,
         ...state
     };
 };

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -31,7 +31,7 @@ import { AppConfig } from "../../../../src/app/types/responseTypes";
 
 describe("BasicApp", () => {
     const getWrapper = (mockSetOpenVisualisationTab = jest.fn(), config: Partial<AppConfig> = {}) => {
-        const state = mockBasicState({ config: config as any });
+        const state = mockBasicState({ config: config as any, configured: true });
 
         const store = new Vuex.Store<BasicState>({
             state,

--- a/app/static/tests/unit/components/code/codeTab.test.ts
+++ b/app/static/tests/unit/components/code/codeTab.test.ts
@@ -29,7 +29,9 @@ describe("CodeTab", () => {
 
     const getWrapper = (odinModelState: Partial<ModelState> = defaultModelState) => {
         const store = new Vuex.Store<BasicState>({
-            state: mockBasicState(),
+            state: mockBasicState({
+                configured: true
+            }),
             modules: {
                 model: {
                     namespaced: true,
@@ -105,5 +107,18 @@ describe("CodeTab", () => {
             compileRequired: true
         });
         expect(wrapper.findComponent(VerticalCollapse).exists()).toBe(false);
+    });
+
+    it("renders nothing when app state is not configured", () => {
+        const store = new Vuex.Store<BasicState>({
+            state: mockBasicState()
+        });
+
+        const wrapper = shallowMount(CodeTab, {
+            global: {
+                plugins: [store]
+            }
+        });
+        expect(wrapper.findAll("div").length).toBe(0);
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -193,7 +193,8 @@ describe("serialise", () => {
         run: runState,
         sensitivity: sensitivityState,
         versions: { versions: null },
-        graphSettings: { logScaleYAxis: true }
+        graphSettings: { logScaleYAxis: true },
+        configured: false
     };
 
     const fitState: FitState = {
@@ -214,7 +215,8 @@ describe("serialise", () => {
         fitData: fitDataState,
         modelFit: modelFitState,
         versions: { versions: null },
-        graphSettings: { logScaleYAxis: true }
+        graphSettings: { logScaleYAxis: true },
+        configured: false
     };
 
     const expectedCode = { currentCode: ["some code"] };

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -71,7 +71,7 @@ describe("AppState actions", () => {
         await (appStateActions[AppStateAction.Initialise] as any)({
             commit, state, dispatch, rootState, getters
         }, payload);
-        expect(commit.mock.calls.length).toBe(4);
+        expect(commit.mock.calls.length).toBe(5);
 
         expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetApp);
         expect(commit.mock.calls[0][1]).toStrictEqual({ appName: "test-app", baseUrl, appsPath });
@@ -86,6 +86,8 @@ describe("AppState actions", () => {
 
         expect(commit.mock.calls[3][0]).toBe(`run/${RunMutation.SetEndTime}`);
         expect(commit.mock.calls[3][1]).toStrictEqual(101);
+
+        expect(commit.mock.calls[4][0]).toBe(AppStateMutation.SetConfigured);
 
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
@@ -114,11 +116,12 @@ describe("AppState actions", () => {
         await (appStateActions[AppStateAction.Initialise] as any)({
             commit, state, dispatch, rootState, getters
         }, payload);
-        expect(commit.mock.calls.length).toBe(3);
+        expect(commit.mock.calls.length).toBe(4);
 
         expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetApp);
         expect(commit.mock.calls[1][0]).toBe(AppStateMutation.SetConfig);
         expect(commit.mock.calls[2][0]).toBe(`code/${CodeMutation.SetCurrentCode}`);
+        expect(commit.mock.calls[3][0]).toBe(AppStateMutation.SetConfigured);
     });
 
     it("Initialise fetches config, commits any default and fetches runner, if no loadSessionId", async () => {
@@ -141,7 +144,7 @@ describe("AppState actions", () => {
         await (appStateActions[AppStateAction.Initialise] as any)({
             commit, state, dispatch, rootState, getters
         }, payload);
-        expect(commit.mock.calls.length).toBe(4);
+        expect(commit.mock.calls.length).toBe(5);
 
         expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetApp);
         expect(commit.mock.calls[1][0]).toBe(AppStateMutation.SetConfig);
@@ -151,6 +154,8 @@ describe("AppState actions", () => {
 
         expect(commit.mock.calls[3][0]).toBe(`run/${RunMutation.SetEndTime}`);
         expect(commit.mock.calls[3][1]).toStrictEqual(101);
+
+        expect(commit.mock.calls[4][0]).toBe(AppStateMutation.SetConfigured);
 
         expect(dispatch).toHaveBeenCalledTimes(2);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);

--- a/app/static/tests/unit/store/appState/mutations.test.ts
+++ b/app/static/tests/unit/store/appState/mutations.test.ts
@@ -48,4 +48,10 @@ describe("AppState mutations", () => {
         appStateMutations.SetSessionLabel(state, "new session label");
         expect(state.sessionLabel).toBe("new session label");
     });
+
+    it("sets configured", () => {
+        const state = mockBasicState();
+        appStateMutations.SetConfigured(state);
+        expect(state.configured).toBe(true);
+    });
 });

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -60,7 +60,8 @@ describe("SessionsActions", () => {
         const rootState = { appName: "testApp", baseUrl: "", appsPath: "apps" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
         expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
-        expect(commit).toHaveBeenCalledTimes(0);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetConfigured);
         expect(dispatch).toHaveBeenCalledTimes(4);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
@@ -94,7 +95,8 @@ describe("SessionsActions", () => {
         const rootState = { appName: "testApp", baseUrl: "", appsPath: "apps" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
         expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
-        expect(commit).toHaveBeenCalledTimes(0);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetConfigured);
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
@@ -111,7 +113,8 @@ describe("SessionsActions", () => {
         const rootState = { appName: "testApp", baseUrl: "", appsPath: "apps" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
         expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
-        expect(commit).toHaveBeenCalledTimes(0);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetConfigured);
         expect(dispatch).toHaveBeenCalledTimes(1);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
@@ -128,7 +131,8 @@ describe("SessionsActions", () => {
         const rootState = { appName: "testApp", baseUrl: "", appsPath: "apps" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
         expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
-        expect(commit).toHaveBeenCalledTimes(0);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetConfigured);
         expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);
@@ -151,7 +155,8 @@ describe("SessionsActions", () => {
         const rootState = { appName: "testApp", baseUrl: "", appsPath: "apps" } as any;
         await (actions[SessionsAction.Rehydrate] as any)({ commit, dispatch, rootState }, "1234");
         expect(rootState.code.currentCode).toStrictEqual(["some saved code"]);
-        expect(commit).toHaveBeenCalledTimes(0);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(AppStateMutation.SetConfigured);
         expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch.mock.calls[0][0]).toBe(`model/${ModelAction.FetchOdinRunner}`);
         expect(dispatch.mock.calls[0][1]).toBe(null);


### PR DESCRIPTION
I'm prettty sure the bug with code not always showing in the editor was happening because the editor component  was sometimes loading before default code had been fetched with the app config, so the editor was getting initialised with empty code. Could have put something in to allow the editor to accept code changes from the state after being loaded but that would have needed to check difference from current value (to avoid infinite update loop) which could have got sticky interacting with the pending changes etc. So instead I've just introduced a 'configured' flag to the state which gets set when config and defaults are loaded.  Code editor is not displayed until app is configured. 

I haven't seen the bug recur after putting in this change, but of course, it's intermittent.. 