### PR TITLE
mrc-4017 Language Switcher Component

### DIFF
--- a/app/static/src/app/components/header/AppHeader.vue
+++ b/app/static/src/app/components/header/AppHeader.vue
@@ -18,7 +18,10 @@
         <li><router-link id="all-sessions-link" class="dropdown-item" to="/sessions">All Sessions</router-link></li>
       </ul>
     </span>
-    <version-menu v-if="initialised" :wodin-version="wodinVersion"></version-menu>
+    <span style="display: flex; align-items: center;">
+      <version-menu v-if="initialised" :wodin-version="wodinVersion"></version-menu>
+      <language-switcher :languagesKeys="languagesKeys"/>
+    </span>
   </nav>
   <edit-session-label id="header-edit-session-label"
                       :open="editSessionLabelOpen"
@@ -35,6 +38,10 @@ import { RouterLink } from "vue-router";
 import { useStore } from "vuex";
 import EditSessionLabel from "../sessions/EditSessionLabel.vue";
 import VersionMenu from "./VersionMenu.vue";
+import { LanguageSwitcher } from "../../../../translationPackage";
+import { Language } from "../../types/languageTypes";
+
+type LanguagesKeys = Record<Language, string>
 
 export default defineComponent({
     name: "AppHeader",
@@ -47,7 +54,8 @@ export default defineComponent({
         RouterLink,
         EditSessionLabel,
         VueFeather,
-        VersionMenu
+        VersionMenu,
+        LanguageSwitcher
     },
     setup() {
         const store = useStore();
@@ -66,6 +74,11 @@ export default defineComponent({
             return sessionLabel.value ? `Session: ${sessionLabel.value}` : "Sessions";
         });
 
+        const languagesKeys: LanguagesKeys = {
+          [Language.en]: "English",
+          [Language.fr]: "Français"
+        }
+
         return {
             baseUrl,
             initialised,
@@ -73,7 +86,8 @@ export default defineComponent({
             editSessionLabelOpen,
             sessionId,
             sessionLabel,
-            sessionMenuHeader
+            sessionMenuHeader,
+            languagesKeys
         };
     }
 });

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -14,7 +14,7 @@ import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
-import getStoreModule from "../../../../translationPackage/getStoreModule";
+import { getStoreModule } from "../../../../translationPackage";
 
 const language = getStoreModule();
 

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -16,7 +16,7 @@ import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
-import getStoreModule from "../../../../translationPackage/getStoreModule";
+import { getStoreModule } from "../../../../translationPackage";
 
 const language = getStoreModule();
 

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -14,7 +14,7 @@ import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphSettings } from "../graphSettings/graphSettings";
 import { getters } from "../appState/getters";
-import getStoreModule from "../../../../translationPackage/getStoreModule";
+import { getStoreModule } from "../../../../translationPackage";
 
 const language = getStoreModule();
 

--- a/app/static/tests/unit/components/versions/appHeader.test.ts
+++ b/app/static/tests/unit/components/versions/appHeader.test.ts
@@ -8,6 +8,7 @@ import EditSessionLabel from "../../../../src/app/components/sessions/EditSessio
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { mockBasicState } from "../../../mocks";
 import VersionMenu from "../../../../src/app/components/header/VersionMenu.vue";
+import { LanguageSwitcher } from "../../../../translationPackage";
 
 describe("AppHeader", () => {
     const getWrapper = (appName: string | null = "test", sessionLabel: string | null = null,
@@ -51,6 +52,8 @@ describe("AppHeader", () => {
         expect(editDlg.props("open")).toBe(false);
         expect(editDlg.props("sessionId")).toBe("testSessionId");
         expect(editDlg.props("sessionLabel")).toBe(null);
+
+        expect(wrapper.findAllComponents(LanguageSwitcher)).toHaveLength(1);
     });
 
     it("renders version menu as expected", () => {

--- a/app/static/translationPackage/getStoreModule.ts
+++ b/app/static/translationPackage/getStoreModule.ts
@@ -1,5 +1,0 @@
-import { language } from "./store/language"
-
-export default function getStoreModule() {
-    return language
-}

--- a/app/static/translationPackage/index.ts
+++ b/app/static/translationPackage/index.ts
@@ -1,0 +1,13 @@
+import { language } from "./store/language";
+import LanguageSwitcher from "./src/LanguageSwitcher.vue";
+import { registerResources } from "./registerTranslations";
+
+function getStoreModule() {
+    return language
+}
+
+export {
+    LanguageSwitcher,
+    getStoreModule,
+    registerResources
+}

--- a/app/static/translationPackage/registerTranslations.ts
+++ b/app/static/translationPackage/registerTranslations.ts
@@ -24,7 +24,7 @@ export default function registerTranslations<L extends string>(languageState: La
     })
 };
 
-const registerResources = (lng: string, resources: Resource[]) => {
+export const registerResources = (lng: string, resources: Resource[]) => {
     resources.forEach(resource => {
         addResource(lng, resource);
     })

--- a/app/static/translationPackage/src/DropDown.vue
+++ b/app/static/translationPackage/src/DropDown.vue
@@ -1,0 +1,22 @@
+<template>
+    <div class="dropdown">
+        <a href="#"
+           class="dropdown-toggle text-decoration-none"
+           role="button"
+           data-bs-toggle="dropdown"
+           aria-expanded="false">{{ text }}</a>
+        <ul class="dropdown-menu dropdown-menu-end">
+            <slot name="items"></slot>
+        </ul>
+    </div>
+</template>
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+    name: "DropDown",
+    props: {
+        text: String
+    }
+});
+</script>

--- a/app/static/translationPackage/src/LanguageSwitcher.vue
+++ b/app/static/translationPackage/src/LanguageSwitcher.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="navbar-text navbar-version ms-3 me-1">
+        <drop-down :text="languagesKeys[currentLanguage]">
+            <template v-slot:items>
+                <li v-for="(language, i18n, index) in languagesKeys" :key="index">
+                    <span class="dropdown-item"
+                    @click="changeWodinLang(i18n)">{{ language }}</span>
+                </li>
+            </template>
+        </drop-down>
+    </div>
+</template>
+<script lang="ts">
+import { PropType, computed, defineComponent } from "vue";
+import DropDown from "./DropDown.vue";
+import VueFeather from "vue-feather";
+import { useStore } from "vuex";
+import { LanguageAction } from "../store/actions";
+
+type LanguageKeys = Record<string, string>
+
+export default defineComponent({
+    name: "LanguageSwitcher",
+    components: {
+        DropDown,
+        VueFeather
+    },
+    props: {
+        languagesKeys: {
+            type: Object as PropType<LanguageKeys>,
+            required: true
+        }
+    },
+    setup(props) {
+        const store = useStore();
+        const currentLanguage = computed(() => store.state.language.currentLanguage);
+        const changeWodinLang = (language: string) => {
+            store.dispatch(`language/${LanguageAction.UpdateLanguage}`, language);
+        };
+
+        return {
+            languagesKeys: props.languagesKeys,
+            changeWodinLang,
+            currentLanguage
+        }
+    }
+});
+</script>

--- a/app/static/translationPackage/tests/registerTranslations.test.ts
+++ b/app/static/translationPackage/tests/registerTranslations.test.ts
@@ -1,9 +1,8 @@
 import i18next from "i18next";
-import { Language } from "../../../src/app/types/languageTypes";
-import registerTranslations from "../../../translationPackage/registerTranslations";
+import registerTranslations, { registerResources } from "../registerTranslations";
 
 describe("Registering translations", () => {
-    const getLanguageState = (currentLanguage = Language.en, enableI18n = true) => {
+    const getLanguageState = (currentLanguage = "en", enableI18n = true) => {
         return {
             currentLanguage,
             enableI18n,
@@ -30,21 +29,21 @@ describe("Registering translations", () => {
             en: [getEnglishLocales()],
             fr: [getFrenchLocales()]
         });
-        expect(i18next.getResourceBundle(Language.en, "translation")).toStrictEqual({
+        expect(i18next.getResourceBundle("en", "translation")).toStrictEqual({
             hello: "hey"
         });
-        expect(i18next.getResourceBundle(Language.fr, "translation")).toStrictEqual({
+        expect(i18next.getResourceBundle("fr", "translation")).toStrictEqual({
             hello: "bonjour"
         });
     });
 
     it("only registers currentLanguage if i18n is off", () => {
-        registerTranslations(getLanguageState(Language.fr, false), {
+        registerTranslations(getLanguageState("fr", false), {
             en: [getEnglishLocales()],
             fr: [getFrenchLocales()]
         });
-        expect(i18next.getResourceBundle(Language.en, "translation")).toBeUndefined();
-        expect(i18next.getResourceBundle(Language.fr, "translation")).toStrictEqual({
+        expect(i18next.getResourceBundle("en", "translation")).toBeUndefined();
+        expect(i18next.getResourceBundle("fr", "translation")).toStrictEqual({
             hello: "bonjour"
         });
     });
@@ -59,5 +58,21 @@ describe("Registering translations", () => {
         } catch (err: any) {
             expect(err.toString()).toBe("Error: The keys [hello] are shared by more than one resource.");
         }
+    });
+
+    it("can add key to existing bundle using registerResources", () => {
+        const state = getLanguageState();
+        registerTranslations(state, {
+            en: [getEnglishLocales()],
+            fr: [getFrenchLocales()]
+        });
+        registerResources("fr", [{ you: "tu" }]);
+        expect(i18next.getResourceBundle("en", "translation")).toStrictEqual({
+            hello: "hey"
+        });
+        expect(i18next.getResourceBundle("fr", "translation")).toStrictEqual({
+            hello: "bonjour",
+            you: "tu"
+        });
     });
 });

--- a/app/static/translationPackage/tests/src/dropdown.test.ts
+++ b/app/static/translationPackage/tests/src/dropdown.test.ts
@@ -1,0 +1,32 @@
+import { shallowMount } from "@vue/test-utils";
+import DropDown from "../../src/DropDown.vue";
+
+describe("dropdown component", () => {
+    const itemList = " <li><span class='dropdown-item' style='cursor: default;'>test</span></li>";
+
+    const getWrapper = () => {
+        return shallowMount(DropDown, {
+            props: {
+                text: "WODIN v1.2.3"
+            },
+            slots: {
+                items: itemList
+            }
+        });
+    };
+
+    it("renders dropdown", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("a").attributes("href")).toBe("#");
+        expect(wrapper.find("a").classes()).toEqual(["dropdown-toggle", "text-decoration-none"]);
+        expect(wrapper.find("a").text()).toBe("WODIN v1.2.3");
+    });
+
+    it("renders dropdown items", () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("ul").classes()).toEqual(["dropdown-menu", "dropdown-menu-end"]);
+        const lists = wrapper.findAll("li");
+        expect(lists.length).toBe(1);
+        expect(lists.at(0)?.text()).toBe("test");
+    });
+});

--- a/app/static/translationPackage/tests/src/languageSwitcher.test.ts
+++ b/app/static/translationPackage/tests/src/languageSwitcher.test.ts
@@ -1,0 +1,68 @@
+import Vuex from 'vuex';
+import { shallowMount, mount } from "@vue/test-utils";
+import LanguageSwitcher from "../../src/LanguageSwitcher.vue";
+
+describe("languageSwitcher component", () => {
+    const mockUpdateLanguage = jest.fn();
+
+    const createStore = () => {
+        return new Vuex.Store({
+            modules: {
+                language: {
+                    namespaced: true,
+                    state: {
+                        currentLanguage: "en",
+                        updatingLanguage: false,
+                        enableI18n: true
+                    },
+                    actions: {
+                        UpdateLanguage: mockUpdateLanguage
+                    }
+                }
+            }
+        })
+    }
+
+    const getWrapper = (isMount: boolean) => {
+        if (isMount) {
+            return mount(LanguageSwitcher, {
+                props: {
+                    languagesKeys: {
+                        "en": "English",
+                        "fr": "French"
+                    }
+                },
+                global: {
+                    plugins: [createStore()]
+                }
+            });
+        } else {
+            return shallowMount(LanguageSwitcher, {
+                props: {
+                    languagesKeys: {
+                        "en": "English",
+                        "fr": "French"
+                    }
+                },
+                global: {
+                    plugins: [createStore()]
+                }
+            });
+        }
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper(false);
+        expect(wrapper.find("div").classes()).toStrictEqual(["navbar-text", "navbar-version", "ms-3", "me-1"]);
+        expect(wrapper.find("drop-down-stub").attributes("text")).toBe("English")
+    });
+
+    it("changing language dispatches updateLanguage action", async () => {
+        const wrapper = getWrapper(true);
+        await wrapper.trigger("click");
+        expect(mockUpdateLanguage).toBeCalledTimes(0);
+        const menuItems = wrapper.findAll("li");
+        await menuItems[1].find("span").trigger("click");
+        expect(mockUpdateLanguage).toBeCalledTimes(1);
+    });
+});

--- a/app/static/translationPackage/tests/store/actions.test.ts
+++ b/app/static/translationPackage/tests/store/actions.test.ts
@@ -1,11 +1,10 @@
 import i18next from "i18next";
-import { LanguageStateMutation } from "../../../../translationPackage/store/mutations";
-import { LanguageAction, actions } from "../../../../translationPackage/store/actions";
-import { Language } from "../../../../src/app/types/languageTypes";
+import { LanguageStateMutation } from "../../store/mutations";
+import { LanguageAction, actions } from "../../store/actions";
 
 describe("Language actions", () => {
     i18next.init({
-        lng: Language.en,
+        lng: "en",
         resources: {
             en: {
                 translation: {
@@ -23,10 +22,10 @@ describe("Language actions", () => {
     it("UpdateLanguage commits change language mutation and i18next function", async () => {
         const commit = jest.fn();
         const spyChangeLanguage = jest.spyOn(i18next, "changeLanguage");
-        await (actions[LanguageAction.UpdateLanguage] as any)({ commit }, Language.fr);
+        await (actions[LanguageAction.UpdateLanguage] as any)({ commit }, "fr");
         expect(commit).toBeCalledTimes(1);
         expect(commit.mock.calls[0][0]).toBe(LanguageStateMutation.ChangeLanguage);
-        expect(commit.mock.calls[0][1]).toStrictEqual(Language.fr);
+        expect(commit.mock.calls[0][1]).toStrictEqual("fr");
         expect(spyChangeLanguage).toBeCalled();
     });
 });

--- a/app/static/translationPackage/tests/store/mutations.test.ts
+++ b/app/static/translationPackage/tests/store/mutations.test.ts
@@ -1,10 +1,9 @@
-import { Language } from "../../../../src/app/types/languageTypes";
-import { mutations } from "../../../../translationPackage/store/mutations";
-import { LanguageState } from "../../../../translationPackage/store/state";
+import { mutations } from "../../store/mutations";
+import { LanguageState } from "../../store/state";
 
 const expectLanguageState = (
     state: LanguageState,
-    currentLanguage = Language.en,
+    currentLanguage = "en",
     updatingLanguage = false,
     enableI18n = true
 ) => {
@@ -16,21 +15,21 @@ const expectLanguageState = (
 describe("Language mutations", () => {
     it("changes language", () => {
         const state = {
-            currentLanguage: Language.en,
+            currentLanguage: "en",
             updatingLanguage: false,
             enableI18n: true
         };
-        mutations.ChangeLanguage(state, Language.fr);
-        expectLanguageState(state, Language.fr, false, true);
+        mutations.ChangeLanguage(state, "fr");
+        expectLanguageState(state, "fr", false, true);
     });
 
     it("sets updating language", () => {
         const state = {
-            currentLanguage: Language.en,
+            currentLanguage: "en",
             updatingLanguage: false,
             enableI18n: true
         };
         mutations.SetUpdatingLanguage(state, true);
-        expectLanguageState(state, Language.en, true, true);
+        expectLanguageState(state, "en", true, true);
     });
 });


### PR DESCRIPTION
## Problems/motivation:
- Need to make a language switcher component as part of the translation epic ticket

## New features/solutions:
- Added Language Switcher component in translation package
- Added Language Switcher component at the end of the app header
- Made index file so all components can import from it (behaving like a package)
- Moved tests from normal unit tests to tests folder in `translationPackage`
- Exporting `registerResources` so people can add translations after initialising `i18n`

## How PR should behave when tested:
- Should have a dropdown at the end of the app header saying your current language (you can vary `defaultLanguage` in Wodin config to check it initialises properly)
- Should be able to click dropdown items and store should update accordingly (can add a console.log after the store dispatch to check)
- If you turn `i18n` off in Wodin config then the language switcher should not be on the app header

## How to run app:
1. Run the app according to the README