### PR TITLE
mrc-3935 Include hidden data summary in sensitivity summary plot

### DIFF
--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -5,20 +5,7 @@
     <div v-if="!hasPlotData" class="plot-placeholder">
       {{ placeholderMessage }}
     </div>
-    <div v-if="hasPlotData" hidden class="wodin-plot-data-summary">
-      <div class="wodin-plot-data-summary-series" v-for="(data, index) in baseData" :key="index"
-           :name="data.name"
-           :count="data.x?.length"
-           :x-min="Math.min(...data.x)"
-           :x-max="Math.max(...data.x)"
-           :y-min="Math.min(...data.y)"
-           :y-max="Math.max(...data.y)"
-           :mode="data.mode"
-           :line-color="data.line?.color"
-           :line-dash="data.line?.dash"
-           :marker-color="data.marker?.color"
-      ></div>
-    </div>
+    <wodin-plot-data-summary :data="baseData"></wodin-plot-data-summary>
     <slot></slot>
   </div>
 </template>
@@ -35,9 +22,11 @@ import {
 import {
     WodinPlotData, fadePlotStyle, margin, config
 } from "../plot";
+import WodinPlotDataSummary from "./WodinPlotDataSummary.vue";
 
 export default defineComponent({
     name: "WodinPlot",
+    components: { WodinPlotDataSummary },
     props: {
         fadePlot: Boolean,
         placeholderMessage: String,

--- a/app/static/src/app/components/WodinPlotDataSummary.vue
+++ b/app/static/src/app/components/WodinPlotDataSummary.vue
@@ -1,0 +1,36 @@
+<template>
+  <div v-if="hasData" hidden class="wodin-plot-data-summary">
+    <div class="wodin-plot-data-summary-series" v-for="(series, index) in data" :key="index"
+         :name="series.name"
+         :count="series.x?.length"
+         :x-min="Math.min(...series.x)"
+         :x-max="Math.max(...series.x)"
+         :y-min="Math.min(...series.y)"
+         :y-max="Math.max(...series.y)"
+         :mode="series.mode"
+         :line-color="series.line?.color"
+         :line-dash="series.line?.dash"
+         :marker-color="series.marker?.color"
+    ></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, PropType } from "vue";
+import { WodinPlotData } from "../plot";
+
+export default defineComponent({
+    name: "WodinPlotDataSummary",
+    props: {
+        data: {
+            type: Object as PropType<WodinPlotData>
+        }
+    },
+    setup(props) {
+        const hasData = computed(() => !!(props.data?.length));
+        return {
+            hasData
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -5,6 +5,7 @@
     <div v-if="!hasPlotData" class="plot-placeholder">
       {{ placeholderMessage }}
     </div>
+    <wodin-plot-data-summary :data="plotData"></wodin-plot-data-summary>
     <slot></slot>
   </div>
 </template>
@@ -25,9 +26,11 @@ import { Batch, OdinSeriesSet } from "../../types/responseTypes";
 import { runPlaceholderMessage } from "../../utils";
 import { RunGetter } from "../../store/run/getters";
 import { Dict } from "../../types/utilTypes";
+import WodinPlotDataSummary from "../WodinPlotDataSummary.vue";
 
 export default defineComponent({
     name: "SensitivitySummaryPlot",
+    components: { WodinPlotDataSummary },
     props: {
         fadePlot: Boolean
     },

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -183,7 +183,7 @@ test.describe("Sensitivity tests", () => {
 
         // Switch to summary view
         await page.locator("#sensitivity-plot-type select").selectOption("ValueAtTime");
-        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6,{ timeout });
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
         await expectSummaryValues(page, 1, "S", 10, "#2e5cb8", null, "4.5", "5.5");
         await expectSummaryValues(page, 2, "I", 10, "#cccc00", null, "4.5", "5.5");
         await expectSummaryValues(page, 3, "R", 10, "#cc0044", null, "4.5", "5.5");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -180,5 +180,15 @@ test.describe("Sensitivity tests", () => {
         await expectSummaryValues(page, 64, "S (Set 1)", 1000, "#2e5cb8", "dot");
         await expectSummaryValues(page, 65, "I (Set 1)", 1000, "#cccc00", "dot");
         await expectSummaryValues(page, 66, "R (Set 1)", 1000, "#cc0044", "dot");
+
+        // Switch to summary view
+        await page.locator("#sensitivity-plot-type select").selectOption("ValueAtTime");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6,{ timeout });
+        await expectSummaryValues(page, 1, "S", 10, "#2e5cb8", null, "4.5", "5.5");
+        await expectSummaryValues(page, 2, "I", 10, "#cccc00", null, "4.5", "5.5");
+        await expectSummaryValues(page, 3, "R", 10, "#cc0044", null, "4.5", "5.5");
+        await expectSummaryValues(page, 4, "S (Set 1)", 10, "#2e5cb8", "dot", "3.6", "4.4");
+        await expectSummaryValues(page, 5, "I (Set 1)", 10, "#cccc00", "dot", "3.6", "4.4");
+        await expectSummaryValues(page, 6, "R (Set 1)", 10, "#cc0044", "dot", "3.6", "4.4");
     });
 });

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -105,7 +105,8 @@ test.describe("Sessions tests", () => {
         await page.click("#edit-current-session-label");
         await enterSessionLabel(page, "header-edit-session-label", "current session label");
         await expect(await page.locator(":nth-match(.session-label, 1)")).toHaveText(
-            "current session label", { timeout });
+            "current session label", { timeout }
+        );
         await expect(await page.innerText("#sessions-menu")).toBe("Session: current session label");
 
         // Set the current session label on a previous session

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -112,7 +112,9 @@ test.describe("Sessions tests", () => {
         // Set the current session label on a previous session
         await page.click(":nth-match(.session-edit-label i, 2)");
         await enterSessionLabel(page, "page-edit-session-label", "previous session label");
-        await expect(await page.innerText(":nth-match(.session-label, 2)")).toBe("previous session label");
+        await expect(await page.locator(":nth-match(.session-label, 2)")).toHaveText(
+            "previous session label", { timeout }
+        );
 
         // NB this will load the second load link, i.e. the older session, not the current one
         await page.click(":nth-match(.session-load a, 3)"); // 3rd because there are two of these on the current

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -104,7 +104,8 @@ test.describe("Sessions tests", () => {
         await page.click("#sessions-menu");
         await page.click("#edit-current-session-label");
         await enterSessionLabel(page, "header-edit-session-label", "current session label");
-        await expect(await page.innerText(":nth-match(.session-label, 1)")).toBe("current session label");
+        await expect(await page.locator(":nth-match(.session-label, 1)")).toHaveText(
+            "current session label", { timeout });
         await expect(await page.innerText("#sessions-menu")).toBe("Session: current session label");
 
         // Set the current session label on a previous session

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -131,13 +131,13 @@ export const expectWodinPlotDataSummary = async (summaryLocator: Locator, name: 
 };
 
 export const expectSummaryValues = async (page: Page, idx: number, name: string, count: number, color: string,
-    dash: string | null = null) => {
+    dash: string | null = null, xMin = "0", xMax = "100") => {
     const summary = ".wodin-plot-data-summary-series";
     const locator = `:nth-match(${summary}, ${idx})`;
     expect(await page.getAttribute(locator, "name")).toBe(name);
     expect(await page.getAttribute(locator, "count")).toBe(count.toString());
-    expect(await page.getAttribute(locator, "x-min")).toBe("0");
-    expect(await page.getAttribute(locator, "x-max")).toBe("100");
+    expect(await page.getAttribute(locator, "x-min")).toBe(xMin);
+    expect(await page.getAttribute(locator, "x-max")).toBe(xMax);
     expect(await page.getAttribute(locator, "mode")).toBe("lines");
     expect(await page.getAttribute(locator, "line-color")).toBe(color);
     expect(await page.getAttribute(locator, "line-dash")).toBe(dash);

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -15,6 +15,7 @@ import {
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
 import { RunGetter } from "../../../../src/app/store/run/getters";
+import WodinPlotDataSummary from "../../../../src/app/components/WodinPlotDataSummary.vue";
 
 jest.mock("plotly.js-basic-dist-min", () => ({
     newPlot: jest.fn(),
@@ -301,6 +302,8 @@ describe("SensitivitySummaryPlot", () => {
         expect(mockPlotlyNewPlot.mock.calls[0][1]).toStrictEqual(expectedPlotData);
         expect(mockPlotlyNewPlot.mock.calls[0][2]).toStrictEqual(expectedLayout);
         expect(mockPlotlyNewPlot.mock.calls[0][3]).toStrictEqual({ responsive: true });
+
+        expect(wrapper.findComponent(WodinPlotDataSummary).props("data")).toStrictEqual(expectedPlotData);
     };
 
     it("plots ValueAtTime data as expected", () => {

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -1,5 +1,4 @@
 // Mock the import of plotly so we can mock Plotly methods
-
 jest.mock("plotly.js-basic-dist-min", () => ({
     newPlot: jest.fn(),
     react: jest.fn(),
@@ -14,6 +13,7 @@ import { nextTick } from "vue";
 import * as plotly from "plotly.js-basic-dist-min";
 import Vuex, { Store } from "vuex";
 import WodinPlot from "../../../src/app/components/WodinPlot.vue";
+import WodinPlotDataSummary from "../../../src/app/components/WodinPlotDataSummary.vue";
 import { BasicState } from "../../../src/app/store/basic/state";
 
 describe("WodinPlot", () => {
@@ -121,6 +121,16 @@ describe("WodinPlot", () => {
         expect(wrapper.find("div.wodin-plot-container").find("h3").text()).toBe("test slot content");
     });
 
+    it("renders data summary", async () => {
+        const wrapper = getWrapper();
+        mockPlotElementOn(wrapper);
+
+        await wrapper.setProps({ redrawWatches: [{} as any] });
+        const summary = wrapper.findComponent(WodinPlotDataSummary);
+        expect(summary.exists()).toBe(true);
+        expect(summary.props("data")).toStrictEqual(mockPlotData);
+    });
+
     it("draws plot and sets event handler when solutions are updated", async () => {
         const wrapper = getWrapper();
         const mockOn = mockPlotElementOn(wrapper);
@@ -154,34 +164,6 @@ describe("WodinPlot", () => {
         expect(mockPlotlyNewPlot).toHaveBeenCalledTimes(1);
 
         expect(mockOn).not.toHaveBeenCalled();
-    });
-
-    it("renders hidden data summary elements", async () => {
-        const wrapper = getWrapper();
-        mockPlotElementOn(wrapper);
-
-        await wrapper.setProps({ redrawWatches: [{} as any] });
-        const summaryContainer = wrapper.find(".wodin-plot-data-summary");
-        const seriesSummaries = summaryContainer.findAll(".wodin-plot-data-summary-series");
-        expect(seriesSummaries.length).toBe(2);
-        const summary1 = seriesSummaries.at(0)!;
-        expect(summary1.attributes("name")).toBe("test markers");
-        expect(summary1.attributes("count")).toBe("2");
-        expect(summary1.attributes("x-min")).toBe("1");
-        expect(summary1.attributes("x-max")).toBe("2");
-        expect(summary1.attributes("y-min")).toBe("3");
-        expect(summary1.attributes("y-max")).toBe("4");
-        expect(summary1.attributes("mode")).toBe("markers");
-        expect(summary1.attributes("marker-color")).toBe("#ff0000");
-        const summary2 = seriesSummaries.at(1)!;
-        expect(summary2.attributes("name")).toBe("test lines");
-        expect(summary2.attributes("count")).toBe("3");
-        expect(summary2.attributes("x-min")).toBe("0");
-        expect(summary2.attributes("x-max")).toBe("20");
-        expect(summary2.attributes("y-min")).toBe("7");
-        expect(summary2.attributes("y-max")).toBe("9");
-        expect(summary2.attributes("mode")).toBe("lines");
-        expect(summary2.attributes("line-color")).toBe("#ff00ff");
     });
 
     it("does not draw run plot if base data is null", async () => {

--- a/app/static/tests/unit/components/wodinPlotDataSummary.test.ts
+++ b/app/static/tests/unit/components/wodinPlotDataSummary.test.ts
@@ -1,0 +1,68 @@
+import { shallowMount } from "@vue/test-utils";
+import WodinPlotDataSummary from "../../../src/app/components/WodinPlotDataSummary.vue";
+
+describe("WodinPlotDataSummary", () => {
+    const getWrapper = () => {
+        const data = [
+            {
+                name: "test markers",
+                x: [1, 2],
+                y: [3, 4],
+                mode: "markers",
+                marker: {
+                    color: "#ff0000"
+                }
+            },
+            {
+                name: "test lines",
+                x: [0, 10, 20],
+                y: [7, 8, 9],
+                mode: "lines",
+                line: {
+                    color: "#ff00ff",
+                    dash: "dot"
+                }
+            }
+        ] as any;
+        return shallowMount(WodinPlotDataSummary, {
+            props: { data }
+        });
+    };
+
+    it("renders hidden data summary elements", async () => {
+        const wrapper = getWrapper();
+        const summaryContainer = wrapper.find(".wodin-plot-data-summary");
+        const seriesSummaries = summaryContainer.findAll(".wodin-plot-data-summary-series");
+        expect(seriesSummaries.length).toBe(2);
+        const summary1 = seriesSummaries.at(0)!;
+        expect(summary1.attributes("name")).toBe("test markers");
+        expect(summary1.attributes("count")).toBe("2");
+        expect(summary1.attributes("x-min")).toBe("1");
+        expect(summary1.attributes("x-max")).toBe("2");
+        expect(summary1.attributes("y-min")).toBe("3");
+        expect(summary1.attributes("y-max")).toBe("4");
+        expect(summary1.attributes("mode")).toBe("markers");
+        expect(summary1.attributes("line-dash")).toBe(undefined);
+        expect(summary1.attributes("marker-color")).toBe("#ff0000");
+        const summary2 = seriesSummaries.at(1)!;
+        expect(summary2.attributes("name")).toBe("test lines");
+        expect(summary2.attributes("count")).toBe("3");
+        expect(summary2.attributes("x-min")).toBe("0");
+        expect(summary2.attributes("x-max")).toBe("20");
+        expect(summary2.attributes("y-min")).toBe("7");
+        expect(summary2.attributes("y-max")).toBe("9");
+        expect(summary2.attributes("mode")).toBe("lines");
+        expect(summary2.attributes("line-dash")).toBe("dot");
+        expect(summary2.attributes("line-color")).toBe("#ff00ff");
+    });
+
+    it("renders nothing if no data or empty data", () => {
+        const emptyWrapper = shallowMount(WodinPlotDataSummary, {
+            props: { data: [] }
+        });
+        expect(emptyWrapper.find("div").exists()).toBe(false);
+
+        const nullWrapper = shallowMount(WodinPlotDataSummary, {});
+        expect(nullWrapper.find("div").exists()).toBe(false);
+    });
+});


### PR DESCRIPTION
This branch adds hidden data summary info to the `SensitivitySummaryPlot` to match `WodinPlot`. The relevant parts of template have been pulled out of `WodinPlot` and made into a separate component which is now used by both plots. 

I've also added a missing e2e test, for parameter set traces rendered in the sensitivity summary plot, using the new data summary. 

Updated session e2e test which had become flaky - don't assume labels will update immediately. 