### PR TITLE
mrc-3894 Show parameter set traces on Sensitivity Summary plot

### DIFF
--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -17,7 +17,7 @@ import { format } from "d3-format";
 import { FitDataGetter } from "../../store/fitData/getters";
 import WodinPlot from "../WodinPlot.vue";
 import {
-    allFitDataToPlotly, filterSeriesSet, odinToPlotly, PlotlyOptions, WodinPlotData
+  allFitDataToPlotly, filterSeriesSet, odinToPlotly, PlotlyOptions, updatePlotTraceName, WodinPlotData
 } from "../../plot";
 import {
     Batch,
@@ -52,6 +52,7 @@ export default defineComponent({
             });
             return result;
         });
+
         const isStochastic = computed(() => store.state.appType === AppType.Stochastic);
         const centralSolution = computed(() => {
             return isStochastic.value ? store.state.run.resultDiscrete?.solution : store.state.run.resultOde?.solution;
@@ -67,19 +68,6 @@ export default defineComponent({
         const selectedVariables = computed(() => store.state.model.selectedVariables);
 
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, true));
-
-        const updatePlotTraceName = (plotTrace: Partial<PlotData>, param: string | null, value: number | null,
-            parameterSetName = "") => {
-            const parenthesisItems = [];
-            if (param && value) {
-                parenthesisItems.push(`${param}=${format(".3f")(value)}`);
-            }
-            if (parameterSetName) {
-                parenthesisItems.push(parameterSetName);
-            }
-            // eslint-disable-next-line no-param-reassign
-            plotTrace.name = `${plotTrace.name} (${parenthesisItems.join(" ")})`;
-        };
 
         const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -13,11 +13,10 @@
 import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
 import { PlotData } from "plotly.js-basic-dist-min";
-import { format } from "d3-format";
 import { FitDataGetter } from "../../store/fitData/getters";
 import WodinPlot from "../WodinPlot.vue";
 import {
-  allFitDataToPlotly, filterSeriesSet, odinToPlotly, PlotlyOptions, updatePlotTraceName, WodinPlotData
+    allFitDataToPlotly, filterSeriesSet, odinToPlotly, PlotlyOptions, updatePlotTraceName, WodinPlotData
 } from "../../plot";
 import {
     Batch,

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,11 +1,11 @@
 import { Dash, PlotData } from "plotly.js-basic-dist-min";
+import { format } from "d3-format";
 import { Palette, paletteData } from "./palette";
 import type { AllFitData, FitData, FitDataLink } from "./store/fitData/state";
 import {
     DiscreteSeriesSet, OdinSeriesSet, OdinSeriesSetValues
 } from "./types/responseTypes";
 import { Dict } from "./types/utilTypes";
-import {format} from "d3-format";
 
 export type WodinPlotData = Partial<PlotData>[];
 
@@ -149,7 +149,7 @@ const lineStyles = ["dot", "dash", "longdash", "dashdot", "longdashdot"];
 export const lineStyleForParameterSetIndex = (index: number): string => (lineStyles[index % lineStyles.length]);
 
 export const updatePlotTraceName = (plotTrace: Partial<PlotData>, param: string | null, value: number | null,
-                             parameterSetName = "") => {
+    parameterSetName = "") => {
     const parenthesisItems = [];
     if (param && value) {
         parenthesisItems.push(`${param}=${format(".3f")(value)}`);

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -5,6 +5,7 @@ import {
     DiscreteSeriesSet, OdinSeriesSet, OdinSeriesSetValues
 } from "./types/responseTypes";
 import { Dict } from "./types/utilTypes";
+import {format} from "d3-format";
 
 export type WodinPlotData = Partial<PlotData>[];
 
@@ -146,3 +147,16 @@ export function allFitDataToPlotly(allFitData: AllFitData | null, paletteModel: 
 
 const lineStyles = ["dot", "dash", "longdash", "dashdot", "longdashdot"];
 export const lineStyleForParameterSetIndex = (index: number): string => (lineStyles[index % lineStyles.length]);
+
+export const updatePlotTraceName = (plotTrace: Partial<PlotData>, param: string | null, value: number | null,
+                             parameterSetName = "") => {
+    const parenthesisItems = [];
+    if (param && value) {
+        parenthesisItems.push(`${param}=${format(".3f")(value)}`);
+    }
+    if (parameterSetName) {
+        parenthesisItems.push(parameterSetName);
+    }
+    // eslint-disable-next-line no-param-reassign
+    plotTrace.name = `${plotTrace.name} (${parenthesisItems.join(" ")})`;
+};

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -153,6 +153,7 @@ export interface Batch {
     solutions: OdinSolution[],
     errors: BatchError[],
     valueAtTime: (time: number) => OdinSeriesSet,
+    extreme: (type: string) => OdinSeriesSet,
     compute: () => boolean
 }
 

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../src/app/store/sensitivity/state";
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
-import {RunGetter} from "../../../../src/app/store/run/getters";
+import { RunGetter } from "../../../../src/app/store/run/getters";
 
 jest.mock("plotly.js-basic-dist-min", () => ({
     newPlot: jest.fn(),
@@ -82,7 +82,7 @@ describe("SensitivitySummaryPlot", () => {
     const mockBatchSet1 = {
         valueAtTime: jest.fn().mockReturnValue(mockDataSet1),
         extreme: jest.fn().mockReturnValue(mockDataSet1)
-    }
+    };
 
     const mockBatchSet2 = {
         valueAtTime: jest.fn().mockReturnValue(mockDataSet2),
@@ -110,9 +110,8 @@ describe("SensitivitySummaryPlot", () => {
     const defaultSelectedVariables = ["S", "I"];
 
     const getWrapper = (hasData = true, plotSettings: SensitivityPlotSettings = defaultPlotSettings,
-                        fadePlot = false, paramSettings: SensitivityParameterSettings = defaultParamSettings,
-                        logScaleYAxis = false, selectedVariables = defaultSelectedVariables, includeParameterSets = false) => {
-
+        fadePlot = false, paramSettings: SensitivityParameterSettings = defaultParamSettings,
+        logScaleYAxis = false, selectedVariables = defaultSelectedVariables, includeParameterSets = false) => {
         const visibleParameterSetNames = includeParameterSets ? ["Set1", "Set2"] : [];
         const parameterSetResults = includeParameterSets ? {
             Set1: {

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -150,6 +150,7 @@ describe("serialise", () => {
                 solutions: [jest.fn(), jest.fn()],
                 errors: [],
                 valueAtTime: jest.fn(),
+                extreme: jest.fn(),
                 compute: jest.fn()
             },
             error: { error: "sensitivity error", detail: "sensitivity error detail" }
@@ -165,6 +166,7 @@ describe("serialise", () => {
                     solutions: [jest.fn(), jest.fn()],
                     errors: [],
                     valueAtTime: jest.fn(),
+                    extreme: jest.fn(),
                     compute: jest.fn()
                 },
                 error: { error: "param set sensitivity error", detail: "param set sensitivity error detail" }


### PR DESCRIPTION
This branch adds traces for parameter set results to the sensitivity summary plot. This can lead to some odd looking charts if the parameter being varied by sensitivity also has different values across the parameter sets. We may modify valid combinations of values in future tickets. 

There is no e2e in this branch as I realised that plot summary data is not rendered in the sensitivity summary plot. There's a separate ticket to add this, update summary plot e2e tests, and add parameter set test: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3935