### PR TITLE
Fill in defaults when returning app config

### DIFF
--- a/app/server/src/controllers/configController.ts
+++ b/app/server/src/controllers/configController.ts
@@ -6,6 +6,21 @@ import { AppFileReader } from "../appFileReader";
 import { ErrorType } from "../errors/errorType";
 import { WodinError } from "../errors/wodinError";
 
+export const configDefaults = (appType: string) => {
+    const base = {
+        readOnlyCode: false,
+        stateUploadIntervalMillis: 2000
+    };
+    if (appType === "stochastic") {
+        return {
+            ...base,
+            maxReplicatesRun: 1000,
+            maxReplicatesDisplay: 20
+        };
+    }
+    return base;
+};
+
 export class ConfigController {
     private static _readAppConfigFile = (
         appName: string,
@@ -17,6 +32,7 @@ export class ConfigController {
     ) => {
         const result = configReader.readConfigFile(appsPath, `${appName}.config.json`) as AppConfig;
         if (result) {
+            const defaults = configDefaults(result.appType);
             result.defaultCode = defaultCodeReader.readFile(appName);
             const appHelp = appHelpReader.readFile(appName);
             if (appHelp.length) {
@@ -25,7 +41,11 @@ export class ConfigController {
                 }
                 result.help.markdown = appHelp;
             }
+
+            // TODO: I want to know what breaks if this is removed.
             result.baseUrl = baseUrl;
+
+            return { ...defaults, ...result };
         }
         return result;
     };

--- a/app/server/src/controllers/configController.ts
+++ b/app/server/src/controllers/configController.ts
@@ -8,6 +8,7 @@ import { WodinError } from "../errors/wodinError";
 
 export const configDefaults = (appType: string) => {
     const base = {
+        endTime: 100,
         readOnlyCode: false,
         stateUploadIntervalMillis: 2000
     };

--- a/app/server/src/controllers/configController.ts
+++ b/app/server/src/controllers/configController.ts
@@ -43,9 +43,6 @@ export class ConfigController {
                 result.help.markdown = appHelp;
             }
 
-            // TODO: I want to know what breaks if this is removed.
-            result.baseUrl = baseUrl;
-
             return { ...defaults, ...result };
         }
         return result;

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -38,7 +38,7 @@ export interface AppConfigFit extends AppConfigBase {
 export interface AppConfigStochastic extends AppConfigBase {
     appType: "stochastic",
     maxReplicatesRun: number,
-    maxReplicatedDisplay: number,
+    maxReplicatesDisplay: number,
 }
 
 export type AppConfig = AppConfigBasic | AppConfigFit | AppConfigStochastic;

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -12,16 +12,35 @@ export interface WodinConfig {
     appsPath: string
 }
 
-export interface AppConfig {
-    appType: string,
+export interface AppConfigBase {
     title: string,
+    // can we drop this? it's not clear why it's here, or why it is
+    // used? try knocking it out and see what fails...
     baseUrl: string,
+    readOnlyCode: boolean,
+    stateUploadIntervalMillis: number,
     defaultCode: string[] | undefined
     help?: {
         markdown?: string[]
         tabName?: string
     }
 }
+
+export interface AppConfigBasic extends AppConfigBase {
+    appType: "basic"
+}
+
+export interface AppConfigFit extends AppConfigBase {
+    appType: "fit"
+}
+
+export interface AppConfigStochastic extends AppConfigBase {
+    appType: "stochastic",
+    maxReplicatesRun: number,
+    maxReplicatedDisplay: number,
+}
+
+export type AppConfig = AppConfigBasic | AppConfigFit | AppConfigStochastic;
 
 export interface AppLocals {
     baseUrl: string,

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -17,6 +17,7 @@ export interface AppConfigBase {
     // can we drop this? it's not clear why it's here, or why it is
     // used? try knocking it out and see what fails...
     baseUrl: string,
+    endTime: number,
     readOnlyCode: boolean,
     stateUploadIntervalMillis: number,
     defaultCode: string[] | undefined

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -14,9 +14,6 @@ export interface WodinConfig {
 
 export interface AppConfigBase {
     title: string,
-    // can we drop this? it's not clear why it's here, or why it is
-    // used? try knocking it out and see what fails...
-    baseUrl: string,
     endTime: number,
     readOnlyCode: boolean,
     stateUploadIntervalMillis: number,

--- a/app/server/tests/controllers/configController.test.ts
+++ b/app/server/tests/controllers/configController.test.ts
@@ -65,6 +65,8 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            readOnlyCode: false,
+            stateUploadIntervalMillis: 2000,
             defaultCode,
             help: {
                 markdown: appHelp
@@ -86,6 +88,8 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            readOnlyCode: false,
+            stateUploadIntervalMillis: 2000,
             defaultCode: []
         });
     });
@@ -110,6 +114,8 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            readOnlyCode: false,
+            stateUploadIntervalMillis: 2000,
             defaultCode: [],
             help: {
                 tabName: "Help",

--- a/app/server/tests/controllers/configController.test.ts
+++ b/app/server/tests/controllers/configController.test.ts
@@ -64,7 +64,6 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls.length).toBe(1);
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
-            baseUrl: "http://localhost:3000",
             endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,
@@ -88,7 +87,6 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls.length).toBe(1);
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
-            baseUrl: "http://localhost:3000",
             endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,
@@ -115,7 +113,6 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls.length).toBe(1);
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
-            baseUrl: "http://localhost:3000",
             endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,

--- a/app/server/tests/controllers/configController.test.ts
+++ b/app/server/tests/controllers/configController.test.ts
@@ -65,6 +65,7 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,
             defaultCode,
@@ -88,6 +89,7 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,
             defaultCode: []
@@ -114,6 +116,7 @@ describe("configController", () => {
         expect(spyJsonResponseSuccess.mock.calls[0][0]).toStrictEqual({
             ...basicConfig,
             baseUrl: "http://localhost:3000",
+            endTime: 100,
             readOnlyCode: false,
             stateUploadIntervalMillis: 2000,
             defaultCode: [],

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -31,8 +31,6 @@ async function immediateUploadState(context: ActionContext<AppState, AppState>) 
     commit(AppStateMutation.SetStateUploadInProgress, false);
 }
 
-const getStateUploadInterval = (state: AppState) => state.config?.stateUploadIntervalMillis || 2000;
-
 export const appStateActions: ActionTree<AppState, AppState> = {
     async [AppStateAction.Initialise](context, payload: InitialisePayload) {
         const {
@@ -93,7 +91,7 @@ export const appStateActions: ActionTree<AppState, AppState> = {
                     commit(AppStateMutation.ClearQueuedStateUpload);
                     immediateUploadState(context);
                 }
-            }, getStateUploadInterval(state));
+            }, state.config?.stateUploadIntervalMillis);
 
             // record the newly queued upload
             commit(AppStateMutation.SetQueuedStateUpload, queuedId);

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -17,28 +17,35 @@ export interface ResponseSuccess {
     errors: null;
 }
 
-export interface AppConfig {
+export interface AppConfigBase {
     defaultCode: string[],
+    endTime: number,
     readOnlyCode: boolean,
-    stateUploadIntervalMillis?: number | null
-    endTime?: number,
+    stateUploadIntervalMillis: number,
+    endTime: number,
     help?: {
         markdown?: string[],
         tabName?: string
     }
 }
 
-export interface BasicConfig extends AppConfig {
+export interface BasicConfig extends AppConfigBase {
+    appType: "basic",
+    // This is used in some testing still.
     basicProp: string
 }
 
-export interface FitConfig extends AppConfig {
-    fitProp: string
+export interface FitConfig extends AppConfigBase {
+    appType: "fit"
 }
 
-export interface StochasticConfig extends AppConfig {
-    stochasticProp: string
+export interface StochasticConfig extends AppConfigBase {
+    appType: "stochastic"
+    maxReplicatesRun: number,
+    maxReplicatesDisplay: number,
 }
+
+export type AppConfig = BasicConfig | FitConfig | StochasticConfig;
 
 export interface Odin {
     new(...args : unknown[]): unknown

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -47,6 +47,8 @@ export const mockFailure = (errorMessage: string): ResponseFailure => {
 const mockAppConfig = {
     baseUrl: "http://localhost:3000",
     readOnlyCode: false,
+    endTime: 100,
+    stateUploadIntervalMillis: 2000,
     defaultCode: []
 };
 
@@ -163,6 +165,7 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
         config: {
+            appType: "basic",
             basicProp: "",
             ...mockAppConfig
         },
@@ -209,7 +212,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
         config: {
-            fitProp: "",
+            appType: "fit",
             ...mockAppConfig
         },
         code: mockCodeState(),
@@ -237,7 +240,9 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
         config: {
-            stochasticProp: "",
+            appType: "stochastic",
+            maxReplicatesRun: 1000,
+            maxReplicatesDisplay: 20,
             ...mockAppConfig
         },
         code: mockCodeState(),

--- a/app/static/tests/unit/components/code/codeEditor.test.ts
+++ b/app/static/tests/unit/components/code/codeEditor.test.ts
@@ -21,6 +21,7 @@ import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import CodeEditor from "../../../../src/app/components/code/CodeEditor.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
+import { BasicConfig } from "../../../../src/app/types/responseTypes";
 import { mockBasicState, mockCodeState } from "../../../mocks";
 
 describe("CodeEditor", () => {
@@ -31,7 +32,7 @@ describe("CodeEditor", () => {
                     defaultCode,
                     readOnlyCode,
                     basicProp: ""
-                }
+                } as BasicConfig
             }),
             modules: {
                 code: {


### PR DESCRIPTION
* made return types more extendable, and filled in bits that were missing in the server response types but used in the static app (this worked previously because we have no validation and because we just pass along the json content)
* harmonised the return types between the server and the client
* remove `baseUrl` from the app config response; this seems harmless to me so far?

I  have added in the as-yet-unused parameters for the stochastic control PR that triggered all of this (#135, mrc-3710) as this makes it all a bit clearer I think