### PR TITLE
Will add another icon button on the parameter set to swap parameter set with current parameter values

### DIFF
--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -20,7 +20,7 @@
                      :disabled="!canSwapParameterSet"
                      :stroke="canSwapParameterSet ? 'black' : 'lightgray'"
                      @click="swapParameterSet"
-                     v-tooltip="'Swap Parameter Set'"></vue-feather>
+                     v-tooltip="'Swap Parameter Set with Current Parameter Values'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"
                      type="trash-2"
                      @click="deleteParameterSet"
@@ -98,7 +98,7 @@ export default defineComponent({
 
         const runRequired = computed(() => store.getters[`run/${RunGetter.runIsRequired}`]);
         const canSwapParameterSet = computed(() => {
-          return !(store.state.model.compileRequired || runRequired.value);
+            return !(store.state.model.compileRequired || runRequired.value);
         });
 
         return {

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -17,6 +17,8 @@
                      v-tooltip="'Show Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable swap-param-set ms-2"
                      type="shuffle"
+                     :disabled="!canSwapParameterSet"
+                     :stroke="canSwapParameterSet ? 'black' : 'lightgray'"
                      @click="swapParameterSet"
                      v-tooltip="'Swap Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"
@@ -45,6 +47,7 @@ import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
 import { RunMutation } from "../../store/run/mutations";
 import { paramSetLineStyle } from "../../plot";
+import { RunGetter } from "../../store/run/getters";
 
 export default defineComponent({
     name: "ParameterSetView",
@@ -93,12 +96,18 @@ export default defineComponent({
             store.commit(`run/${RunMutation.ToggleParameterSetHidden}`, props.parameterSet.name);
         };
 
+        const runRequired = computed(() => store.getters[`run/${RunGetter.runIsRequired}`]);
+        const canSwapParameterSet = computed(() => {
+          return !(store.state.model.compileRequired || runRequired.value);
+        });
+
         return {
             lineStyleClass,
             getStyle,
             deleteParameterSet,
             swapParameterSet,
-            toggleHidden
+            toggleHidden,
+            canSwapParameterSet
         };
     }
 });

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -15,6 +15,10 @@
                      type="eye"
                      @click="toggleHidden"
                      v-tooltip="'Show Parameter Set'"></vue-feather>
+        <vue-feather class="inline-icon clickable swap-param-set ms-2"
+                     type="refresh-cw"
+                     @click="swapParameterSet"
+                     v-tooltip="'Swap Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"
                      type="trash-2"
                      @click="deleteParameterSet"
@@ -81,6 +85,10 @@ export default defineComponent({
             store.dispatch(`run/${RunAction.DeleteParameterSet}`, props.parameterSet.name);
         };
 
+        const swapParameterSet = () => {
+            store.dispatch(`run/${RunAction.SwapParameterSet}`, props.parameterSet.name);
+        };
+
         const toggleHidden = () => {
             store.commit(`run/${RunMutation.ToggleParameterSetHidden}`, props.parameterSet.name);
         };
@@ -89,6 +97,7 @@ export default defineComponent({
             lineStyleClass,
             getStyle,
             deleteParameterSet,
+            swapParameterSet,
             toggleHidden
         };
     }

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -19,6 +19,7 @@
                      type="shuffle"
                      :disabled="!canSwapParameterSet"
                      :stroke="canSwapParameterSet ? 'black' : 'lightgray'"
+                     :style="{ cursor: canSwapParameterSet ? 'pointer' : 'default' }"
                      @click="swapParameterSet"
                      v-tooltip="'Swap Parameter Set with Current Parameter Values'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"
@@ -46,7 +47,7 @@ import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
 import { RunMutation } from "../../store/run/mutations";
-import { paramSetLineStyle } from "../../plot";
+import { paramSetLineStyle } from '../../plot';
 import { RunGetter } from "../../store/run/getters";
 
 export default defineComponent({

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -16,7 +16,7 @@
                      @click="toggleHidden"
                      v-tooltip="'Show Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable swap-param-set ms-2"
-                     type="refresh-cw"
+                     type="shuffle"
                      @click="swapParameterSet"
                      v-tooltip="'Swap Parameter Set'"></vue-feather>
         <vue-feather class="inline-icon clickable delete-param-set ms-2"

--- a/app/static/src/app/components/options/ParameterSetView.vue
+++ b/app/static/src/app/components/options/ParameterSetView.vue
@@ -47,7 +47,7 @@ import VueFeather from "vue-feather";
 import { ParameterSet } from "../../store/run/state";
 import { RunAction } from "../../store/run/actions";
 import { RunMutation } from "../../store/run/mutations";
-import { paramSetLineStyle } from '../../plot';
+import { paramSetLineStyle } from "../../plot";
 import { RunGetter } from "../../store/run/getters";
 
 export default defineComponent({

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -15,7 +15,8 @@ export enum RunAction {
     RunModelOnRehydrate = "RunModelOnRehydrate",
     DownloadOutput = "DownloadOutput",
     NewParameterSet = "NewParameterSet",
-    DeleteParameterSet = "DeleteParameterSet"
+    DeleteParameterSet = "DeleteParameterSet",
+    SwapParameterSet = "SwapParameterSet"
 }
 
 const runOdeModel = (parameterValues: OdinUserType, startTime: number, endTime: number, runner: OdinRunnerOde,
@@ -166,5 +167,14 @@ export const actions: ActionTree<RunState, AppState> = {
         const { commit } = context;
         commit(RunMutation.DeleteParameterSet, parameterSetName);
         commit(`sensitivity/${SensitivityMutation.ParameterSetDeleted}`, parameterSetName, { root: true });
-    }
+    },
+
+    [RunAction.SwapParameterSet](context, parameterSetName: string) {
+        const { commit, getters } = context;
+        // Swapping parameter sets when run is required is disallowed in UI, but check here too
+        if (!getters[RunGetter.runIsRequired]) {
+            commit(RunMutation.SwapParameterSet, parameterSetName);
+            // commit(`sensitivity/${SensitivityMutation.ParameterSetAdded}`, name, { root: true });
+        }
+    },
 };

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -174,7 +174,7 @@ export const actions: ActionTree<RunState, AppState> = {
         // Swapping parameter sets when run is required is disallowed in UI, but check here too
         if (!getters[RunGetter.runIsRequired]) {
             commit(RunMutation.SwapParameterSet, parameterSetName);
-            // commit(`sensitivity/${SensitivityMutation.ParameterSetAdded}`, name, { root: true });
+            commit(`sensitivity/${SensitivityMutation.ParameterSetSwapped}`, parameterSetName, { root: true });
         }
     },
 };

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -171,7 +171,7 @@ export const actions: ActionTree<RunState, AppState> = {
 
     [RunAction.SwapParameterSet](context, parameterSetName: string) {
         const { commit, getters } = context;
-        // Swapping parameter sets when run is required is disallowed in UI, but check here too
+        // Swapping parameter sets when run is required is disallowed to stop replacing saving parameter sets without results
         if (!getters[RunGetter.runIsRequired]) {
             commit(RunMutation.SwapParameterSet, parameterSetName);
             commit(`sensitivity/${SensitivityMutation.ParameterSetSwapped}`, parameterSetName, { root: true });

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -171,10 +171,11 @@ export const actions: ActionTree<RunState, AppState> = {
 
     [RunAction.SwapParameterSet](context, parameterSetName: string) {
         const { commit, getters } = context;
-        // Swapping parameter sets when run is required is disallowed to stop replacing saving parameter sets without results
+        // Swapping parameter sets when run is required is disallowed 
+        // to stop replacing saving parameter sets without results
         if (!getters[RunGetter.runIsRequired]) {
             commit(RunMutation.SwapParameterSet, parameterSetName);
             commit(`sensitivity/${SensitivityMutation.ParameterSetSwapped}`, parameterSetName, { root: true });
         }
-    },
+    }
 };

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -171,7 +171,7 @@ export const actions: ActionTree<RunState, AppState> = {
 
     [RunAction.SwapParameterSet](context, parameterSetName: string) {
         const { commit, getters } = context;
-        // Swapping parameter sets when run is required is disallowed 
+        // Swapping parameter sets when run is required is disallowed
         // to stop replacing saving parameter sets without results
         if (!getters[RunGetter.runIsRequired]) {
             commit(RunMutation.SwapParameterSet, parameterSetName);

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -106,10 +106,12 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
         if (paramSet && state.parameterValues) {
-            [state.parameterValues, paramSet.parameterValues] = [paramSet.parameterValues, state.parameterValues]
+            [state.parameterValues, paramSet.parameterValues] 
+            = [paramSet.parameterValues, state.parameterValues];
         }
         if (state.parameterSetResults[parameterSetName] && state.resultOde) {
-            [state.parameterSetResults[parameterSetName], state.resultOde] = [state.resultOde, state.parameterSetResults[parameterSetName]]
+            [state.parameterSetResults[parameterSetName], state.resultOde] 
+            = [state.resultOde, state.parameterSetResults[parameterSetName]];
         }
     },
 

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -106,12 +106,12 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
         if (paramSet && state.parameterValues) {
-            const temp = { ...state.parameterValues };
+            const temp = state.parameterValues;
             state.parameterValues = paramSet.parameterValues;
             paramSet.parameterValues = temp;
         }
         if (state.parameterSetResults[parameterSetName] && state.resultOde) {
-            const temp = { ...state.resultOde };
+            const temp = state.resultOde;
             state.resultOde = state.parameterSetResults[parameterSetName];
             state.parameterSetResults[parameterSetName] = temp;
         }

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -107,13 +107,13 @@ export const mutations: MutationTree<RunState> = {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
         if (paramSet && state.parameterValues && state.resultOde) {
             // swap values
-            const temp = state.parameterValues;
+            const value = state.parameterValues;
             state.parameterValues = paramSet.parameterValues;
-            paramSet.parameterValues = temp;
+            paramSet.parameterValues = value;
             // swap results
-            const tempResult = state.resultOde;
+            const result = state.resultOde;
             state.resultOde = state.parameterSetResults[parameterSetName];
-            state.parameterSetResults[parameterSetName] = tempResult;
+            state.parameterSetResults[parameterSetName] = result;
         }
     },
 

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -17,6 +17,7 @@ export enum RunMutation {
     SetParameterSetResult = "SetParameterSetResult",
     AddParameterSet = "AddParameterSet",
     DeleteParameterSet = "DeleteParameterSet",
+    SwapParameterSet = "SwapParameterSet",
     ToggleParameterSetHidden = "ToggleParameterSetHidden"
 }
 
@@ -100,6 +101,16 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.DeleteParameterSet](state: RunState, parameterSetName: string) {
         state.parameterSets = state.parameterSets.filter((set: ParameterSet) => set.name !== parameterSetName);
         delete state.parameterSetResults[parameterSetName];
+    },
+
+    [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
+        const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
+        if (paramSet && state.parameterValues) {
+            [state.parameterValues, paramSet.parameterValues] = [paramSet.parameterValues, state.parameterValues]
+        }
+        if (state.parameterSetResults[parameterSetName] && state.resultOde) {
+            [state.parameterSetResults[parameterSetName], state.resultOde] = [state.resultOde, state.parameterSetResults[parameterSetName]]
+        }
     },
 
     [RunMutation.ToggleParameterSetHidden](state: RunState, parameterSetName: string) {

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -105,15 +105,15 @@ export const mutations: MutationTree<RunState> = {
 
     [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
-        if (paramSet && state.parameterValues) {
+        if (paramSet && state.parameterValues && state.resultOde) {
+            // swap values
             const temp = state.parameterValues;
             state.parameterValues = paramSet.parameterValues;
             paramSet.parameterValues = temp;
-        }
-        if (state.parameterSetResults[parameterSetName] && state.resultOde) {
-            const temp = state.resultOde;
+            // swap results
+            const tempResult = state.resultOde;
             state.resultOde = state.parameterSetResults[parameterSetName];
-            state.parameterSetResults[parameterSetName] = temp;
+            state.parameterSetResults[parameterSetName] = tempResult;
         }
     },
 

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -106,12 +106,12 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
         if (paramSet && state.parameterValues) {
-            const temp = structuredClone(state.parameterValues);
+            const temp = { ...state.parameterValues };
             state.parameterValues = paramSet.parameterValues;
             paramSet.parameterValues = temp;
         }
         if (state.parameterSetResults[parameterSetName] && state.resultOde) {
-            const temp = structuredClone(state.resultOde);
+            const temp = { ...state.resultOde };
             state.resultOde = state.parameterSetResults[parameterSetName];
             state.parameterSetResults[parameterSetName] = temp;
         }

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -106,12 +106,14 @@ export const mutations: MutationTree<RunState> = {
     [RunMutation.SwapParameterSet](state: RunState, parameterSetName: string) {
         const paramSet = state.parameterSets.find((set: ParameterSet) => set.name === parameterSetName);
         if (paramSet && state.parameterValues) {
-            [state.parameterValues, paramSet.parameterValues] 
-            = [paramSet.parameterValues, state.parameterValues];
+            const temp = structuredClone(state.parameterValues);
+            state.parameterValues = paramSet.parameterValues;
+            paramSet.parameterValues = temp;
         }
         if (state.parameterSetResults[parameterSetName] && state.resultOde) {
-            [state.parameterSetResults[parameterSetName], state.resultOde] 
-            = [state.resultOde, state.parameterSetResults[parameterSetName]];
+            const temp = structuredClone(state.resultOde);
+            state.resultOde = state.parameterSetResults[parameterSetName];
+            state.parameterSetResults[parameterSetName] = temp;
         }
     },
 

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -93,7 +93,8 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
         if (state.parameterSetResults[parameterSetName] && state.result) {
-            [state.parameterSetResults[parameterSetName], state.result] = [state.result, state.parameterSetResults[parameterSetName]]
+            [state.parameterSetResults[parameterSetName], state.result] 
+            = [state.result, state.parameterSetResults[parameterSetName]];
         }
-    },
+    }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -21,7 +21,8 @@ export enum SensitivityMutation {
     SetRunning = "SetRunning",
     ParameterSetAdded = "ParameterSetAdded",
     SetParameterSetResults = "SetParameterSetResults",
-    ParameterSetDeleted = "ParameterSetDeleted"
+    ParameterSetDeleted = "ParameterSetDeleted",
+    ParameterSetSwapped = "ParameterSetSwapped"
 }
 
 export const mutations: MutationTree<SensitivityState> = {
@@ -88,5 +89,11 @@ export const mutations: MutationTree<SensitivityState> = {
     },
     [SensitivityMutation.ParameterSetDeleted](state: SensitivityState, parameterSetName: string) {
         delete state.parameterSetResults[parameterSetName];
-    }
+    },
+
+    [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
+        if (state.parameterSetResults[parameterSetName] && state.result) {
+            [state.parameterSetResults[parameterSetName], state.result] = [state.result, state.parameterSetResults[parameterSetName]]
+        }
+    },
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -92,7 +92,7 @@ export const mutations: MutationTree<SensitivityState> = {
     },
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
-        const result = state.result;
+        const { result } = state;
         state.result = state.parameterSetResults[parameterSetName] || null;
         if (!result) {
             delete state.parameterSetResults[parameterSetName];

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -92,7 +92,7 @@ export const mutations: MutationTree<SensitivityState> = {
     },
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
-        if (state.parameterSetResults[parameterSetName] && state.result) {
+        if (state.result) {
             const temp = state.result;
             state.result = state.parameterSetResults[parameterSetName];
             state.parameterSetResults[parameterSetName] = temp;

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -93,7 +93,7 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
         if (state.parameterSetResults[parameterSetName] && state.result) {
-            const temp = structuredClone(state.result);
+            const temp = { ...state.result };
             state.result = state.parameterSetResults[parameterSetName];
             state.parameterSetResults[parameterSetName] = temp;
         }

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -92,14 +92,12 @@ export const mutations: MutationTree<SensitivityState> = {
     },
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
-        if (state.result) {
-            const temp = state.result;
-            state.result = state.parameterSetResults[parameterSetName] || null;
-            if (temp == null) {
-                delete state.parameterSetResults[parameterSetName];
-            } else {
-                state.parameterSetResults[parameterSetName] = temp;
-            }
+        const temp = state.result;
+        state.result = state.parameterSetResults[parameterSetName] || null;
+        if (temp == null) {
+            delete state.parameterSetResults[parameterSetName];
+        } else {
+            state.parameterSetResults[parameterSetName] = temp;
         }
     }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -92,12 +92,12 @@ export const mutations: MutationTree<SensitivityState> = {
     },
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
-        const temp = state.result;
+        const result = state.result;
         state.result = state.parameterSetResults[parameterSetName] || null;
-        if (temp == null) {
+        if (!result) {
             delete state.parameterSetResults[parameterSetName];
         } else {
-            state.parameterSetResults[parameterSetName] = temp;
+            state.parameterSetResults[parameterSetName] = result;
         }
     }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -93,8 +93,9 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
         if (state.parameterSetResults[parameterSetName] && state.result) {
-            [state.parameterSetResults[parameterSetName], state.result] 
-            = [state.result, state.parameterSetResults[parameterSetName]];
+            const temp = structuredClone(state.result);
+            state.result = state.parameterSetResults[parameterSetName];
+            state.parameterSetResults[parameterSetName] = temp;
         }
     }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -94,8 +94,12 @@ export const mutations: MutationTree<SensitivityState> = {
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
         if (state.result) {
             const temp = state.result;
-            state.result = state.parameterSetResults[parameterSetName];
-            state.parameterSetResults[parameterSetName] = temp;
+            state.result = state.parameterSetResults[parameterSetName] || null;
+            if (temp == null) {
+                delete state.parameterSetResults[parameterSetName];
+            } else {
+                state.parameterSetResults[parameterSetName] = temp;
+            }
         }
     }
 };

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -93,7 +93,7 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.ParameterSetSwapped](state: SensitivityState, parameterSetName: string) {
         if (state.parameterSetResults[parameterSetName] && state.result) {
-            const temp = { ...state.result };
+            const temp = state.result;
             state.result = state.parameterSetResults[parameterSetName];
             state.parameterSetResults[parameterSetName] = temp;
         }

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -246,39 +246,62 @@ test.describe("Options Tab tests", () => {
         await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
     });
 
-    test("can swap a parameter set", async ({ page }) => {
+    test("can swap a parameter set and its run traces", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", "6");
+        await page.fill(":nth-match(#model-params input, 2)", "1000000");
+        await page.fill(":nth-match(#model-params input, 3)", "1000000");
+        await page.fill(":nth-match(#model-params input, 4)", "0");
+        await page.click("#run-btn");
         await createParameterSet(page);
         await page.fill(":nth-match(#model-params input, 1)", "5");
-        await page.fill(":nth-match(#model-params input, 2)", "2");
-        await page.fill(":nth-match(#model-params input, 3)", "2000000");
+        await page.fill(":nth-match(#model-params input, 2)", "0");
+        await page.fill(":nth-match(#model-params input, 3)", "1000000");
         await page.fill(":nth-match(#model-params input, 4)", "1.5");
         await page.click("#run-btn");
         await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
 
         await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("5");
-        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("2");
-        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("2,000,000");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("0");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1,000,000");
         await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("1.5");
 
         await expect((await page.innerText(".parameter-set .card-header")).trim()).toBe("Set 1");
-        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 4");
-        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 1");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 6");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 1000000");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 1000000");
-        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 4)")).toBe("sigma: 2");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 4)")).toBe("sigma: 0");
+
+        // current parameters
+        await expectSummaryValues(page, 1, "S", 1000, "#2e5cb8", null, "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 2, "I", 1000, "#cccc00", null, "0", "100", "0", "0");
+        await expectSummaryValues(page, 3, "R", 1000, "#cc0044", null, "0", "100", "0", "0");
+        // parameter set
+        await expectSummaryValues(page, 4, "S (Set 1)", 1000, "#2e5cb8", "dot", "0", "100", "0", "0");
+        await expectSummaryValues(page, 5, "I (Set 1)", 1000, "#cccc00", "dot", "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 6, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
 
         await swapParameterSet(1, page);
         await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
 
-        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
-        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("6");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1,000,000");
         await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1,000,000");
-        await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
+        await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("0");
 
         await expect((await page.innerText(".parameter-set .card-header")).trim()).toBe("Set 1");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 5");
-        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 2");
-        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 2000000");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 0");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 1000000");
         await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 4)")).toBe("sigma: 1.5");
+
+        // current parameters
+        await expectSummaryValues(page, 1, "S", 1000, "#2e5cb8", null, "0", "100", "0", "0");
+        await expectSummaryValues(page, 2, "I", 1000, "#cccc00", null, "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 3, "R", 1000, "#cc0044", null, "0", "100", "0", "0");
+        // parameter set
+        await expectSummaryValues(page, 4, "S (Set 1)", 1000, "#2e5cb8", "dot", "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 5, "I (Set 1)", 1000, "#cccc00", "dot", "0", "100", "0", "0");
+        await expectSummaryValues(page, 6, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
     });
 
     test("can hide and show a parameter set", async ({ page }) => {

--- a/app/static/tests/e2e/options.etest.ts
+++ b/app/static/tests/e2e/options.etest.ts
@@ -205,6 +205,10 @@ test.describe("Options Tab tests", () => {
         await page.click(`:nth-match(.delete-param-set, ${index})`);
     };
 
+    const swapParameterSet = async (index: number, page: Page) => {
+        await page.click(`:nth-match(.swap-param-set, ${index})`);
+    };
+
     const updateBetaParamAndRun = async (value: number, page: Page) => {
         await page.fill(":nth-match(.parameter-input, 1)", value.toString());
         await page.click("#run-btn");
@@ -240,6 +244,41 @@ test.describe("Options Tab tests", () => {
         await expectSummaryValues(page, 1, "S", 1000, "#2e5cb8");
         await expectSummaryValues(page, 2, "I", 1000, "#cccc00");
         await expectSummaryValues(page, 3, "R", 1000, "#cc0044");
+    });
+
+    test("can swap a parameter set", async ({ page }) => {
+        await createParameterSet(page);
+        await page.fill(":nth-match(#model-params input, 1)", "5");
+        await page.fill(":nth-match(#model-params input, 2)", "2");
+        await page.fill(":nth-match(#model-params input, 3)", "2000000");
+        await page.fill(":nth-match(#model-params input, 4)", "1.5");
+        await page.click("#run-btn");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
+
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("5");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("2");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("2,000,000");
+        await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("1.5");
+
+        await expect((await page.innerText(".parameter-set .card-header")).trim()).toBe("Set 1");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 4");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 1");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 1000000");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 4)")).toBe("sigma: 2");
+
+        await swapParameterSet(1, page);
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(6, { timeout });
+
+        await expect(await page.inputValue(":nth-match(#model-params input, 1)")).toBe("4");
+        await expect(await page.inputValue(":nth-match(#model-params input, 2)")).toBe("1");
+        await expect(await page.inputValue(":nth-match(#model-params input, 3)")).toBe("1,000,000");
+        await expect(await page.inputValue(":nth-match(#model-params input, 4)")).toBe("2");
+
+        await expect((await page.innerText(".parameter-set .card-header")).trim()).toBe("Set 1");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 1)")).toBe("beta: 5");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 2)")).toBe("I0: 2");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 3)")).toBe("N: 2000000");
+        await expect(await page.innerText(":nth-match(.parameter-set .card-body span.badge, 4)")).toBe("sigma: 1.5");
     });
 
     test("can hide and show a parameter set", async ({ page }) => {

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -191,4 +191,40 @@ test.describe("Sensitivity tests", () => {
         await expectSummaryValues(page, 5, "I (Set 1)", 10, "#cccc00", "dot", "3.6", "4.4");
         await expectSummaryValues(page, 6, "R (Set 1)", 10, "#cc0044", "dot", "3.6", "4.4");
     });
+
+    test("can swap sensitivity run traces", async ({ page }) => {
+        await page.fill(":nth-match(#model-params input, 1)", "6");
+        await page.fill(":nth-match(#model-params input, 2)", "1000000");
+        await page.fill(":nth-match(#model-params input, 3)", "1000000");
+        await page.fill(":nth-match(#model-params input, 4)", "0");
+        await page.click("#run-sens-btn");
+        await page.click("#create-param-set");
+        await page.fill(":nth-match(#model-params input, 1)", "5");
+        await page.fill(":nth-match(#model-params input, 2)", "0");
+        await page.fill(":nth-match(#model-params input, 3)", "1000000");
+        await page.fill(":nth-match(#model-params input, 4)", "1.5");
+        await page.click("#run-sens-btn");
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(66, { timeout });
+
+        // current parameters
+        await expectSummaryValues(page, 31, "S", 1000, "#2e5cb8", null, "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 32, "I", 1000, "#cccc00", null, "0", "100", "0", "0");
+        await expectSummaryValues(page, 33, "R", 1000, "#cc0044", null, "0", "100", "0", "0");
+        // parameter set
+        await expectSummaryValues(page, 64, "S (Set 1)", 1000, "#2e5cb8", "dot", "0", "100", "0", "0");
+        await expectSummaryValues(page, 65, "I (Set 1)", 1000, "#cccc00", "dot", "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 66, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
+
+        await page.click(`:nth-match(.swap-param-set, ${1})`);
+        await expect(await page.locator(".wodin-plot-data-summary-series")).toHaveCount(66, { timeout });
+
+        // current parameters
+        await expectSummaryValues(page, 31, "S", 1000, "#2e5cb8", null, "0", "100", "0", "0");
+        await expectSummaryValues(page, 32, "I", 1000, "#cccc00", null, "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 33, "R", 1000, "#cc0044", null, "0", "100", "0", "0");
+        // parameter set
+        await expectSummaryValues(page, 64, "S (Set 1)", 1000, "#2e5cb8", "dot", "0", "100", "1000000", "1000000");
+        await expectSummaryValues(page, 65, "I (Set 1)", 1000, "#cccc00", "dot", "0", "100", "0", "0");
+        await expectSummaryValues(page, 66, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
+    });
 });

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -131,7 +131,7 @@ export const expectWodinPlotDataSummary = async (summaryLocator: Locator, name: 
 };
 
 export const expectSummaryValues = async (page: Page, idx: number, name: string, count: number, color: string,
-    dash: string | null = null, xMin = "0", xMax = "100") => {
+    dash: string | null = null, xMin = "0", xMax = "100", yMin: string | null = null, yMax: string | null = null) => {
     const summary = ".wodin-plot-data-summary-series";
     const locator = `:nth-match(${summary}, ${idx})`;
     expect(await page.getAttribute(locator, "name")).toBe(name);
@@ -141,4 +141,10 @@ export const expectSummaryValues = async (page: Page, idx: number, name: string,
     expect(await page.getAttribute(locator, "mode")).toBe("lines");
     expect(await page.getAttribute(locator, "line-color")).toBe(color);
     expect(await page.getAttribute(locator, "line-dash")).toBe(dash);
+    if (yMin) {
+        expect(await page.getAttribute(locator, "y-min")).toBe(yMin);
+    }
+    if (yMax) {
+        expect(await page.getAttribute(locator, "y-max")).toBe(yMax);
+    }
 };

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -11,6 +11,7 @@ describe("ParameterSetView", () => {
     const mockDeleteParameterSet = jest.fn();
     const mockToggleParameterSetHidden = jest.fn();
     const mockTooltipDirective = jest.fn();
+    const mockSwapParameterSet = jest.fn();
 
     beforeEach(() => {
         jest.resetAllMocks();
@@ -26,7 +27,8 @@ describe("ParameterSetView", () => {
                         parameterValues: { alpha: 1, beta: 2, gamma: 3 }
                     }),
                     actions: {
-                        [RunAction.DeleteParameterSet]: mockDeleteParameterSet
+                        [RunAction.DeleteParameterSet]: mockDeleteParameterSet,
+                        [RunAction.SwapParameterSet]: mockSwapParameterSet
                     },
                     mutations: {
                         [RunMutation.ToggleParameterSetHidden]: mockToggleParameterSetHidden
@@ -66,11 +68,14 @@ describe("ParameterSetView", () => {
         expect((paramSpans[2].element as HTMLSpanElement).style.borderColor).toBe("#479fb6");
 
         const icons = wrapper.findAllComponents(VueFeather);
-        expect(icons.length).toBe(2);
+        expect(icons.length).toBe(3);
         const hideIcon = icons.at(0)!;
         expect(hideIcon.classes()).toContain("hide-param-set");
         expect(hideIcon.props("type")).toBe("eye-off");
-        const deleteIcon = icons.at(1)!;
+        const swapIcon = icons.at(1)!;
+        expect(swapIcon.classes()).toContain("swap-param-set");
+        expect(swapIcon.props("type")).toBe("refresh-cw");
+        const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
 
@@ -92,36 +97,44 @@ describe("ParameterSetView", () => {
 
     it("uses tooltip directive", () => {
         const wrapper = getWrapper();
-        expect(mockTooltipDirective).toHaveBeenCalledTimes(2);
+        expect(mockTooltipDirective).toHaveBeenCalledTimes(3);
         const icons = wrapper.findAllComponents(VueFeather);
-        expect(icons.length).toBe(2);
+        expect(icons.length).toBe(3);
         const hideIconEl = icons.at(0)!.element;
         expect(mockTooltipDirective.mock.calls[0][0]).toBe(hideIconEl);
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Hide Parameter Set");
-        const deleteIconEl = icons.at(1)!.element;
-        expect(mockTooltipDirective.mock.calls[1][0]).toBe(deleteIconEl);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Delete Parameter Set");
+        const swapIconEl = icons.at(1)!.element;
+        expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIconEl);
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        const deleteIconEl = icons.at(2)!.element;
+        expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIconEl);
+        expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
     });
 
     it("renders as expected when parameter set is hidden", () => {
         const wrapper = getWrapper(true);
 
         const icons = wrapper.findAllComponents(VueFeather);
-        expect(icons.length).toBe(2);
+        expect(icons.length).toBe(3);
         const showIcon = icons.at(0)!;
         expect(showIcon.classes()).toContain("show-param-set");
         expect(showIcon.props("type")).toBe("eye");
-        const deleteIcon = icons.at(1)!;
+        const swapIcon = icons.at(1)!;
+        expect(swapIcon.classes()).toContain("swap-param-set");
+        expect(swapIcon.props("type")).toBe("refresh-cw");
+        const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
 
         expect(wrapper.find(".card-body").classes()).toContain("hidden-parameter-set");
 
-        expect(mockTooltipDirective).toHaveBeenCalledTimes(2);
+        expect(mockTooltipDirective).toHaveBeenCalledTimes(3);
         expect(mockTooltipDirective.mock.calls[0][0]).toBe(showIcon.element);
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Show Parameter Set");
-        expect(mockTooltipDirective.mock.calls[1][0]).toBe(deleteIcon.element);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Delete Parameter Set");
+        expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIcon.element);
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIcon.element);
+        expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
     });
 
     it("clicking delete icon dispatches DeleteParameterSet action", async () => {
@@ -129,6 +142,13 @@ describe("ParameterSetView", () => {
         await wrapper.find(".delete-param-set").trigger("click");
         expect(mockDeleteParameterSet).toHaveBeenCalledTimes(1);
         expect(mockDeleteParameterSet.mock.calls[0][1]).toBe("Set 1");
+    });
+
+    it("clicking swap icon dispatches SwapParameterSet action", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find(".swap-param-set").trigger("click");
+        expect(mockSwapParameterSet).toHaveBeenCalledTimes(1);
+        expect(mockSwapParameterSet.mock.calls[0][1]).toBe("Set 1");
     });
 
     it("clicking hide icon commits ToggleParameterSetHidden", async () => {

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -2,7 +2,7 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import VueFeather from "vue-feather";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockRunState, mockModelState } from '../../../mocks';
+import { mockBasicState, mockRunState, mockModelState } from "../../../mocks";
 import ParameterSetView from "../../../../src/app/components/options/ParameterSetView.vue";
 import { RunAction } from "../../../../src/app/store/run/actions";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
@@ -21,7 +21,7 @@ describe("ParameterSetView", () => {
     const getWrapper = (paramSetHidden = false, index = 0, modelChanged = false, compileRequired = false) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
-                model: mockModelState({ compileRequired: compileRequired })
+                model: mockModelState({ compileRequired })
             }),
             modules: {
                 run: {
@@ -29,7 +29,7 @@ describe("ParameterSetView", () => {
                     state: mockRunState({
                         parameterValues: { alpha: 1, beta: 2, gamma: 3 },
                         runRequired: {
-                            modelChanged: modelChanged,
+                            modelChanged,
                             parameterValueChanged: false,
                             endTimeChanged: false,
                             numberOfReplicatesChanged: false
@@ -118,7 +118,7 @@ describe("ParameterSetView", () => {
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Hide Parameter Set");
         const swapIconEl = icons.at(1)!.element;
         expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIconEl);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set with Current Parameter Values");
         const deleteIconEl = icons.at(2)!.element;
         expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIconEl);
         expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
@@ -145,7 +145,7 @@ describe("ParameterSetView", () => {
         expect(mockTooltipDirective.mock.calls[0][0]).toBe(showIcon.element);
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Show Parameter Set");
         expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIcon.element);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set with Current Parameter Values");
         expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIcon.element);
         expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
     });
@@ -172,7 +172,7 @@ describe("ParameterSetView", () => {
         expect(mockTooltipDirective.mock.calls[0][0]).toBe(showIcon.element);
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Hide Parameter Set");
         expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIcon.element);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set with Current Parameter Values");
         expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIcon.element);
         expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
     });
@@ -199,7 +199,7 @@ describe("ParameterSetView", () => {
         expect(mockTooltipDirective.mock.calls[0][0]).toBe(showIcon.element);
         expect(mockTooltipDirective.mock.calls[0][1].value).toBe("Hide Parameter Set");
         expect(mockTooltipDirective.mock.calls[1][0]).toBe(swapIcon.element);
-        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set");
+        expect(mockTooltipDirective.mock.calls[1][1].value).toBe("Swap Parameter Set with Current Parameter Values");
         expect(mockTooltipDirective.mock.calls[2][0]).toBe(deleteIcon.element);
         expect(mockTooltipDirective.mock.calls[2][1].value).toBe("Delete Parameter Set");
     });
@@ -217,8 +217,6 @@ describe("ParameterSetView", () => {
         expect(mockSwapParameterSet).toHaveBeenCalledTimes(1);
         expect(mockSwapParameterSet.mock.calls[0][1]).toBe("Set 1");
     });
-
-
 
     it("clicking hide icon commits ToggleParameterSetHidden", async () => {
         const wrapper = getWrapper();

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -74,7 +74,7 @@ describe("ParameterSetView", () => {
         expect(hideIcon.props("type")).toBe("eye-off");
         const swapIcon = icons.at(1)!;
         expect(swapIcon.classes()).toContain("swap-param-set");
-        expect(swapIcon.props("type")).toBe("refresh-cw");
+        expect(swapIcon.props("type")).toBe("shuffle");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
@@ -121,7 +121,7 @@ describe("ParameterSetView", () => {
         expect(showIcon.props("type")).toBe("eye");
         const swapIcon = icons.at(1)!;
         expect(swapIcon.classes()).toContain("swap-param-set");
-        expect(swapIcon.props("type")).toBe("refresh-cw");
+        expect(swapIcon.props("type")).toBe("shuffle");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");

--- a/app/static/tests/unit/components/options/parameterSetView.test.ts
+++ b/app/static/tests/unit/components/options/parameterSetView.test.ts
@@ -87,6 +87,7 @@ describe("ParameterSetView", () => {
         expect(swapIcon.classes()).toContain("swap-param-set");
         expect(swapIcon.props("type")).toBe("shuffle");
         expect(swapIcon.props("stroke")).toBe("black");
+        expect((swapIcon.element as HTMLButtonElement).style.cursor).toBe("pointer");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
@@ -135,6 +136,8 @@ describe("ParameterSetView", () => {
         const swapIcon = icons.at(1)!;
         expect(swapIcon.classes()).toContain("swap-param-set");
         expect(swapIcon.props("type")).toBe("shuffle");
+        expect(swapIcon.props("stroke")).toBe("black");
+        expect((swapIcon.element as HTMLButtonElement).style.cursor).toBe("pointer");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
@@ -163,6 +166,7 @@ describe("ParameterSetView", () => {
         expect(swapIcon.classes()).toContain("swap-param-set");
         expect(swapIcon.props("type")).toBe("shuffle");
         expect(swapIcon.props("stroke")).toBe("lightgray");
+        expect((swapIcon.element as HTMLButtonElement).style.cursor).toBe("default");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");
@@ -190,6 +194,7 @@ describe("ParameterSetView", () => {
         expect(swapIcon.classes()).toContain("swap-param-set");
         expect(swapIcon.props("type")).toBe("shuffle");
         expect(swapIcon.props("stroke")).toBe("lightgray");
+        expect((swapIcon.element as HTMLButtonElement).style.cursor).toBe("default");
         const deleteIcon = icons.at(2)!;
         expect(deleteIcon.classes()).toContain("delete-param-set");
         expect(deleteIcon.props("type")).toBe("trash-2");

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -528,6 +528,25 @@ describe("Run actions", () => {
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
     });
 
+    it("SwapParameterSet does nothing if run is required", () => {
+        const state = mockRunState({
+            parameterSetsCreated: 1,
+            parameterValues: { p1: 1, p2: 2 },
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false }],
+            parameterSetResults: { "Set 1": { solution: "another fake result" } } as any,
+            resultOde: { solution: "fake result" } as any
+        });
+
+        const testGetters = {
+            [RunGetter.runIsRequired]: true
+        };
+
+        const commit = jest.fn();
+
+        (actions[RunAction.SwapParameterSet] as any)({ state, getters: testGetters, commit });
+        expect(commit).toHaveBeenCalledTimes(0);
+    });
+
     it("DeleteParameterSet commits run and sensitivity mutations", () => {
         const commit = jest.fn();
         (actions[RunAction.DeleteParameterSet] as any)({ commit }, "Set 1");

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -503,6 +503,31 @@ describe("Run actions", () => {
         expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
     });
 
+    it("SwapParameterSet commits run and sensitivity mutations", () => {
+        const state = mockRunState({
+            parameterSetsCreated: 1,
+            parameterValues: { p1: 1, p2: 2 },
+            parameterSets: [{ name: "Set 1", parameterValues: { p1: 3, p2: 4 }, hidden: false }],
+            parameterSetResults: { "Set 1": { solution: "another fake result" } } as any,
+            resultOde: { solution: "fake result" } as any
+        });
+
+        const commit = jest.fn();
+
+        const testGetters = {
+            [RunGetter.runIsRequired]: false
+        };
+
+        (actions[RunAction.SwapParameterSet] as any)({ state, getters: testGetters, commit }, "Set 1");
+        expect(commit).toHaveBeenCalledTimes(2);
+        // ? ask about better way to test the swap of parameters and results
+        expect(commit.mock.calls[0][0]).toBe(RunMutation.SwapParameterSet);
+        expect(commit.mock.calls[0][1]).toBe("Set 1");
+        expect(commit.mock.calls[1][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetSwapped}`);
+        expect(commit.mock.calls[1][1]).toBe("Set 1");
+        expect(commit.mock.calls[1][2]).toStrictEqual({ root: true });
+    });
+
     it("DeleteParameterSet commits run and sensitivity mutations", () => {
         const commit = jest.fn();
         (actions[RunAction.DeleteParameterSet] as any)({ commit }, "Set 1");

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -520,7 +520,6 @@ describe("Run actions", () => {
 
         (actions[RunAction.SwapParameterSet] as any)({ state, getters: testGetters, commit }, "Set 1");
         expect(commit).toHaveBeenCalledTimes(2);
-        // ? ask about better way to test the swap of parameters and results
         expect(commit.mock.calls[0][0]).toBe(RunMutation.SwapParameterSet);
         expect(commit.mock.calls[0][1]).toBe("Set 1");
         expect(commit.mock.calls[1][0]).toBe(`sensitivity/${SensitivityMutation.ParameterSetSwapped}`);

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -202,6 +202,22 @@ describe("Run mutations", () => {
         expect(state.parameterSetResults).toStrictEqual({ Set2: { value: "test 2" } });
     });
 
+    it("swaps parameter sets with current parameter values", () => {
+        const state = mockRunState({
+            parameterValues: { a: 1 },
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 2 }, hidden: false },
+            ],
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any,
+            resultOde: { solution: "fake result" } as any
+        });
+        mutations.SwapParameterSet(state, "Set1");
+        expect(state.parameterValues).toStrictEqual({ a: 2 });
+        expect(state.parameterSets).toStrictEqual([{ name: "Set1", parameterValues: { a: 1 }, hidden: false }]);
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "fake result" } });
+        expect(state.resultOde).toStrictEqual({ solution: "another fake result" })
+    });
+
     it("toggles parameter set hidden", () => {
         const state = mockRunState({
             parameterSets: [

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -206,7 +206,7 @@ describe("Run mutations", () => {
         const state = mockRunState({
             parameterValues: { a: 1 },
             parameterSets: [
-                { name: "Set1", parameterValues: { a: 2 }, hidden: false },
+                { name: "Set1", parameterValues: { a: 2 }, hidden: false }
             ],
             parameterSetResults: { Set1: { solution: "another fake result" } } as any,
             resultOde: { solution: "fake result" } as any
@@ -215,7 +215,7 @@ describe("Run mutations", () => {
         expect(state.parameterValues).toStrictEqual({ a: 2 });
         expect(state.parameterSets).toStrictEqual([{ name: "Set1", parameterValues: { a: 1 }, hidden: false }]);
         expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "fake result" } });
-        expect(state.resultOde).toStrictEqual({ solution: "another fake result" })
+        expect(state.resultOde).toStrictEqual({ solution: "another fake result" });
     });
 
     it("toggles parameter set hidden", () => {

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -218,6 +218,54 @@ describe("Run mutations", () => {
         expect(state.resultOde).toStrictEqual({ solution: "another fake result" });
     });
 
+    it("does not swap parameter sets if paramSet does not exist", () => {
+        const state = mockRunState({
+            parameterValues: { a: 1 },
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 2 }, hidden: false }
+            ],
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any,
+            resultOde: { solution: "fake result" } as any
+        });
+        mutations.SwapParameterSet(state, "Set2");
+        expect(state.parameterValues).toStrictEqual({ a: 1 });
+        expect(state.parameterSets).toStrictEqual([{ name: "Set1", parameterValues: { a: 2 }, hidden: false }]);
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "another fake result" } });
+        expect(state.resultOde).toStrictEqual({ solution: "fake result" });
+    });
+
+    it("does not swap parameter sets if parameterValues do not exist", () => {
+        const state = mockRunState({
+            parameterValues: null,
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 2 }, hidden: false }
+            ],
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any,
+            resultOde: { solution: "fake result" } as any
+        });
+        mutations.SwapParameterSet(state, "Set2");
+        expect(state.parameterValues).toStrictEqual(null);
+        expect(state.parameterSets).toStrictEqual([{ name: "Set1", parameterValues: { a: 2 }, hidden: false }]);
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "another fake result" } });
+        expect(state.resultOde).toStrictEqual({ solution: "fake result" });
+    });
+
+    it("does not swap parameter sets if resultOde does not exist", () => {
+        const state = mockRunState({
+            parameterValues: { a: 1 },
+            parameterSets: [
+                { name: "Set1", parameterValues: { a: 2 }, hidden: false }
+            ],
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any,
+            resultOde: null
+        });
+        mutations.SwapParameterSet(state, "Set2");
+        expect(state.parameterValues).toStrictEqual({ a: 1 });
+        expect(state.parameterSets).toStrictEqual([{ name: "Set1", parameterValues: { a: 2 }, hidden: false }]);
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "another fake result" } });
+        expect(state.resultOde).toStrictEqual(null);
+    });
+
     it("toggles parameter set hidden", () => {
         const state = mockRunState({
             parameterSets: [

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -175,4 +175,14 @@ describe("Sensitivity mutations", () => {
         mutations.ParameterSetDeleted(state, "Set1");
         expect(state.parameterSetResults).toStrictEqual({ Set2: { batch: "test 2" } });
     });
+
+    it("swaps parameter set results", () => {
+        const state = mockSensitivityState({
+            result: { solution: "fake result" } as any,
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any
+        });
+        mutations.ParameterSetSwapped(state, "Set1");
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "fake result" } });
+        expect(state.result).toStrictEqual({ solution: "another fake result" });
+    });
 });

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -185,4 +185,14 @@ describe("Sensitivity mutations", () => {
         expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "fake result" } });
         expect(state.result).toStrictEqual({ solution: "another fake result" });
     });
+
+    it("does not swap parameter set results if result does not exist", () => {
+        const state = mockSensitivityState({
+            result: null,
+            parameterSetResults: { Set1: { solution: "another fake result" } } as any
+        });
+        mutations.ParameterSetSwapped(state, "Set1");
+        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "another fake result" } });
+        expect(state.result).toStrictEqual(null);
+    });
 });

--- a/app/static/tests/unit/store/sensitivity/mutations.test.ts
+++ b/app/static/tests/unit/store/sensitivity/mutations.test.ts
@@ -186,13 +186,13 @@ describe("Sensitivity mutations", () => {
         expect(state.result).toStrictEqual({ solution: "another fake result" });
     });
 
-    it("does not swap parameter set results if result does not exist", () => {
+    it("deletes set1 key in results if result of Ode was null", () => {
         const state = mockSensitivityState({
             result: null,
             parameterSetResults: { Set1: { solution: "another fake result" } } as any
         });
         mutations.ParameterSetSwapped(state, "Set1");
-        expect(state.parameterSetResults).toStrictEqual({ Set1: { solution: "another fake result" } });
-        expect(state.result).toStrictEqual(null);
+        expect(state.parameterSetResults).toStrictEqual({});
+        expect(state.result).toStrictEqual({ solution: "another fake result" });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "wodin",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wodin",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This PR will add a "shuffle" vue feather icon to swap current parameter values with the parameter set values. This PR will add the following:
- VueFeather: "shuffle" icon
- RunAction: SwapParameterSet - commits SwapParameterSet mutation and ParameterSetSwapped sensitivity mutation if rerun is not required
- RunMutation: SwapParameterSet - swaps parameter values and results (so both values and graphs update)
- SensitivityMutation: ParameterSetSwapped - swaps sensitivity results (sensitivity graphs)
- Testing on all of the above

Note: the swap uses JavaScript de-structuring to swap the values, sensitivity swap can lag a tiny bit 