### PR TITLE
mrc-3960 Resize generic help dialog

### DIFF
--- a/app/static/src/app/components/help/DraggableDialog.vue
+++ b/app/static/src/app/components/help/DraggableDialog.vue
@@ -11,9 +11,11 @@
       <slot></slot>
     </div>
     <svg class="resize-handle" height="24" width="24" @mousedown="handleResizeStart" @touchstart="handleResizeStart">
-      <polygon points="0,24 24,0 24,24" style="fill:#ddd" />
+      <polygon points="0,24 24,0 24,24" style="fill:white" />
       <line x1="0" y1="24" x2="24" y2="0" style="stroke:#aaa;stroke-width:2" />
       <line x1="6" y1="24" x2="24" y2="6" style="stroke:#aaa;stroke-width:2" />
+      <line x1="12" y1="24" x2="24" y2="12" style="stroke:#aaa;stroke-width:2" />
+      <line x1="18" y1="24" x2="24" y2="18" style="stroke:#aaa;stroke-width:2" />
     </svg>
   </div>
 </template>

--- a/app/static/src/app/components/help/DraggableDialog.vue
+++ b/app/static/src/app/components/help/DraggableDialog.vue
@@ -10,6 +10,7 @@
     <div class="overflow-auto draggable-content">
       <slot></slot>
     </div>
+    <div class="resize-handle"></div>
   </div>
 </template>
 
@@ -34,10 +35,15 @@ export default defineComponent({
     },
     setup(props, { emit }) {
         const draggable = ref<null | HTMLElement>(null); // Picks up the element with 'draggable' ref in the template
+        const zeroPoint = { x: 0, y: 0 };
 
-        const position = ref<Point>({ x: 0, y: 0 });
-        const moveClientStart = ref<Point>({ x: 0, y: 0 });
-        const movePositionStart = ref<Point>({ x: 0, y: 0 });
+        const position = ref<Point>({...zeroPoint});
+        const moveClientStart = ref<Point>({...zeroPoint});
+        const movePositionStart = ref<Point>({...zeroPoint});
+        const resizeClientStart = ref<Point>({...zeroPoint});
+        const resizePositionStart = ref<Point>({...zeroPoint});
+        const resizeWidth = ref(0);
+        const resizeHeight = ref(0);
 
         const getTouchEvent = (event: Event) => {
             return (event as TouchEvent).touches?.length > 0 ? (event as TouchEvent).touches[0] : event;
@@ -84,6 +90,10 @@ export default defineComponent({
 
             moveClientStart.value = { x: clientX, y: clientY };
             movePositionStart.value = { x: position.value.x, y: position.value.y };
+        };
+
+        const handleResizeStart = (event: any) => {
+
         };
 
         const close = () => { emit("close"); };
@@ -137,6 +147,21 @@ export default defineComponent({
       background-color: aliceblue;
       border: #ccc 1px solid;
       height: calc(100% - 2.5rem);
+    }
+
+    .resize-handle {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 0;
+      height: 0;
+      cursor: nw-resize;
+      border-top: 0;
+      border-right: 0;
+      border-left: 2rem solid transparent;
+      border-bottom: 2rem solid grey;
+
+
     }
   }
 </style>

--- a/app/static/src/app/components/help/DraggableDialog.vue
+++ b/app/static/src/app/components/help/DraggableDialog.vue
@@ -226,7 +226,7 @@ export default defineComponent({
     .draggable-content {
       background-color: aliceblue;
       border: #ccc 1px solid;
-      height: calc(100% - 3.5rem);
+      height: calc(100% - 42px);
     }
 
     .resize-handle {

--- a/app/static/src/app/components/help/DraggableDialog.vue
+++ b/app/static/src/app/components/help/DraggableDialog.vue
@@ -10,13 +10,17 @@
     <div class="overflow-auto draggable-content">
       <slot></slot>
     </div>
-    <div class="resize-handle" @mousedown="handleResizeStart" @touchstart="handleResizeStart"></div>
+    <svg class="resize-handle" height="24" width="24" @mousedown="handleResizeStart" @touchstart="handleResizeStart">
+      <polygon points="0,24 24,0 24,24" style="fill:#ddd" />
+      <line x1="0" y1="24" x2="24" y2="0" style="stroke:#aaa;stroke-width:2" />
+      <line x1="6" y1="24" x2="24" y2="6" style="stroke:#aaa;stroke-width:2" />
+    </svg>
   </div>
 </template>
 
 <script lang="ts">
 import {
-    computed, defineComponent, onMounted, ref
+    computed, CSSProperties, defineComponent, onMounted, ref
 } from "vue";
 import VueFeather from "vue-feather";
 
@@ -41,6 +45,7 @@ export default defineComponent({
     setup(props, { emit }) {
         const draggable = ref<null | HTMLElement>(null); // Picks up the element with 'draggable' ref in the template
         const zeroPoint = { x: 0, y: 0 };
+        const minimumSize = 140; // Minimum width and height in px
 
         const position = ref<Point | null>(null);
         const moveClientStart = ref<Point | null>(null);
@@ -57,16 +62,45 @@ export default defineComponent({
             left: 0, top: 0, width: 0, height: 0
         });
 
+        const getViewportSize = () => ({ width: window.innerWidth, height: window.innerHeight });
+
         const containInWindow = (newPosition: Point) => {
             // Don't allow top of draggable to move outside the bounds of the window
             const rect = draggableRect();
-            const viewportWidth = window.innerWidth;
-            const viewportHeight = window.innerHeight;
+            const viewportSize = getViewportSize();
 
-            const containedX = Math.min(Math.max(newPosition.x, 0), viewportWidth - rect.width);
-            const containedY = Math.min(Math.max(newPosition.y, 0), viewportHeight - rect.height);
+            const containedX = Math.min(Math.max(newPosition.x, 0), viewportSize.width - rect.width);
+            const containedY = Math.min(Math.max(newPosition.y, 0), viewportSize.height - rect.height);
 
             return { x: containedX, y: containedY };
+        };
+
+        const constrainSize = (newSize: Size) => {
+            const rect = draggableRect();
+            const viewportSize = getViewportSize();
+            // Don't allow size smaller than min, or which will expand off the screen
+            const constrainedWidth = Math.min(Math.max(newSize.width, minimumSize), viewportSize.width - rect.left);
+            const constrainedHeight = Math.min(Math.max(newSize.height, minimumSize), viewportSize.height - rect.top);
+            return {
+                width: constrainedWidth,
+                height: constrainedHeight
+            };
+        };
+
+        type DragHandler = (event: Event) => void;
+
+        const addDragListeners = (move: DragHandler, end: DragHandler) => {
+            document.addEventListener("mousemove", move);
+            document.addEventListener("touchmove", move);
+            document.addEventListener("mouseup", end);
+            document.addEventListener("touchend", end);
+        };
+
+        const removeDragListeners = (move: DragHandler, end: DragHandler) => {
+            document.removeEventListener("mousemove", move);
+            document.removeEventListener("touchmove", move);
+            document.removeEventListener("mouseup", end);
+            document.removeEventListener("touchend", end);
         };
 
         const handleDragMove = (event: Event) => {
@@ -81,44 +115,31 @@ export default defineComponent({
         };
 
         const handleDragEnd = (event: Event) => {
-            document.removeEventListener("mousemove", handleDragMove);
-            document.removeEventListener("touchmove", handleDragMove);
-            document.removeEventListener("mouseup", handleDragEnd);
-            document.removeEventListener("touchend", handleDragEnd);
+            removeDragListeners(handleDragMove, handleDragEnd);
             movePositionStart.value = null;
             moveClientStart.value = null;
             event.preventDefault();
         };
         const handleDragStart = (event: Event) => {
             const { clientX, clientY } = getTouchEvent(event) as MouseEvent | Touch;
-            document.addEventListener("mousemove", handleDragMove);
-            document.addEventListener("touchmove", handleDragMove);
-            document.addEventListener("mouseup", handleDragEnd);
-            document.addEventListener("touchend", handleDragEnd);
-
             moveClientStart.value = { x: clientX, y: clientY };
             movePositionStart.value = position.value ? { x: position.value.x, y: position.value.y } : { ...zeroPoint };
+            addDragListeners(handleDragMove, handleDragEnd);
         };
 
         const handleResizeMove = (event: Event) => {
             if (resizeStartSize.value && resizeClientStart.value) {
                 const { clientX, clientY } = getTouchEvent(event) as MouseEvent | Touch;
-                // resizeWidth.value = resizeStartWidth.value + clientX - resizeClientStart.value.x;
-                // resizeHeight.value = resizeStartHeight.value + clientY - resizeClientStart.value.y;
+                const width = resizeStartSize.value.width + clientX - resizeClientStart.value.x;
+                const height = resizeStartSize.value.height + clientY - resizeClientStart.value.y;
 
-                resizedSize.value = {
-                    width: resizeStartSize.value.width + clientX - resizeClientStart.value.x,
-                    height: resizeStartSize.value.height + clientY - resizeClientStart.value.y
-                };
+                resizedSize.value = constrainSize({ width, height });
             }
             event.preventDefault();
         };
 
         const handleResizeEnd = (event: Event) => {
-            document.removeEventListener("mousemove", handleResizeMove);
-            document.removeEventListener("touchmove", handleResizeMove);
-            document.removeEventListener("mouseup", handleResizeEnd);
-            document.removeEventListener("touchend", handleResizeEnd);
+            removeDragListeners(handleResizeMove, handleResizeEnd);
             resizeClientStart.value = null;
             resizeStartSize.value = null;
             event.preventDefault();
@@ -126,13 +147,10 @@ export default defineComponent({
 
         const handleResizeStart = (event: Event) => {
             const { clientX, clientY } = getTouchEvent(event) as MouseEvent | Touch;
-            document.addEventListener("mousemove", handleResizeMove);
-            document.addEventListener("touchmove", handleResizeMove);
-            document.addEventListener("mouseup", handleResizeEnd);
-            document.addEventListener("touchend", handleResizeEnd);
             resizeClientStart.value = { x: clientX, y: clientY };
             const rect = draggableRect();
             resizeStartSize.value = { width: rect.width, height: rect.height };
+            addDragListeners(handleResizeMove, handleResizeEnd);
         };
 
         const close = () => {
@@ -149,7 +167,7 @@ export default defineComponent({
         });
 
         const dialogStyle = computed(() => {
-            const result = {} as any; // TODO: sort this out Partial style
+            const result = {} as Partial<CSSProperties>;
             if (position.value) {
                 result.top = `${position.value.y}px`;
                 result.left = `${position.value.x}px`;
@@ -167,6 +185,7 @@ export default defineComponent({
             moveClientStart,
             movePositionStart,
             position,
+            resizedSize,
             dialogStyle,
             close,
             handleDragStart,
@@ -205,21 +224,16 @@ export default defineComponent({
     .draggable-content {
       background-color: aliceblue;
       border: #ccc 1px solid;
-      height: calc(100% - 2.5rem);
+      height: calc(100% - 3.5rem);
     }
 
     .resize-handle {
       position: absolute;
       bottom: 0;
       right: 0;
-      width: 0;
-      height: 0;
+      width: 24px;
+      height: 24px;
       cursor: nw-resize;
-      border-top: 0;
-      border-right: 0;
-      border-left: 2rem solid transparent;
-      border-bottom: 2rem solid grey;
-
     }
   }
 </style>


### PR DESCRIPTION
Allows user to resize the generic help dialog down to a minimum size. Constrains title to a single line - it gets messy when it wraps at small sizes!

I've made the resize work from a single handle in the lower right rather than being able to pull out from the sides - mostly just for simplicity, Thoughts on the handle design? Had to cook something up myself for this as there wasn't a standard feather icon. It's based on the resize handle on github.com editor panes!