### PR TITLE
mrc-3255 Show trace line style in parameter set view

### DIFF
--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -3,7 +3,7 @@
   <div class="card">
     <div class="card-header">
       {{parameterSet.name}}
-      <div class="d-inline-block trace ms-2" :class="'trace-'+lineStyle"></div>
+      <div class="d-inline-block trace ms-2" :class="'trace-' + lineStyle"></div>
       <span class="float-end">
         <vue-feather class="inline-icon clickable hide-param-set"
                      v-if="!parameterSet.hidden"
@@ -124,12 +124,22 @@ export default defineComponent({
   }
 
   .trace-dashdot {
-    background-image: linear-gradient(to right, $trace-color 10%, transparent 10% 30%, $trace-color 30% 80%, transparent 80%);
+    background-image: linear-gradient(
+            to right,
+            $trace-color 10%,
+            transparent 10% 30%,
+            $trace-color 30% 80%,
+            transparent 80%);
     background-size: 16px 2px;
   }
 
   .trace-longdashdot {
-    background-image: linear-gradient(to right, $trace-color 8%, transparent 8% 30%, $trace-color 30% 78%, transparent 78%);
+    background-image: linear-gradient(
+            to right,
+            $trace-color 8%,
+            transparent 8% 30%,
+            $trace-color 30% 78%,
+            transparent 78%);
     background-size: 24px 2px;
   }
 

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -3,6 +3,7 @@
   <div class="card">
     <div class="card-header">
       {{parameterSet.name}}
+      <div class="d-inline-block trace ms-2" :class="'trace-'+lineStyle"></div>
       <span class="float-end">
         <vue-feather class="inline-icon clickable hide-param-set"
                      v-if="!parameterSet.hidden"
@@ -39,10 +40,15 @@ import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
 import { RunMutation } from "../../store/run/mutations";
+import { lineStyleForParameterSetIndex } from "../../plot";
 
 export default defineComponent({
     name: "ParameterSetView",
     props: {
+        index: {
+            type: Number,
+            required: true
+        },
         parameterSet: {
             type: Object as PropType<ParameterSet>,
             required: true
@@ -69,6 +75,8 @@ export default defineComponent({
             };
         };
 
+        const lineStyle = computed(() => lineStyleForParameterSetIndex(props.index));
+
         const deleteParameterSet = () => {
             store.dispatch(`run/${RunAction.DeleteParameterSet}`, props.parameterSet.name);
         };
@@ -78,6 +86,7 @@ export default defineComponent({
         };
 
         return {
+            lineStyle,
             getStyle,
             deleteParameterSet,
             toggleHidden
@@ -88,6 +97,42 @@ export default defineComponent({
 
 <style scoped lang="scss">
 .parameter-set {
+
+  $trace-color: #333;
+
+  .trace {
+    border-top: $trace-color;
+    border-top-width: 2px;
+    width: 6rem;
+    height: 0.5rem;
+    background-position: left top;
+    background-repeat: repeat-x;
+  }
+
+  .trace-dot {
+    border-top-style: dotted;
+  }
+
+  .trace-dash {
+    background-image: linear-gradient(to right, $trace-color 50%, transparent 50%);
+    background-size: 10px 2px;
+  }
+
+  .trace-longdash {
+    background-image: linear-gradient(to right, $trace-color 50%, transparent 50%);
+    background-size: 20px 2px;
+  }
+
+  .trace-dashdot {
+    background-image: linear-gradient(to right, $trace-color 10%, transparent 10% 30%, $trace-color 30% 80%, transparent 80%);
+    background-size: 16px 2px;
+  }
+
+  .trace-longdashdot {
+    background-image: linear-gradient(to right, $trace-color 8%, transparent 8% 30%, $trace-color 30% 78%, transparent 78%);
+    background-size: 24px 2px;
+  }
+
   .parameter {
     font-size: medium;
   }

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -3,7 +3,7 @@
   <div class="card">
     <div class="card-header">
       {{parameterSet.name}}
-      <div class="d-inline-block trace ms-2" :class="'trace-' + lineStyle"></div>
+      <div class="d-inline-block trace ms-2" :class="lineStyleClass"></div>
       <span class="float-end">
         <vue-feather class="inline-icon clickable hide-param-set"
                      v-if="!parameterSet.hidden"
@@ -40,7 +40,7 @@ import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
 import { RunMutation } from "../../store/run/mutations";
-import { lineStyleForParameterSetIndex } from "../../plot";
+import { paramSetLineStyle } from "../../plot";
 
 export default defineComponent({
     name: "ParameterSetView",
@@ -75,7 +75,7 @@ export default defineComponent({
             };
         };
 
-        const lineStyle = computed(() => lineStyleForParameterSetIndex(props.index));
+        const lineStyleClass = computed(() => `trace-${paramSetLineStyle(props.index)}`);
 
         const deleteParameterSet = () => {
             store.dispatch(`run/${RunAction.DeleteParameterSet}`, props.parameterSet.name);
@@ -86,7 +86,7 @@ export default defineComponent({
         };
 
         return {
-            lineStyle,
+            lineStyleClass,
             getStyle,
             deleteParameterSet,
             toggleHidden

--- a/app/static/src/app/components/options/ParameterSets.vue
+++ b/app/static/src/app/components/options/ParameterSets.vue
@@ -7,7 +7,11 @@
       Save Current Parameters
     </button>
   </div>
-  <parameter-set-view v-for="(paramSet, index) in parameterSets" :parameter-set="paramSet" :index="index" class="mt-2" :key="paramSet.name">
+  <parameter-set-view v-for="(paramSet, index) in parameterSets"
+                      :parameter-set="paramSet"
+                      :index="index"
+                      class="mt-2"
+                      :key="paramSet.name">
   </parameter-set-view>
 </template>
 

--- a/app/static/src/app/components/options/ParameterSets.vue
+++ b/app/static/src/app/components/options/ParameterSets.vue
@@ -7,7 +7,7 @@
       Save Current Parameters
     </button>
   </div>
-  <parameter-set-view v-for="paramSet in parameterSets" :parameter-set="paramSet" class="mt-2" :key="paramSet.name">
+  <parameter-set-view v-for="(paramSet, index) in parameterSets" :parameter-set="paramSet" :index="index" class="mt-2" :key="paramSet.name">
   </parameter-set-view>
 </template>
 

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -145,4 +145,4 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
 }
 
 const lineStyles = ["dot", "dash", "longdash", "dashdot", "longdashdot"];
-export const lineStyleForParameterSetIndex = (index: number): string => (lineStyles[index % lineStyles.length]);
+export const paramSetLineStyle = (index: number): string => (lineStyles[index % lineStyles.length]);

--- a/app/static/src/app/store/run/getters.ts
+++ b/app/static/src/app/store/run/getters.ts
@@ -2,7 +2,7 @@ import { Getter, GetterTree } from "vuex";
 import { ParameterSet, RunState } from "./state";
 import { AppState } from "../appState/state";
 import { Dict } from "../../types/utilTypes";
-import { lineStyleForParameterSetIndex } from "../../plot";
+import { paramSetLineStyle } from "../../plot";
 import { anyTrue } from "../../utils";
 
 export enum RunGetter {
@@ -20,7 +20,7 @@ export const getters: RunGetters & GetterTree<RunState, AppState> = {
     [RunGetter.lineStylesForParameterSets]: (state: RunState): Dict<string> => {
         const result: Dict<string> = {};
         state.parameterSets.forEach((set, idx) => {
-            result[set.name] = lineStyleForParameterSetIndex(idx);
+            result[set.name] = paramSetLineStyle(idx);
         });
         return result;
     },

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -199,7 +199,7 @@ test.describe("Options Tab tests", () => {
 
     test("can create a parameter set, and see run traces for that set", async ({ page }) => {
         await page.click("#create-param-set");
-        await expect(await page.innerText(".parameter-set .card-header")).toBe("Set 1");
+        await expect((await page.innerText(".parameter-set .card-header")).trim()).toBe("Set 1");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 4");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 1");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 1000000");

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -271,7 +271,7 @@ test.describe("Options Tab tests", () => {
         await updateBetaParamAndRun(2, page);
         await createParameterSet(page);
         await expect(await page.locator(".parameter-set").count()).toBe(2);
-        await expect(await page.innerText(":nth-match(.parameter-set  .card-header, 1)")).toBe("Set 1");
-        await expect(await page.innerText(":nth-match(.parameter-set  .card-header, 2)")).toBe("Set 3");
+        await expect((await page.innerText(":nth-match(.parameter-set  .card-header, 1)")).trim()).toBe("Set 1");
+        await expect((await page.innerText(":nth-match(.parameter-set  .card-header, 2)")).trim()).toBe("Set 3");
     });
 });

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -16,7 +16,7 @@ describe("ParameterSetView", () => {
         jest.resetAllMocks();
     });
 
-    const getWrapper = (paramSetHidden = false) => {
+    const getWrapper = (paramSetHidden = false, index = 0) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState(),
             modules: {
@@ -44,7 +44,8 @@ describe("ParameterSetView", () => {
                     name: "Set 1",
                     parameterValues: { alpha: 0, beta: 2, gamma: 4 },
                     hidden: paramSetHidden
-                }
+                },
+                index
             }
         });
     };
@@ -74,6 +75,19 @@ describe("ParameterSetView", () => {
         expect(deleteIcon.props("type")).toBe("trash-2");
 
         expect(wrapper.find(".card-body").classes()).not.toContain("hidden-parameter-set");
+    });
+
+    it("renders all trace line styles", () => {
+        const testExpectedTraceClassForIndex = (index: number, expectedClass: string) => {
+            const wrapper = getWrapper(false, index);
+            expect(wrapper.find("div.trace").classes()).toContain(expectedClass);
+        };
+        testExpectedTraceClassForIndex(0, "trace-dot");
+        testExpectedTraceClassForIndex(1, "trace-dash");
+        testExpectedTraceClassForIndex(2, "trace-longdash");
+        testExpectedTraceClassForIndex(3, "trace-dashdot");
+        testExpectedTraceClassForIndex(4, "trace-longdashdot");
+        testExpectedTraceClassForIndex(5, "trace-dot"); // back to start
     });
 
     it("uses tooltip directive", () => {

--- a/app/static/tests/unit/components/options/parameterSets.test.ts
+++ b/app/static/tests/unit/components/options/parameterSets.test.ts
@@ -52,7 +52,9 @@ describe("ParameterSets", () => {
         const paramSetViews = wrapper.findAllComponents(ParameterSetView);
         expect(paramSetViews.length).toBe(2);
         expect(paramSetViews.at(0)!.props("parameterSet")).toStrictEqual(runState.parameterSets[0]);
+        expect(paramSetViews.at(0)!.props("index")).toBe(0);
         expect(paramSetViews.at(1)!.props("parameterSet")).toStrictEqual(runState.parameterSets[1]);
+        expect(paramSetViews.at(1)!.props("index")).toBe(1);
     });
 
     it("cannot save new parameter set if compile is required", () => {

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -1,7 +1,7 @@
 import { Dash } from "plotly.js-basic-dist-min";
 import {
     allFitDataToPlotly, discreteSeriesSetToPlotly,
-    fitDataToPlotly, lineStyleForParameterSetIndex,
+    fitDataToPlotly, paramSetLineStyle,
     odinToPlotly
 } from "../../src/app/plot";
 
@@ -276,13 +276,13 @@ describe("discreteSeriesSetToPlotly", () => {
     });
 });
 
-describe("lineStyleForParameterSetIndex", () => {
+describe("paramSetLineStyle", () => {
     it("fetches expected line styles", () => {
-        expect(lineStyleForParameterSetIndex(0)).toBe("dot");
-        expect(lineStyleForParameterSetIndex(1)).toBe("dash");
-        expect(lineStyleForParameterSetIndex(2)).toBe("longdash");
-        expect(lineStyleForParameterSetIndex(3)).toBe("dashdot");
-        expect(lineStyleForParameterSetIndex(4)).toBe("longdashdot");
-        expect(lineStyleForParameterSetIndex(5)).toBe("dot");
+        expect(paramSetLineStyle(0)).toBe("dot");
+        expect(paramSetLineStyle(1)).toBe("dash");
+        expect(paramSetLineStyle(2)).toBe("longdash");
+        expect(paramSetLineStyle(3)).toBe("dashdot");
+        expect(paramSetLineStyle(4)).toBe("longdashdot");
+        expect(paramSetLineStyle(5)).toBe("dot");
     });
 });


### PR DESCRIPTION
This branch updates the parameter set view to add an indication of the set's  line style in the graphs. This is shown next to parameter set name. 

Css is used to approximate the plotly line style. There are five line styles:
- dot
- dash
- longdash
- dashdot
- longdashdot

Most of these are implemented using css linear gradient, except for dot, which uses border-style. Perhaps this should use linear gradients too, just to be consistent?

Could have also used border-style for dash - however this does not give any control over the length of the dashes (which need to be shorter than longdash), and also I found that the line began with a shorter dash, which was visually confusing, and could be misinterpreted as dashdot. 

Css spec also includes a dashdot border style, but this is not well supported yet. 

Image below shows extreme case where all five possible line styles are in use by parameter sets. We would expect most users to only want one parameter set to compare against!
![Screenshot from 2023-01-18 10-47-50](https://user-images.githubusercontent.com/44669576/213154826-3c6202e2-0f49-49ce-b134-29a0e0cc7320.png)


NB line style is based on current index in the array, so it is not fixed for a parameter set e.g. it will change if a previous parameter set is deleted. More than five parameter sets can, in theory be added - line styles will be reused in this case. 
