### PR TITLE
Better error and warning highlighting for Code Editor

### DIFF
--- a/app/server/views/app.hbs
+++ b/app/server/views/app.hbs
@@ -3,7 +3,8 @@
     <head>
         <meta charset="utf-8">
         <title>{{title}}</title>
-        <link rel="stylesheet" href="{{baseUrl}}/css/wodin.css"
+        <link rel="stylesheet" href="{{baseUrl}}/css/wodin.css"/>
+        <script src="https://kit.fontawesome.com/8e829cc319.js" crossorigin="anonymous"></script>
     </head>
     <body>
         <div id="app">

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -66,13 +66,18 @@ export interface OdinModelResponseError {
     message: string
 }
 
+export interface OdinMetadataMessage {
+    line: number[],
+    message: string
+}
+
 export interface OdinModelResponse{
     valid: boolean,
     metadata?: {
         variables: string[],
         dt: number | null,
         parameters: OdinParameter[],
-        messages: string[]
+        messages: OdinMetadataMessage[]
     },
     model?: string,
     error?: OdinModelResponseError

--- a/app/static/src/scss/editor.scss
+++ b/app/static/src/scss/editor.scss
@@ -1,0 +1,17 @@
+.editor-error-background {
+    background-color: #ff00002d;
+}
+
+.editor-warning-background {
+    background-color: #ff910033;
+}
+
+.error-glyph-style {
+    color: red;
+    font-size: 15.5px;
+}
+
+.warning-glyph-style {
+    color: orange;
+    font-size: 15.5px;
+}

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -1,5 +1,6 @@
 @import "../../node_modules/bootstrap/scss/bootstrap.scss";
 @import "./tooltip.scss";
+@import "./editor.scss";
 
 .container {
   max-width: 100%;

--- a/app/static/tests/unit/components/code/codeEditor.test.ts
+++ b/app/static/tests/unit/components/code/codeEditor.test.ts
@@ -4,9 +4,9 @@ const mockMonacoEditor = {
     getModel: () => {
         return { getLinesContent: jest.fn().mockReturnValueOnce(["new code"]) };
     },
-    setValue: jest.fn()
+    setValue: jest.fn(),
+    deltaDecorations: jest.fn()
 };
-
 const mockMonaco = {
     editor: {
         create: jest.fn().mockReturnValue(mockMonacoEditor)
@@ -16,16 +16,59 @@ jest.mock("@monaco-editor/loader", () => {
     return { init: async () => mockMonaco };
 });
 
+const editorGlyphs: any = {
+    error: "fa-solid fa-circle-xmark",
+    warning: "fa-solid fa-triangle-exclamation"
+};
+const monacoLineRange = (line: number, reset = false) => {
+    return {
+        startLineNumber: line,
+        startColumn: reset ? 1 : 0,
+        endLineNumber: line,
+        endColumn: reset ? 1 : Infinity
+    };
+};
+const monacoOptions = (state: string, message: string) => {
+    return {
+        className: `editor-${state}-background`,
+        glyphMarginClassName: `${editorGlyphs[state]} ${state}-glyph-style ms-1`,
+        hoverMessage: { value: message },
+        glyphMarginHoverMessage: { value: message }
+    };
+};
+const expectDeltaDecorationInputs = (line: number, state: string, message: string, done: jest.DoneCallback) => {
+    setTimeout(() => {
+        const changeHandler = mockMonacoEditor.onDidChangeModelContent.mock.calls[0][0];
+        changeHandler();
+        setTimeout(() => {
+            // 1 for resetting all decorations and 1 for adding state decorations
+            expect(mockMonacoEditor.deltaDecorations).toHaveBeenCalledTimes(2);
+            expect(mockMonacoEditor.deltaDecorations.mock.calls[0][1]).toStrictEqual([{
+                range: monacoLineRange(1, true),
+                options: {}
+            }]);
+            expect(mockMonacoEditor.deltaDecorations.mock.calls[1][1]).toStrictEqual([{
+                range: monacoLineRange(line),
+                options: monacoOptions(state, message)
+            }]);
+            done();
+        }, 700);
+    });
+};
+
 /* eslint-disable import/first */
 import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import CodeEditor from "../../../../src/app/components/code/CodeEditor.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { BasicConfig } from "../../../../src/app/types/responseTypes";
-import { mockBasicState, mockCodeState } from "../../../mocks";
+import { mockBasicState, mockCodeState, mockModelState } from "../../../mocks";
 
 describe("CodeEditor", () => {
-    const getWrapper = (readOnlyCode = false, mockUpdateCode = jest.fn(), defaultCode = ["default code"]) => {
+    const getWrapper = (readOnlyCode = false,
+        mockUpdateCode = jest.fn(),
+        defaultCode = ["default code"],
+        odinModelResponse = { valid: true }) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
                 config: {
@@ -43,6 +86,12 @@ describe("CodeEditor", () => {
                     actions: {
                         UpdateCode: mockUpdateCode
                     }
+                },
+                model: {
+                    namespaced: true,
+                    state: mockModelState({
+                        odinModelResponse
+                    })
                 }
             }
         });
@@ -68,7 +117,9 @@ describe("CodeEditor", () => {
                 language: "r",
                 minimap: { enabled: false },
                 readOnly: false,
-                automaticLayout: true
+                automaticLayout: true,
+                glyphMargin: true,
+                lineNumbersMinChars: 3
             });
 
             done();
@@ -90,7 +141,7 @@ describe("CodeEditor", () => {
                 expect(mockUpdateCode).toHaveBeenCalled();
                 expect(mockUpdateCode.mock.calls[0][1]).toStrictEqual(["new code"]);
                 done();
-            }, 1000);
+            }, 700);
         });
     });
 
@@ -124,5 +175,81 @@ describe("CodeEditor", () => {
         const mockUpdateCode = jest.fn();
         const wrapper = getWrapper(true, mockUpdateCode);
         expect(wrapper.find("#reset-btn").exists()).toBe(false);
+    });
+
+    it("executes deltaDecorations when there is an error", (done) => {
+        const mockUpdateCode = jest.fn();
+        const odinModelResponse = {
+            valid: false,
+            error: { line: [2], message: "error here" }
+        };
+        getWrapper(false, mockUpdateCode, ["hey code"], odinModelResponse);
+        expectDeltaDecorationInputs(2, "error", "error here", done);
+    });
+
+    it("no input in deltaDecorations when error lines and messages are empty", (done) => {
+        const mockUpdateCode = jest.fn();
+        const odinModelResponse = {
+            valid: false,
+            error: {}
+        };
+        getWrapper(false, mockUpdateCode, ["hey code"], odinModelResponse);
+        setTimeout(() => {
+            const changeHandler = mockMonacoEditor.onDidChangeModelContent.mock.calls[0][0];
+            changeHandler();
+            setTimeout(() => {
+                expect(mockMonacoEditor.deltaDecorations).toHaveBeenCalledTimes(2);
+                expect(mockMonacoEditor.deltaDecorations.mock.calls[1][1]).toStrictEqual([]);
+                done();
+            }, 700);
+        });
+    });
+
+    it("executes deltaDecorations when there is an warning", (done) => {
+        const mockUpdateCode = jest.fn();
+        const odinModelResponse = {
+            valid: true,
+            metadata: {
+                messages: [{ line: [3], message: "warning here" }]
+            }
+        };
+        getWrapper(false, mockUpdateCode, ["hey code"], odinModelResponse);
+        expectDeltaDecorationInputs(3, "warning", "warning here", done);
+    });
+
+    it("no input in deltaDecorations when warning lines and messages are empty", (done) => {
+        const mockUpdateCode = jest.fn();
+        const odinModelResponse = {
+            valid: true,
+            metadata: {
+                messages: [{ line: [], message: "" }]
+            }
+        };
+        getWrapper(false, mockUpdateCode, ["hey code"], odinModelResponse);
+        setTimeout(() => {
+            const changeHandler = mockMonacoEditor.onDidChangeModelContent.mock.calls[0][0];
+            changeHandler();
+            setTimeout(() => {
+                expect(mockMonacoEditor.deltaDecorations).toHaveBeenCalledTimes(2);
+                expect(mockMonacoEditor.deltaDecorations.mock.calls[1][1]).toStrictEqual([]);
+                done();
+            }, 700);
+        });
+    });
+
+    it("only executes deltaDecorations once when success", (done) => {
+        const mockUpdateCode = jest.fn();
+        const odinSuccessResponse = {
+            valid: true
+        };
+        getWrapper(false, mockUpdateCode, ["hey code"], odinSuccessResponse);
+        setTimeout(() => {
+            const changeHandler = mockMonacoEditor.onDidChangeModelContent.mock.calls[0][0];
+            changeHandler();
+            setTimeout(() => {
+                expect(mockMonacoEditor.deltaDecorations).toHaveBeenCalledTimes(1);
+                done();
+            }, 700);
+        });
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -50,7 +50,7 @@ describe("serialise", () => {
                         name: "beta", default: 0.1, min: -1, max: 10.5, is_integer: false, rank: 1
                     }
                 ],
-                messages: ["a test message"]
+                messages: [{ message: "a test message", line: [1] }]
             },
             model: "a test model",
             error: { line: [1], message: "test model error" }


### PR DESCRIPTION
With this PR I hope to add better indicators for errors/warnings in the Monaco Editor in Wodin. The new features I hope to implement are:
- Updating type of OdinModelResponse (metadata messages are actually an array of objects)
- Adding fontAwesome to Wodin
- Adding scss styles for errors and warnings
- Using deltaDecorations from monaco editor to change the CSS for the lines in Monaco Editor
To test this feature just type some invalid code in the editor! If you want to see the warning, declare an unused variable.