### PR TITLE
mrc-3256 Hide/show parameter set traces

### DIFF
--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -5,9 +5,15 @@
       {{parameterSet.name}}
       <span class="float-end">
         <vue-feather class="inline-icon clickable hide-param-set"
-                     :type="parameterSet.hidden ? 'eye' : 'eye-off'"
+                     v-if="!parameterSet.hidden"
+                     type="eye-off"
                      @click="toggleHidden"
-                     v-tooltip="parameterSet.hidden ? 'Show Parameter Set' : 'Hide Parameter Set'"></vue-feather>
+                     v-tooltip="'Hide Parameter Set'"></vue-feather>
+        <vue-feather class="inline-icon clickable hide-param-set"
+                     v-if="parameterSet.hidden"
+                     type="eye"
+                     @click="toggleHidden"
+                     v-tooltip="'Show Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"
                      type="trash-2"
                      @click="deleteParameterSet"

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -9,7 +9,7 @@
                      type="eye-off"
                      @click="toggleHidden"
                      v-tooltip="'Hide Parameter Set'"></vue-feather>
-        <vue-feather class="inline-icon clickable hide-param-set"
+        <vue-feather class="inline-icon clickable show-param-set"
                      v-if="parameterSet.hidden"
                      type="eye"
                      @click="toggleHidden"

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -4,12 +4,17 @@
     <div class="card-header">
       {{parameterSet.name}}
       <span class="float-end">
-        <vue-feather class="inline-icon clickable delete-param-set"
-                     type="trash-2" @click="deleteParameterSet"
+        <vue-feather class="inline-icon clickable hide-param-set"
+                     :type="parameterSet.hidden ? 'eye' : 'eye-off'"
+                     @click="toggleHidden"
+                     v-tooltip="parameterSet.hidden ? 'Show Parameter Set' : 'Hide Parameter Set'"></vue-feather>
+        <vue-feather class="inline-icon clickable delete-param-set ms-2"
+                     type="trash-2"
+                     @click="deleteParameterSet"
                      v-tooltip="'Delete Parameter Set'"></vue-feather>
       </span>
     </div>
-    <div class="card-body">
+    <div class="card-body" :class="parameterSet.hidden ? 'hidden-parameter-set' : ''">
        <span v-for="(value, name) in parameterSet.parameterValues"
              :key="name"
              class="badge badge-light me-2 mb-2 parameter"
@@ -27,6 +32,7 @@ import { useStore } from "vuex";
 import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
+import {RunMutation} from "../../store/run/mutations";
 
 export default defineComponent({
     name: "ParameterSetView",
@@ -61,9 +67,14 @@ export default defineComponent({
             store.dispatch(`run/${RunAction.DeleteParameterSet}`, props.parameterSet.name);
         };
 
+        const toggleHidden = () => {
+            store.commit(`run/${RunMutation.ToggleParameterSetHidden}`, props.parameterSet.name);
+        };
+
         return {
             getStyle,
-            deleteParameterSet
+            deleteParameterSet,
+            toggleHidden
         };
     }
 });

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -38,7 +38,7 @@ import { useStore } from "vuex";
 import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
-import {RunMutation} from "../../store/run/mutations";
+import { RunMutation } from "../../store/run/mutations";
 
 export default defineComponent({
     name: "ParameterSetView",

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -35,11 +35,13 @@ export default defineComponent({
         const store = useStore();
 
         const solution = computed(() => (store.state.run.resultOde?.solution));
+        const visibleParameterSetNames = computed(() => store.getters[`run/${RunGetter.visibleParameterSetNames}`]);
+
         const parameterSetSolutions = computed(() => {
             const result = {} as Dict<OdinSolution>;
             Object.keys(store.state.run.parameterSetResults).forEach((name) => {
                 const sln = store.state.run.parameterSetResults[name].solution;
-                if (sln) {
+                if (sln && visibleParameterSetNames.value.includes(name)) {
                     result[name] = sln;
                 }
             });

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -41,10 +41,14 @@ export default defineComponent({
 
         const solutions = computed(() => (store.state.sensitivity.result?.batch?.solutions || []));
 
+        const visibleParameterSetNames = computed(() => store.getters[`run/${RunGetter.visibleParameterSetNames}`]);
+
         const parameterSetBatches = computed(() => {
             const result = {} as Dict<Batch>;
             Object.keys(store.state.sensitivity.parameterSetResults).forEach((name) => {
-                result[name] = store.state.sensitivity.parameterSetResults[name].batch;
+                if (visibleParameterSetNames.value.includes(name)) {
+                    result[name] = store.state.sensitivity.parameterSetResults[name].batch;
+                }
             });
             return result;
         });

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -1,18 +1,30 @@
 import { Tooltip } from "bootstrap";
 import { DirectiveBinding } from "vue";
 
+const disposeTooltip = (el: HTMLElement) => {
+    const tooltip = Tooltip.getInstance(el);
+    if (tooltip) {
+        tooltip.dispose();
+    }
+};
+
+const setTooltip = (el: HTMLElement, binding: DirectiveBinding<string>) => {
+    const { value } = binding;
+    el.setAttribute("title", value);
+    // eslint-disable-next-line no-new
+    new Tooltip(el);
+};
+
 export default {
     beforeMount(el: HTMLElement, binding: DirectiveBinding<string>) {
-        const { value } = binding;
         el.setAttribute("data-bs-toggle", "tooltip");
-        el.setAttribute("title", value);
-        // eslint-disable-next-line no-new
-        new Tooltip(el);
+        setTooltip(el, binding);
     },
     beforeUnmount(el: HTMLElement) {
-        const tooltip = Tooltip.getInstance(el);
-        if (tooltip) {
-            tooltip.dispose();
-        }
+        disposeTooltip(el);
+    },
+    updated(el: HTMLElement, binding: DirectiveBinding<string>) {
+        disposeTooltip(el);
+        setTooltip(el, binding);
     }
 };

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -16,4 +16,3 @@ export default {
         }
     }
 };
-

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -23,6 +23,8 @@ export default {
     beforeUnmount(el: HTMLElement) {
         disposeTooltip(el);
     },
+    // TODO: This is flaky! :(
+    // Needs to be async?
     updated(el: HTMLElement, binding: DirectiveBinding<string>) {
         disposeTooltip(el);
         setTooltip(el, binding);

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -1,32 +1,19 @@
 import { Tooltip } from "bootstrap";
 import { DirectiveBinding } from "vue";
 
-const disposeTooltip = (el: HTMLElement) => {
-    const tooltip = Tooltip.getInstance(el);
-    if (tooltip) {
-        tooltip.dispose();
-    }
-};
-
-const setTooltip = (el: HTMLElement, binding: DirectiveBinding<string>) => {
-    const { value } = binding;
-    el.setAttribute("title", value);
-    // eslint-disable-next-line no-new
-    new Tooltip(el);
-};
-
 export default {
     beforeMount(el: HTMLElement, binding: DirectiveBinding<string>) {
+        const { value } = binding;
         el.setAttribute("data-bs-toggle", "tooltip");
-        setTooltip(el, binding);
+        el.setAttribute("title", value);
+        // eslint-disable-next-line no-new
+        new Tooltip(el);
     },
     beforeUnmount(el: HTMLElement) {
-        disposeTooltip(el);
-    },
-    // TODO: This is flaky! :(
-    // Needs to be async?
-    updated(el: HTMLElement, binding: DirectiveBinding<string>) {
-        disposeTooltip(el);
-        setTooltip(el, binding);
+        const tooltip = Tooltip.getInstance(el);
+        if (tooltip) {
+            tooltip.dispose();
+        }
     }
 };
+

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -148,7 +148,8 @@ export const actions: ActionTree<RunState, AppState> = {
             const name = `Set ${state.parameterSets.length + 1}`; // This will not be reliable when we add set deletion!
             const parameterSet = {
                 name,
-                parameterValues: { ...state.parameterValues }
+                parameterValues: { ...state.parameterValues },
+                hidden: false
             };
             commit(RunMutation.AddParameterSet, parameterSet);
 

--- a/app/static/src/app/store/run/getters.ts
+++ b/app/static/src/app/store/run/getters.ts
@@ -8,7 +8,8 @@ import { anyTrue } from "../../utils";
 export enum RunGetter {
     lineStylesForParameterSets = "lineStylesForParameterSets",
     runIsRequired = "runIsRequired",
-    runParameterSetsIsRequired = "runParameterSetsIsRequired"
+    runParameterSetsIsRequired = "runParameterSetsIsRequired",
+    visibleParameterSetNames = "visibleParameterSetNames"
 }
 
 export interface RunGetters {
@@ -35,5 +36,9 @@ export const getters: RunGetters & GetterTree<RunState, AppState> = {
         // an update required for any reason except parameterValueChanged (e.g. endTime has changed)
         const missingSetResults = parameterSets.some((ps: ParameterSet) => !parameterSetResults[ps.name]?.solution);
         return missingSetResults || anyTrue({ ...state.runRequired, parameterValueChanged: false });
+    },
+    [RunGetter.visibleParameterSetNames]: (state: RunState): string[] => {
+        // gets the names of all parameter sets which are not hidden
+        return state.parameterSets.filter((set) => !set.hidden).map((set) => set.name);
     }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -16,7 +16,8 @@ export enum RunMutation {
     SetNumberOfReplicates = "SetNumberOfReplicates",
     SetParameterSetResult = "SetParameterSetResult",
     AddParameterSet = "AddParameterSet",
-    DeleteParameterSet = "DeleteParameterSet"
+    DeleteParameterSet = "DeleteParameterSet",
+    ToggleParameterSetHidden = "TogglParameterSetHidden"
 }
 
 const runRequiredNone = {
@@ -98,5 +99,12 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.DeleteParameterSet](state: RunState, parameterSetName: string) {
         state.parameterSets = state.parameterSets.filter((set: ParameterSet) => set.name !== parameterSetName);
         delete state.parameterSetResults[parameterSetName];
+    },
+
+    [RunMutation.ToggleParameterSetHidden](state: RunState, parameterSetName: string) {
+        const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
+        if (paramSet) {
+            paramSet.hidden = !paramSet.hidden;
+        }
     }
 };

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -17,7 +17,7 @@ export enum RunMutation {
     SetParameterSetResult = "SetParameterSetResult",
     AddParameterSet = "AddParameterSet",
     DeleteParameterSet = "DeleteParameterSet",
-    ToggleParameterSetHidden = "TogglParameterSetHidden"
+    ToggleParameterSetHidden = "ToggleParameterSetHidden"
 }
 
 const runRequiredNone = {

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -11,7 +11,8 @@ export interface RunUpdateRequiredReasons {
 
 export interface ParameterSet {
     name: string,
-    parameterValues: OdinUserType
+    parameterValues: OdinUserType,
+    hidden: boolean
 }
 
 export interface RunState {

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -71,3 +71,7 @@ $grey: #ccc;
 .clickable {
   cursor: pointer;
 }
+
+.hidden-parameter-set {
+  background-color: $light-grey;
+}

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -240,7 +240,7 @@ test.describe("Options Tab tests", () => {
         await expectSummaryValues(page, 2, "I", 1000, "#cccc00");
         await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
 
-        await page.click(".hide-param-set");
+        await page.click(".show-param-set");
         await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
         await expectSummaryValues(page, 4, "S (Set 1)", 1000, "#2e5cb8", "dot");
         await expectSummaryValues(page, 5, "I (Set 1)", 1000, "#cccc00", "dot");

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -228,4 +228,22 @@ test.describe("Options Tab tests", () => {
         await expectSummaryValues(page, 2, "I", 1000, "#cccc00");
         await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
     });
+
+    test("can hide and show a parameter set", async ({page}) => {
+        await page.click("#create-param-set");
+        await page.click("#run-btn");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
+
+        await page.click(".hide-param-set");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(3, { timeout });
+        await expectSummaryValues(page, 1, "S", 1000, "#2e5cb8");
+        await expectSummaryValues(page, 2, "I", 1000, "#cccc00");
+        await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
+
+        await page.click(".hide-param-set");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
+        await expectSummaryValues(page, 4, "S (Set 1)", 1000, "#2e5cb8", "dot");
+        await expectSummaryValues(page, 5, "I (Set 1)", 1000, "#cccc00", "dot");
+        await expectSummaryValues(page, 6, "R (Set 1)", 1000, "#cc0044", "dot");
+    });
 });

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -229,7 +229,7 @@ test.describe("Options Tab tests", () => {
         await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
     });
 
-    test("can hide and show a parameter set", async ({page}) => {
+    test("can hide and show a parameter set", async ({ page }) => {
         await page.click("#create-param-set");
         await page.click("#run-btn");
         await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -5,7 +5,7 @@ import { BasicState } from "../../../../src/app/store/basic/state";
 import { mockBasicState, mockRunState } from "../../../mocks";
 import ParameterSetView from "../../../../src/app/components/options/ParameterSetView.vue";
 import { RunAction } from "../../../../src/app/store/run/actions";
-import {RunMutation} from "../../../../src/app/store/run/mutations";
+import { RunMutation } from "../../../../src/app/store/run/mutations";
 
 describe("ParameterSetView", () => {
     const mockDeleteParameterSet = jest.fn();

--- a/app/static/tests/unit/components/options/parameterSets.test.ts
+++ b/app/static/tests/unit/components/options/parameterSets.test.ts
@@ -41,8 +41,8 @@ describe("ParameterSets", () => {
     it("renders as expected", () => {
         const runState = {
             parameterSets: [
-                { name: "Set 1", parameterValues: { alpha: 1, beta: 2, gamma: 3 } },
-                { name: "Set 2", parameterValues: { alpha: 10, beta: 20, gamma: 30 } }
+                { name: "Set 1", parameterValues: { alpha: 1, beta: 2, gamma: 3 }, hidden: false },
+                { name: "Set 2", parameterValues: { alpha: 10, beta: 20, gamma: 30 }, hidden: false }
             ],
             parameterValues: { alpha: 2, beta: 3, gamma: 4 }
         };
@@ -82,8 +82,8 @@ describe("ParameterSets", () => {
         const runState = {
             parameterValues: { alpha: 2, beta: 3, gamma: 4 },
             parameterSets: [
-                { name: "Set 1", parameterValues: { alpha: 1, beta: 2, gamma: 3 } },
-                { name: "Set 2", parameterValues: { alpha: 2, beta: 3, gamma: 4 } }
+                { name: "Set 1", parameterValues: { alpha: 1, beta: 2, gamma: 3 }, hidden: false },
+                { name: "Set 2", parameterValues: { alpha: 2, beta: 3, gamma: 4 }, hidden: false }
             ]
         };
         const wrapper = getWrapper(runState);

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -59,6 +59,22 @@ describe("RunPlot", () => {
         error: null
     };
 
+    const mockParamSetSolution3 = jest.fn().mockReturnValue({
+        names: ["S", "I"],
+        x: [0, 1],
+        values: [
+            { name: "S", y: [300, 4000] },
+            { name: "I", y: [500, 6000] },
+            { name: "R", y: [700, 8000] }
+        ]
+    });
+
+    const mockParamSetResult3 = {
+        inputs: {},
+        solution: mockParamSetSolution3,
+        error: null
+    };
+
     const paletteModel = {
         S: "#ff0000",
         I: "#00ff00",
@@ -153,12 +169,14 @@ describe("RunPlot", () => {
                         endTime: 99,
                         resultOde: mockResult,
                         parameterSets: [
-                            { name: "Set1", parameterValues: { alpha: 1, beta: 2 } },
-                            { name: "Set2", parameterValues: { alpha: 10, beta: 20 } }
+                            { name: "Set1", parameterValues: { alpha: 1, beta: 2 }, hidden: false },
+                            { name: "Set2", parameterValues: { alpha: 10, beta: 20 }, hidden: false },
+                            { name: "Set3", parameterValues: { alpha: 100, beta: 200 }, hidden: true }
                         ],
                         parameterSetResults: {
                             Set1: mockParamSetResult1,
-                            Set2: mockParamSetResult2
+                            Set2: mockParamSetResult2,
+                            Set3: mockParamSetResult3
                         }
                     },
                     getters: runGetters

--- a/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTracesPlot.test.ts
@@ -354,21 +354,30 @@ const expectedFitPlotData = {
 const selectedVariables = ["y", "z"];
 
 const mockParameterSets = [
-    { name: "Set 1", parameterValues: { alpha: 1 } }
+    { name: "Set 1", parameterValues: { alpha: 1 }, hidden: false },
+    { name: "Set 2", parameterValues: { alpha: 2 }, hidden: true }
 ];
 
-const mockParameterSetBatch = {
+const mockParameterSetBatch1 = {
+    solutions: [mockParameterSetSln1, mockParameterSetSln2]
+};
+
+const mockParameterSetBatch2 = {
     solutions: [mockParameterSetSln1, mockParameterSetSln2]
 };
 
 const mockParameterSetResults = {
     "Set 1": {
-        batch: mockParameterSetBatch
+        batch: mockParameterSetBatch1
+    },
+    "Set 2": {
+        batch: mockParameterSetBatch2
     }
 };
 
 const mockParameterSetCentralResults = {
-    "Set 1": { solution: mockParameterSetCentralSln }
+    "Set 1": { solution: mockParameterSetCentralSln },
+    "Set 2": { solution: mockParameterSetCentralSln }
 } as any;
 
 describe("SensitivityTracesPlot", () => {
@@ -484,7 +493,7 @@ describe("SensitivityTracesPlot", () => {
             ...mockSolutions,
             mockAllFitData,
             selectedVariables,
-            { "Set 1": mockParameterSetBatch }
+            { "Set 1": mockParameterSetBatch1 }
         ]);
 
         const plotData = wodinPlot.props("plotData");

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -89,7 +89,7 @@ describe("serialise", () => {
             error: { error: "run discrete error", detail: "run discrete error detail" }
         },
         parameterSets: [
-            { name: "Set 1", parameterValues: { alpha: 1, beta: 3.3 } }
+            { name: "Set 1", parameterValues: { alpha: 1, beta: 3.3 }, hidden: false }
         ],
         parameterSetResults: {
             "Set 1": {

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -459,7 +459,8 @@ describe("Run actions", () => {
         (actions[RunAction.NewParameterSet] as any)({ state, getters, commit });
         expect(commit).toHaveBeenCalledTimes(3);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.AddParameterSet);
-        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
+        expect(commit.mock.calls[0][1])
+            .toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
         expect(commit.mock.calls[1][0]).toBe(RunMutation.SetParameterSetResult);
         expect(commit.mock.calls[1][1]).toStrictEqual({ name: "Set 2", result: { solution: "fake result" } });
         expect(commit.mock.calls[2][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetAdded}`);
@@ -493,7 +494,8 @@ describe("Run actions", () => {
         (actions[RunAction.NewParameterSet] as any)({ state, getters, commit });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.AddParameterSet);
-        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
+        expect(commit.mock.calls[0][1])
+            .toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
         expect(commit.mock.calls[1][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetAdded}`);
         expect(commit.mock.calls[1][1]).toBe("Set 2");
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -34,8 +34,8 @@ describe("Run actions", () => {
 
         const parameterValues = { p1: 1, p2: 2 };
         const parameterSets = [
-            { name: "Set 1", parameterValues: { p1: 3, p2: 4 } },
-            { name: "Set 2", parameterValues: { p1: 5, p2: 6 } }
+            { name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false },
+            { name: "Set 2", parameterValues: { p1: 5, p2: 6 }, hidden: false }
         ];
         const runner = mockRunnerOde();
         const modelState = mockModelState({
@@ -80,8 +80,8 @@ describe("Run actions", () => {
 
         const parameterValues = { p1: 1, p2: 2 };
         const parameterSets = [
-            { name: "Set 1", parameterValues: { p1: 3, p2: 4 } },
-            { name: "Set 2", parameterValues: { p1: 5, p2: 6 } }
+            { name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false },
+            { name: "Set 2", parameterValues: { p1: 5, p2: 6 }, hidden: false }
         ];
         const runner = mockRunnerOde();
         const modelState = mockModelState({
@@ -451,7 +451,7 @@ describe("Run actions", () => {
     it("NewParameterSet commits parameter set and result", () => {
         const state = mockRunState({
             parameterValues: { p1: 1, p2: 2 },
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false }],
             resultOde: { solution: "fake result" } as any
         });
         const commit = jest.fn();
@@ -459,7 +459,7 @@ describe("Run actions", () => {
         (actions[RunAction.NewParameterSet] as any)({ state, getters, commit });
         expect(commit).toHaveBeenCalledTimes(3);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.AddParameterSet);
-        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 } });
+        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
         expect(commit.mock.calls[1][0]).toBe(RunMutation.SetParameterSetResult);
         expect(commit.mock.calls[1][1]).toStrictEqual({ name: "Set 2", result: { solution: "fake result" } });
         expect(commit.mock.calls[2][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetAdded}`);
@@ -470,7 +470,7 @@ describe("Run actions", () => {
     it("NewParameterSet does nothing if run is required", () => {
         const state = mockRunState({
             parameterValues: { p1: 1, p2: 2 },
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false }],
             resultOde: { solution: "fake result" } as any
         });
         const testGetters = {
@@ -485,7 +485,7 @@ describe("Run actions", () => {
     it("NewParameterSet does not commit null result", () => {
         const state = mockRunState({
             parameterValues: { p1: 1, p2: 2 },
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false }],
             resultOde: null
         });
         const commit = jest.fn();
@@ -493,7 +493,7 @@ describe("Run actions", () => {
         (actions[RunAction.NewParameterSet] as any)({ state, getters, commit });
         expect(commit).toHaveBeenCalledTimes(2);
         expect(commit.mock.calls[0][0]).toBe(RunMutation.AddParameterSet);
-        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 } });
+        expect(commit.mock.calls[0][1]).toStrictEqual({ name: "Set 2", parameterValues: { p1: 1, p2: 2 }, hidden: false });
         expect(commit.mock.calls[1][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetAdded}`);
         expect(commit.mock.calls[1][1]).toBe("Set 2");
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });

--- a/app/static/tests/unit/store/run/getters.test.ts
+++ b/app/static/tests/unit/store/run/getters.test.ts
@@ -89,9 +89,9 @@ describe("Run getters", () => {
     it("gets visibleParameterSetNames", () => {
         const state = mockRunState({
             parameterSets: [
-                {name: "Set 1", parameterValues: {alpha: 1}, hidden: false},
-                {name: "Set 2", parameterValues: {alpha: 1}, hidden: true},
-                {name: "Set 3", parameterValues: {alpha: 1}, hidden: false}
+                { name: "Set 1", parameterValues: { alpha: 1 }, hidden: false },
+                { name: "Set 2", parameterValues: { alpha: 1 }, hidden: true },
+                { name: "Set 3", parameterValues: { alpha: 1 }, hidden: false }
             ]
         });
         expect((getters[RunGetter.visibleParameterSetNames] as any)(state)).toStrictEqual(["Set 1", "Set 3"]);

--- a/app/static/tests/unit/store/run/getters.test.ts
+++ b/app/static/tests/unit/store/run/getters.test.ts
@@ -5,8 +5,8 @@ describe("Run getters", () => {
     it("lineStylesForParameterSets returns expected results", () => {
         const state = mockRunState({
             parameterSets: [
-                { name: "Set 1", parameterValues: { p1: 1 } },
-                { name: "Set 2", parameterValues: { p1: 2 } }
+                { name: "Set 1", parameterValues: { p1: 1 }, hidden: false },
+                { name: "Set 2", parameterValues: { p1: 2 }, hidden: false }
             ]
         });
         const result = (getters[RunGetter.lineStylesForParameterSets] as any)(state);
@@ -47,7 +47,7 @@ describe("Run getters", () => {
     it("runParameterSetIsRequired returns true if any required reason except parameterValueChanged is true", () => {
         const runParameterSetIsRequired = getters[RunGetter.runParameterSetsIsRequired] as any;
         const state = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }],
             parameterSetResults: { "Set 1": { solution: "fake solution" } as any }
         });
         expect(runParameterSetIsRequired(state)).toBe(false);
@@ -72,7 +72,7 @@ describe("Run getters", () => {
 
     it("runParameterSetIsRequired returns true if there are missing parameter set results", () => {
         const state = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }],
             parameterSetResults: {}
         });
         expect((getters[RunGetter.runParameterSetsIsRequired] as any)(state)).toBe(true);
@@ -80,9 +80,20 @@ describe("Run getters", () => {
 
     it("runParameterSetIsRequired returns true if parameter set result has no solution", () => {
         const state = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }],
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }],
             parameterSetResults: { "Set 1": { solution: null } as any }
         });
         expect((getters[RunGetter.runParameterSetsIsRequired] as any)(state)).toBe(true);
+    });
+
+    it("gets visibleParameterSetNames", () => {
+        const state = mockRunState({
+            parameterSets: [
+                {name: "Set 1", parameterValues: {alpha: 1}, hidden: false},
+                {name: "Set 2", parameterValues: {alpha: 1}, hidden: true},
+                {name: "Set 3", parameterValues: {alpha: 1}, hidden: false}
+            ]
+        });
+        expect((getters[RunGetter.visibleParameterSetNames] as any)(state)).toStrictEqual(["Set 1", "Set 3"]);
     });
 });

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -190,11 +190,33 @@ describe("Run mutations", () => {
 
     it("deletes parameter set", () => {
         const state = mockRunState({
-            parameterSets: [{ name: "Set1", parameterValues: { a: 1 } }, { name: "Set2", parameterValues: { a: 2 } }],
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 1 }, hidden: false },
+                { name: "Set2", parameterValues: { a: 2 }, hidden: false }
+            ],
             parameterSetResults: { Set1: { value: "test 1" }, Set2: { value: "test 2" } } as any
         });
         mutations.DeleteParameterSet(state, "Set1");
-        expect(state.parameterSets).toStrictEqual([{ name: "Set2", parameterValues: { a: 2 } }]);
+        expect(state.parameterSets).toStrictEqual([{ name: "Set2", parameterValues: { a: 2 }, hidden: false }]);
         expect(state.parameterSetResults).toStrictEqual({ Set2: { value: "test 2" } });
+    });
+
+    it("toggles parameter set hidden", () => {
+        const state = mockRunState({
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 1 }, hidden: false },
+                { name: "Set2", parameterValues: { a: 2 }, hidden: false }
+            ]
+        });
+        mutations.ToggleParameterSetHidden(state, "Set2");
+        expect(state.parameterSets).toStrictEqual([
+            { name: "Set1", parameterValues: { a: 1 }, hidden: false },
+            { name: "Set2", parameterValues: { a: 2 }, hidden: true }
+        ]);
+        mutations.ToggleParameterSetHidden(state, "Set2");
+        expect(state.parameterSets).toStrictEqual([
+            { name: "Set1", parameterValues: { a: 1 }, hidden: false },
+            { name: "Set2", parameterValues: { a: 2 }, hidden: false }
+        ]);
     });
 });

--- a/app/static/tests/unit/store/sensitivity/getters.test.ts
+++ b/app/static/tests/unit/store/sensitivity/getters.test.ts
@@ -86,7 +86,7 @@ describe("Sensitivity getters", () => {
     it("parameterSetSensitivityUpdateRequired is true if any reason except parameterValueChanged is true", () => {
         const paramSetSensUpdateRequired = getters[SensitivityGetter.parameterSetSensitivityUpdateRequired] as any;
         const runState = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }]
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }]
         });
         const rootState = { run: runState };
 
@@ -127,7 +127,7 @@ describe("Sensitivity getters", () => {
 
     it("parameterSetSensitivityUpdateRequired returns true if there are missing parameter set results", () => {
         const runState = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }]
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }]
         });
 
         const rootState = { run: runState };
@@ -138,7 +138,7 @@ describe("Sensitivity getters", () => {
 
     it("parameterSetSensitivityUpdateRequired returns true if parameter set result has no batch", () => {
         const runState = mockRunState({
-            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 } }]
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 1 }, hidden: false }]
         });
         const rootState = { run: runState };
         const state = mockSensitivityState({


### PR DESCRIPTION
This branch allows the user to hide/show traces for a parameter set on Run and Sensitivity graphs by clicking on the eye icon in the parameter set in the Options tab. When a Parameter Set is hidden, its background is greyed out. 

There are two VueFeather icon components, one for Hide and the other for Show, rather than just one whose icon, tooltip etc gets updated when the `hidden` value changes - this is because I had problems getting the tooltip to update via the directive. Updating content in the existing `Tooltip` threw an error in Bootstrap, and creating a new `Tooltip` object on value update was flaky (new tooltip was not always immediately shown). I'll made a ticket to look into this properly as it would be nice to have an updating tooltip directive, but for now using two icons seems to work reliably. 
