### PR TITLE
Add bash script to update sources

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 RUN apt-get update \
         && apt-get install -y --no-install-recommends ca-certificates curl \
         && curl -sL https://deb.nodesource.com/setup_16.x | bash \
-        && apt-get install -y nodejs
+        && apt-get install -y git nodejs
 
 COPY . /wodin
 RUN /wodin/scripts/build.sh && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,5 +6,6 @@ RUN apt-get update \
         && apt-get install -y nodejs
 
 COPY . /wodin
-RUN /wodin/scripts/build.sh
+RUN /wodin/scripts/build.sh && \
+        cp ./wodin/docker/update-site /usr/local/bin
 ENTRYPOINT ["/wodin/docker/wodin"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update \
 
 COPY . /wodin
 RUN /wodin/scripts/build.sh && \
-        cp ./wodin/docker/update-site /usr/local/bin
+        cp ./wodin/docker/update-site ./wodin/docker/update-sites /usr/local/bin
 ENTRYPOINT ["/wodin/docker/wodin"]

--- a/docker/update-site
+++ b/docker/update-site
@@ -13,6 +13,9 @@ mkdir -p $REPO_PATH
 if [[ ! -d $REPO_PATH/.git ]]; then
     echo "Cloning $REPO_PATH from $REPO_URL"
     git clone $REPO_URL $REPO_PATH
+    REPO_DEFAULT_BRANCH=$(git -C $REPO_PATH rev-parse --abbrev-ref HEAD)
+    git -C $REPO_PATH checkout --detach
+    git -C $REPO_PATH branch -d $REPO_DEFAULT_BRANCH
 else
     echo "Updating $REPO_PATH from $REPO_URL"
     git -C $REPO_PATH fetch

--- a/docker/update-site
+++ b/docker/update-site
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eu
+if [[ $# != 3 ]]; then
+    echo "Usage: $0 <path> <url> <ref>"
+    exit 1
+fi
+
+REPO_PATH=$1
+REPO_URL=$2
+REPO_REF=$3
+
+mkdir -p $REPO_PATH
+if [[ ! -d $REPO_PATH/.git ]]; then
+    echo "Cloning $REPO_PATH from $REPO_URL"
+    git clone $REPO_URL $REPO_PATH
+else
+    echo "Updating $REPO_PATH from $REPO_URL"
+    git -C $REPO_PATH fetch
+fi
+
+## The hard bit is converting the reference into a sensible format
+##
+## We could have a branch, in which case we want the *remote* copy of
+## the branch. We can get that with
+##
+##   git show-ref origin/main
+##
+##   git rev-parse origin/main => b50c264eac9a03e8e18d17c41620c73c99b2219f
+##   git rev-parse b50c264 => b50c264eac9a03e8e18d17c41620c73c99b2219f
+##   git rev-parse v1.2.3 => b50c264eac9a03e8e18d17c41620c73c99b2219f
+##
+## So the main issue is that if we have a branch name we need to add
+## origin/ in front of it.
+##
+## Just try and resolve something as a remote branch and then fall
+## back on the reference directly, die noisily if we can't do it.
+REPO_REF_RESOLVED=
+set +e
+echo "...trying to resolve $REPO_REF as remote branch name 'origin/$REPO_REF'"
+REPO_REF_TMP=$(git -C $REPO_PATH rev-parse "origin/$REPO_REF" 2> /dev/null)
+if [[ $? -ne 0 ]]; then
+    echo "...trying to resolve $REPO_REF directly"
+    REPO_REF_TMP=$(git -C $REPO_PATH rev-parse "$REPO_REF" 2> /dev/null)
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to resolve reference $REPO_REF :("
+        exit 1
+    fi
+fi
+echo "Reference resolved as $REPO_REF_TMP"
+set -e
+REPO_REF_RESOLVED=$REPO_REF_TMP
+
+git -C $REPO_PATH reset --hard $REPO_REF_TMP

--- a/docker/update-sites
+++ b/docker/update-sites
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+if [[ $# -eq 0 ]]; then
+    echo "No args given"
+    exit 1
+elif (( $# % 3 != 0 )); then
+    echo "Invalid number given"
+    exit 1
+fi
+
+echo "Updating $(( $# / 3 )) sites"
+
+while [[ $# -ne 0 ]]; do
+    update-site $1 $2 $3
+    shift 3
+done


### PR DESCRIPTION
I know I said we might do this with node on the server, but this is probably enough for now as a little bash script.

The only really hairy bit is trying to resolve the reference argument nicely. If it's a branch name it's important that we match the remote one, not the locally checked out sources (so main is really origin/main). However, if the user has provided a hash or a tag then we need to match the tag directly. I don't think there's as way of saying "resolve this reference like the remote would" because that would simplify things. There may be an entirely different way of doing this aside from rev-parse but who knows.

Once we have the reference, we do a hard reset on the repo, which just says "get here, I don't care how". To keep this all tidy, I've deleted the default branch from the checked out copy (and forced it into detached HEAD state) so that it's pretty clear what is going on. This is not wildly different to what submodules do.

The point of all this shenanigans is that in the deploy tool/scripts we can use 

```bash
#          volume, later mounted into wodin to run things
#          vvvvvvvvvvvvvvvvvvvvvvv
docker run -v wodin-config:/config --entrypoint=update-site wodin:main \
       https://github.com/mrc-ide/wodin-msc-idm-2022 /config/demo main
#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^ ^^^^
#      url                                           dest         ref
```

and call that once per site within the config to update things before the first deploy, or equally to update things later

I've added a pluralised helper version that will take multiples of 3 args, same strategy as above but one after another, and will update everything in one docker run

Note that this does drag git into the docker image, that feels fairly harmless though.