### PR TITLE
Config option for i18n and language + add language to store

### DIFF
--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -45,7 +45,7 @@ export class AppsController {
                     loadSessionId: sessionId || "",
                     shareNotFound: shareNotFound || "",
                     mathjaxSrc: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js",
-                    i18n: wodinConfig.internationalisation,
+                    internationalisation: wodinConfig.internationalisation,
                     defaultLanguage: wodinConfig?.defaultLanguage || "en"
                 };
                 res.render(view, viewOptions);

--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -30,6 +30,9 @@ export class AppsController {
             if (config) {
                 const baseUrl = wodinConfig.baseUrl.replace(/\/$/, "");
                 const view = `${config.appType}-app`;
+                if (!wodinConfig.hasOwnProperty("internationalisation")) {
+                    wodinConfig.internationalisation = true;
+                }
                 // TODO: validate config against schema for app type
                 const viewOptions = {
                     appName,
@@ -41,7 +44,9 @@ export class AppsController {
                     wodinVersion,
                     loadSessionId: sessionId || "",
                     shareNotFound: shareNotFound || "",
-                    mathjaxSrc: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
+                    mathjaxSrc: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js",
+                    i18n: wodinConfig.internationalisation,
+                    defaultLanguage: wodinConfig?.defaultLanguage || "en"
                 };
                 res.render(view, viewOptions);
             } else {

--- a/app/server/src/types.ts
+++ b/app/server/src/types.ts
@@ -9,7 +9,9 @@ export interface WodinConfig {
     baseUrl: string,
     odinApi: string,
     redisUrl: string,
-    appsPath: string
+    appsPath: string,
+    internationalisation: boolean,
+    defaultLanguage: "en" | "fr" | "pt"
 }
 
 export interface AppConfigBase {

--- a/app/server/views/basic-app.hbs
+++ b/app/server/views/basic-app.hbs
@@ -15,7 +15,7 @@
              <wodin-session :app-name="'{{appName}}'"
                             :base-url="'{{baseUrl}}'"
                             :apps-path="'{{appsPath}}'"
-                            :i18n="{{i18n}}"
+                            :internationalisation="{{internationalisation}}"
                             :default-language="'{{defaultLanguage}}'"
                             :load-session-id="'{{loadSessionId}}'"
                             :share-not-found="'{{shareNotFound}}'"></wodin-session>

--- a/app/server/views/basic-app.hbs
+++ b/app/server/views/basic-app.hbs
@@ -15,6 +15,8 @@
              <wodin-session :app-name="'{{appName}}'"
                             :base-url="'{{baseUrl}}'"
                             :apps-path="'{{appsPath}}'"
+                            :i18n="{{i18n}}"
+                            :default-language="'{{defaultLanguage}}'"
                             :load-session-id="'{{loadSessionId}}'"
                             :share-not-found="'{{shareNotFound}}'"></wodin-session>
         </div>

--- a/app/server/views/fit-app.hbs
+++ b/app/server/views/fit-app.hbs
@@ -15,7 +15,7 @@
             <wodin-session :app-name="'{{appName}}'"
                            :base-url="'{{baseUrl}}'"
                            :apps-path="'{{appsPath}}'"
-                           :i18n="{{i18n}}"
+                           :internationalisation="{{internationalisation}}"
                            :default-language="'{{defaultLanguage}}'"
                            :load-session-id="'{{loadSessionId}}'"
                            :share-not-found="'{{shareNotFound}}'"></wodin-session>

--- a/app/server/views/fit-app.hbs
+++ b/app/server/views/fit-app.hbs
@@ -15,6 +15,8 @@
             <wodin-session :app-name="'{{appName}}'"
                            :base-url="'{{baseUrl}}'"
                            :apps-path="'{{appsPath}}'"
+                           :i18n="{{i18n}}"
+                           :default-language="'{{defaultLanguage}}'"
                            :load-session-id="'{{loadSessionId}}'"
                            :share-not-found="'{{shareNotFound}}'"></wodin-session>
         </div>

--- a/app/server/views/stochastic-app.hbs
+++ b/app/server/views/stochastic-app.hbs
@@ -15,7 +15,7 @@
             <wodin-session :app-name="'{{appName}}'"
                            :base-url="'{{baseUrl}}'"
                            :apps-path="'{{appsPath}}'"
-                           :i18n="{{i18n}}"
+                           :internationalisation="{{internationalisation}}"
                            :default-language="'{{defaultLanguage}}'"
                            :load-session-id="'{{loadSessionId}}'"
                            :share-not-found="'{{shareNotFound}}'"></wodin-session>

--- a/app/server/views/stochastic-app.hbs
+++ b/app/server/views/stochastic-app.hbs
@@ -15,6 +15,8 @@
             <wodin-session :app-name="'{{appName}}'"
                            :base-url="'{{baseUrl}}'"
                            :apps-path="'{{appsPath}}'"
+                           :i18n="{{i18n}}"
+                           :default-language="'{{defaultLanguage}}'"
                            :load-session-id="'{{loadSessionId}}'"
                            :share-not-found="'{{shareNotFound}}'"></wodin-session>
         </div>

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -14,6 +14,7 @@
         "bootstrap": "^5.1.3",
         "csv-parse": "^5.2.1",
         "d3-format": "^3.1.0",
+        "i18next": "^22.4.10",
         "markdown-it": "^13.0.1",
         "markdown-it-mathjax": "^2.0.0",
         "moment": "^2.29.4",
@@ -1858,12 +1859,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-      "dev": true,
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -15198,6 +15198,28 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/i18next": {
+      "version": "22.4.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.10.tgz",
+      "integrity": "sha512-3EqgGK6fAJRjnGgfkNSStl4mYLCjUoJID338yVyLMj5APT67HUtWoqSayZewiiC5elzMUB1VEUwcmSCoeQcNEA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -24096,10 +24118,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -31289,12 +31310,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-      "dev": true,
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -41963,6 +41983,14 @@
         }
       }
     },
+    "i18next": {
+      "version": "22.4.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.10.tgz",
+      "integrity": "sha512-3EqgGK6fAJRjnGgfkNSStl4mYLCjUoJID338yVyLMj5APT67HUtWoqSayZewiiC5elzMUB1VEUwcmSCoeQcNEA==",
+      "requires": {
+        "@babel/runtime": "^7.20.6"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -49107,10 +49135,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -30,6 +30,7 @@
     "bootstrap": "^5.1.3",
     "csv-parse": "^5.2.1",
     "d3-format": "^3.1.0",
+    "i18next": "^22.4.10",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax": "^2.0.0",
     "moment": "^2.29.4",

--- a/app/static/src/app/basic.ts
+++ b/app/static/src/app/basic.ts
@@ -7,8 +7,10 @@ import AppHeader from "./components/header/AppHeader.vue";
 import { BasicState } from "./store/basic/state";
 import { initialiseRouter } from "./router";
 import tooltip from "./directives/tooltip";
+import registerTranslations from "./store/translations/registerTranslations";
 
 export const store = new Vuex.Store<BasicState>(storeOptions);
+registerTranslations(store);
 
 const app = createApp({ components: { WodinSession, AppHeader } });
 app.use(store);

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -35,14 +35,18 @@ export default defineComponent({
                 appName,
                 baseUrl,
                 loadSessionId,
-                appsPath
+                appsPath,
+                internationalisation,
+                defaultLanguage
             } = props;
             store.dispatch(AppStateAction.Initialise,
                 {
                     appName,
                     baseUrl,
                     loadSessionId,
-                    appsPath
+                    appsPath,
+                    internationalisation,
+                    defaultLanguage
                 });
         });
 

--- a/app/static/src/app/components/WodinSession.vue
+++ b/app/static/src/app/components/WodinSession.vue
@@ -16,7 +16,9 @@ export default defineComponent({
         baseUrl: String,
         appsPath: String,
         loadSessionId: String,
-        shareNotFound: String
+        shareNotFound: String,
+        internationalisation: Boolean,
+        defaultLanguage: String
     },
     components: {
         RouterView

--- a/app/static/src/app/fit.ts
+++ b/app/static/src/app/fit.ts
@@ -7,8 +7,10 @@ import AppHeader from "./components/header/AppHeader.vue";
 import { FitState } from "./store/fit/state";
 import { initialiseRouter } from "./router";
 import tooltip from "./directives/tooltip";
+import registerTranslations from "./store/translations/registerTranslations";
 
 export const store = new Vuex.Store<FitState>(storeOptions);
+registerTranslations(store);
 
 const app = createApp({ components: { WodinSession, AppHeader } });
 app.use(store);

--- a/app/static/src/app/stochastic.ts
+++ b/app/static/src/app/stochastic.ts
@@ -7,8 +7,10 @@ import AppHeader from "./components/header/AppHeader.vue";
 import { StochasticState } from "./store/stochastic/state";
 import { initialiseRouter } from "./router";
 import tooltip from "./directives/tooltip";
+import registerTranslations from "./store/translations/registerTranslations";
 
 export const store = new Vuex.Store<StochasticState>(storeOptions);
+registerTranslations(store);
 
 const app = createApp({ components: { WodinSession, AppHeader } });
 app.use(store);

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -40,9 +40,11 @@ export const appStateActions: ActionTree<AppState, AppState> = {
             appName,
             baseUrl,
             loadSessionId,
-            appsPath
+            appsPath,
+            internationalisation,
+            defaultLanguage
         } = payload;
-        commit(AppStateMutation.SetApp, { appName, baseUrl, appsPath });
+        commit(AppStateMutation.SetApp, { appName, baseUrl, appsPath, internationalisation, defaultLanguage });
         localStorageManager.addSessionId(appName, getters[AppStateGetter.baseUrlPath], state.sessionId);
 
         const response = await api(context)

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -2,6 +2,7 @@ import { MutationTree } from "vuex";
 import { AppState, VisualisationTab } from "./state";
 import { AppConfig } from "../../types/responseTypes";
 import { SetAppPayload } from "../../types/payloadTypes";
+import { Language } from "../translations/locales";
 
 export enum AppStateMutation {
     SetApp = "SetApp",
@@ -25,6 +26,8 @@ export const appStateMutations: MutationTree<AppState> = {
         state.appName = payload.appName;
         state.baseUrl = payload.baseUrl;
         state.appsPath = payload.appsPath;
+        state.language.currentLanguage = Language[payload.defaultLanguage];
+        state.language.internationalisation = payload.internationalisation;
     },
 
     [AppStateMutation.SetConfig](state: AppState, payload: AppConfig) {

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -5,6 +5,7 @@ import { AppConfig } from "../../types/responseTypes";
 import { SensitivityState } from "../sensitivity/state";
 import { VersionsState } from "../versions/state";
 import { GraphSettingsState } from "../graphSettings/state";
+import { LanguageState } from "../language/state";
 
 export enum AppType {
     Basic = "basic",
@@ -35,5 +36,6 @@ export interface AppState {
     sensitivity: SensitivityState,
     graphSettings: GraphSettingsState,
     versions: VersionsState,
-    configured: boolean // true if configuration has been loaded or rehydrated and defaults set
+    configured: boolean, // true if configuration has been loaded or rehydrated and defaults set
+    language: LanguageState
 }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -7,6 +7,7 @@ import { model } from "../model/model";
 import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
+import { language } from "../language/language";
 import { logMutations, persistState } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
@@ -45,7 +46,8 @@ export const storeOptions: StoreOptions<BasicState> = {
         sensitivity,
         sessions,
         versions,
-        graphSettings
+        graphSettings,
+        language
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -7,6 +7,7 @@ import { model } from "../model/model";
 import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
+import { language } from "../language/language";
 import { fitData } from "../fitData/fitData";
 import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
@@ -49,7 +50,8 @@ export const storeOptions: StoreOptions<FitState> = {
         sensitivity,
         sessions,
         versions,
-        graphSettings
+        graphSettings,
+        language
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/store/language/actions.ts
+++ b/app/static/src/app/store/language/actions.ts
@@ -1,0 +1,17 @@
+import { ActionTree } from "vuex";
+import i18next from "i18next";
+import { LanguageStateMutation } from "./mutations";
+import { LanguageState } from "./state";
+import { AppState } from "../appState/state";
+
+export enum LanguageAction {
+    UpdateLanguage= "UpdateLanguage"
+}
+
+export const actions: ActionTree<LanguageState, AppState> = {
+    async [LanguageAction.UpdateLanguage](context, language) {
+        const { commit } = context;
+        await i18next.changeLanguage(language);
+        commit(LanguageStateMutation.ChangeLanguage, language);
+    }
+};

--- a/app/static/src/app/store/language/language.ts
+++ b/app/static/src/app/store/language/language.ts
@@ -1,0 +1,17 @@
+import { LanguageState } from "./state";
+import { mutations } from "./mutations";
+import { actions } from "./actions";
+import { Language } from "../translations/locales";
+
+export const defaultState: LanguageState = {
+    currentLanguage: Language.en,
+    updatingLanguage: false,
+    internationalisation: true
+};
+
+export const language = {
+    namespaced: true,
+    state: defaultState,
+    mutations,
+    actions
+};

--- a/app/static/src/app/store/language/mutations.ts
+++ b/app/static/src/app/store/language/mutations.ts
@@ -1,0 +1,23 @@
+import { MutationTree } from "vuex";
+import { Language } from "../translations/locales";
+import { LanguageState } from "./state";
+
+export enum LanguageStateMutation {
+    ChangeLanguage = "ChangeLanguage",
+    SetUpdatingLanguage = "SetUpdatingLanguage",
+    ToggleInternationalisation = "ToggleInternationalisation"
+}
+
+export const mutations: MutationTree<LanguageState> = {
+    [LanguageStateMutation.ChangeLanguage](state: LanguageState, payload: Language) {
+        state.currentLanguage = payload;
+    },
+
+    [LanguageStateMutation.SetUpdatingLanguage](state: LanguageState, payload: boolean) {
+        state.updatingLanguage = payload;
+    },
+
+    [LanguageStateMutation.ToggleInternationalisation](state: LanguageState, payload: boolean) {
+        state.internationalisation = payload;
+    }
+};

--- a/app/static/src/app/store/language/state.ts
+++ b/app/static/src/app/store/language/state.ts
@@ -1,0 +1,7 @@
+import { Language } from "../translations/locales";
+
+export interface LanguageState {
+    currentLanguage: Language,
+    updatingLanguage: boolean,
+    internationalisation: boolean
+}

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -7,6 +7,7 @@ import { model } from "../model/model";
 import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
+import { language } from "../language/language";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newSessionId } from "../../utils";
 import { logMutations, persistState } from "../plugins";
@@ -45,7 +46,8 @@ export const storeOptions: StoreOptions<StochasticState> = {
         sensitivity,
         sessions,
         versions,
-        graphSettings
+        graphSettings,
+        language
     },
     plugins: [
         logMutations,

--- a/app/static/src/app/store/translations/locales.ts
+++ b/app/static/src/app/store/translations/locales.ts
@@ -1,0 +1,23 @@
+export interface Translations {
+    add: string
+}
+
+const en: Partial<Translations> = {
+    add: "Add"
+};
+
+const fr: Partial<Translations> = {
+    add: "Ajouter"
+};
+
+const pt: Partial<Translations> = {
+    add: "Adicionar"
+};
+
+export const locales = {
+    en,
+    fr,
+    pt
+};
+
+export enum Language {en = "en", fr = "fr", pt = "pt"}

--- a/app/static/src/app/store/translations/registerTranslations.ts
+++ b/app/static/src/app/store/translations/registerTranslations.ts
@@ -1,0 +1,17 @@
+import i18next from "i18next";
+import { Language, locales } from "./locales";
+import { Store } from "vuex";
+import { BasicState } from "../basic/state";
+import { AppState } from "../appState/state";
+
+export default <S extends AppState>(store: Store<S>) => {
+    i18next.init({
+        lng: store.state.language.currentLanguage,
+        resources: {
+            en: { translation: locales.en },
+            fr: { translation: locales.fr },
+            pt: { translation: locales.pt }
+        },
+        fallbackLng: Language.en
+    });
+}

--- a/app/static/src/app/types/payloadTypes.ts
+++ b/app/static/src/app/types/payloadTypes.ts
@@ -4,6 +4,8 @@ export interface SetAppPayload {
     appName: string
     baseUrl: string
     appsPath: string
+    internationalisation: boolean
+    defaultLanguage: "en" | "fr" | "pt"
 }
 
 export interface InitialisePayload extends SetAppPayload{

--- a/config/wodin.config.json
+++ b/config/wodin.config.json
@@ -5,5 +5,7 @@
     "appsPath": "apps",
     "baseUrl": "http://localhost:3000",
     "odinApi": "http://localhost:8001",
-    "redisUrl": "redis://localhost:6379"
+    "redisUrl": "redis://localhost:6379",
+    "internationalisation": true,
+    "defaultLanguage": "en"
 }


### PR DESCRIPTION
## With this PR I will:
- Add i18n and default language config properties to WODIN
- Add language state to store with `currentLanguage`, `updatingLanguage` and `internationalisation` properities.
### Note:
This was mostly copied and modified from HINT. I like the updatingLanguage prop as it will be used in the future for our loading components. Internationalisation is part of language state so we can easily do checks for internationalisation before changing language since we don't want this to happen.