### PR TITLE
mrc-4305 Add loading to code status

### DIFF
--- a/app/static/src/app/components/code/CodeEditor.vue
+++ b/app/static/src/app/components/code/CodeEditor.vue
@@ -21,6 +21,7 @@ import * as monaco from "monaco-editor";
 import Timeout = NodeJS.Timeout;
 import { AppConfig, OdinModelResponse } from "../../types/responseTypes";
 import { CodeAction } from "../../store/code/actions";
+import { CodeMutation } from "../../store/code/mutations";
 
 interface DecorationOptions {
     range: {
@@ -134,6 +135,7 @@ export default defineComponent({
             decoration)
             */
             oldDecorations.value = editorInstance.deltaDecorations(oldDecorations.value, newDecorations);
+            store.commit(`code/${CodeMutation.SetLoading}`, false);
         };
 
         const updateCode = () => {
@@ -142,6 +144,7 @@ export default defineComponent({
         };
 
         const setPendingCodeUpdate = () => {
+            store.commit(`code/${CodeMutation.SetLoading}`, true);
             if (!timeoutId) {
                 timeoutId = setTimeout(() => {
                     updateCode();

--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -3,17 +3,13 @@
         <generic-help title="Write odin code" :markdown="codeHelp"></generic-help>
         <code-editor/>
         <button class="btn btn-primary mt-2" id="compile-btn" :disabled="!codeIsValid" @click="compile">Compile</button>
-        <div v-show="!codeValidating" class="mt-2" id="code-status">
+        <div class="mt-2" id="code-status" :class="codeValidating ? 'code-validating-text' : ''">
             <vue-feather class="inline-icon me-1"
                          :class="iconClass"
                          :type="validIcon"
                          :size="20"
                          :stroke-width="4"></vue-feather>
             {{ validMsg }}
-        </div>
-        <div v-show="codeValidating" class="mt-2" id="code-loading">
-            <span class="spinner-border spinner-border-sm me-2 text-warning"></span>
-            {{ loadingMessage }}
         </div>
         <error-info :error="error"></error-info>
         <div class="mt-3">
@@ -57,7 +53,8 @@ export default defineComponent({
         const error = computed(() => store.state.model.odinModelCodeError);
         const validMsg = computed(() => (codeIsValid.value ? userMessages.code.isValid : userMessages.code.isNotValid));
         const validIcon = computed(() => (codeIsValid.value ? "check" : "x"));
-        const iconClass = computed(() => (codeIsValid.value ? "text-success" : "text-danger"));
+        const iconValidatedClass = computed(() => (codeIsValid.value ? "text-success" : "text-danger"));
+        const iconClass = computed(() => (codeValidating.value ? "code-validating-icon" : iconValidatedClass.value));
         const allVariables = computed<string[]>(() => store.state.model.odinModelResponse?.metadata?.variables || []);
         const showSelectedVariables = computed(() => allVariables.value.length && !store.state.model.compileRequired);
         const appIsConfigured = computed(() => store.state.configured);
@@ -80,3 +77,11 @@ export default defineComponent({
     }
 });
 </script>
+<style>
+    .code-validating-icon {
+        color: gray;
+    }
+    .code-validating-text {
+        color: rgba(0, 0, 0, 0.7);
+    }
+</style>

--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -3,9 +3,17 @@
         <generic-help title="Write odin code" :markdown="codeHelp"></generic-help>
         <code-editor/>
         <button class="btn btn-primary mt-2" id="compile-btn" :disabled="!codeIsValid" @click="compile">Compile</button>
-        <div class="mt-2" id="code-status">
-            <vue-feather class="inline-icon" :class="iconClass" :type="validIcon"></vue-feather>
+        <div v-show="!codeValidating" class="mt-2" id="code-status">
+            <vue-feather class="inline-icon me-1"
+                         :class="iconClass"
+                         :type="validIcon"
+                         :size="20"
+                         :stroke-width="4"></vue-feather>
             {{ validMsg }}
+        </div>
+        <div v-show="codeValidating" class="mt-2" id="code-loading">
+            <span class="spinner-border spinner-border-sm me-2 text-warning"></span>
+            {{ loadingMessage }}
         </div>
         <error-info :error="error"></error-info>
         <div class="mt-3">
@@ -45,6 +53,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const codeIsValid = computed(() => store.state.model.odinModelResponse?.valid);
+        const codeValidating = computed(() => store.state.code.loading);
         const error = computed(() => store.state.model.odinModelCodeError);
         const validMsg = computed(() => (codeIsValid.value ? userMessages.code.isValid : userMessages.code.isNotValid));
         const validIcon = computed(() => (codeIsValid.value ? "check" : "x"));
@@ -53,6 +62,7 @@ export default defineComponent({
         const showSelectedVariables = computed(() => allVariables.value.length && !store.state.model.compileRequired);
         const appIsConfigured = computed(() => store.state.configured);
         const compile = () => store.dispatch(`model/${ModelAction.CompileModel}`);
+        const loadingMessage = userMessages.code.isValidating;
 
         return {
             appIsConfigured,
@@ -63,7 +73,9 @@ export default defineComponent({
             compile,
             error,
             showSelectedVariables,
-            codeHelp
+            codeHelp,
+            codeValidating,
+            loadingMessage
         };
     }
 });

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -18,7 +18,8 @@ import { Dict } from "./types/utilTypes";
 
 function serialiseCode(code: CodeState) : CodeState {
     return {
-        currentCode: code.currentCode
+        currentCode: code.currentCode,
+        loading: code.loading
     };
 }
 

--- a/app/static/src/app/store/code/code.ts
+++ b/app/static/src/app/store/code/code.ts
@@ -3,7 +3,8 @@ import { mutations } from "./mutations";
 import { actions } from "./actions";
 
 export const defaultState: CodeState = {
-    currentCode: []
+    currentCode: [],
+    loading: false
 };
 
 export const code = {

--- a/app/static/src/app/store/code/mutations.ts
+++ b/app/static/src/app/store/code/mutations.ts
@@ -2,7 +2,7 @@ import { MutationTree } from "vuex";
 import { CodeState } from "./state";
 
 export enum CodeMutation {
-    SetCurrentCode = "SetCurrentCodes",
+    SetCurrentCode = "SetCurrentCode",
     SetLoading = "SetLoading"
 }
 

--- a/app/static/src/app/store/code/mutations.ts
+++ b/app/static/src/app/store/code/mutations.ts
@@ -2,11 +2,16 @@ import { MutationTree } from "vuex";
 import { CodeState } from "./state";
 
 export enum CodeMutation {
-    SetCurrentCode = "SetCurrentCode"
+    SetCurrentCode = "SetCurrentCodes",
+    SetLoading = "SetLoading"
 }
 
 export const mutations: MutationTree<CodeState> = {
     [CodeMutation.SetCurrentCode](state: CodeState, payload: string[]) {
         state.currentCode = payload;
+    },
+
+    [CodeMutation.SetLoading](state: CodeState, payload: boolean) {
+        state.loading = payload;
     }
 };

--- a/app/static/src/app/store/code/state.ts
+++ b/app/static/src/app/store/code/state.ts
@@ -1,3 +1,4 @@
 export interface CodeState {
-    currentCode: string[]
+    currentCode: string[],
+    loading: boolean
 }

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -3,7 +3,8 @@ import settings from "./settings";
 export default {
     code: {
         isValid: "Code is valid",
-        isNotValid: "Code is not valid"
+        isNotValid: "Code is not valid",
+        isValidating: "Code is validating"
     },
     download: {
         invalidPoints: "Modelled points must be between 1 and 50,001"

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -127,9 +127,9 @@ test.describe("Code Tab tests", () => {
         await page.press(".monaco-editor textarea", "Control+A");
         await page.press(".monaco-editor textarea", "Delete");
         page.fill(".monaco-editor textarea", "blah");
-        expect(page.locator("#code-loading")).toHaveText("Code is validating");
-        expect(page.locator("#code-loading").locator("span"))
-            .toHaveClass("spinner-border spinner-border-sm me-2 text-warning");
+        expect(page.locator("#code-status")).toHaveClass("mt-2 code-validating-text");
+        expect(page.locator("#code-status").locator("i"))
+            .toHaveClass("vue-feather vue-feather--check inline-icon me-1 code-validating-icon");
     });
 
     test("can see code not valid msg when update code with syntax error", async ({ page }) => {

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -123,6 +123,15 @@ test.describe("Code Tab tests", () => {
         await expect(await page.innerHTML(`:nth-match(${legendTextSelector}, 3)`)).toBe("y3");
     });
 
+    test("code loading on input renders as expected", async ({ page }) => {
+        await page.press(".monaco-editor textarea", "Control+A");
+        await page.press(".monaco-editor textarea", "Delete");
+        page.fill(".monaco-editor textarea", "blah");
+        expect(page.locator("#code-loading")).toHaveText("Code is validating");
+        expect(page.locator("#code-loading").locator("span"))
+            .toHaveClass("spinner-border spinner-border-sm me-2 text-warning");
+    });
+
     test("can see code not valid msg when update code with syntax error", async ({ page }) => {
         const invalidCode = "deriv(y1) test * faker";
         await writeCode(page, invalidCode);

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -94,6 +94,7 @@ export const mockRunState = (state: Partial<RunState> = {}): RunState => {
 export const mockCodeState = (state: Partial<CodeState> = {}): CodeState => {
     return {
         currentCode: [],
+        loading: false,
         ...state
     };
 };

--- a/app/static/tests/unit/components/code/codeTab.test.ts
+++ b/app/static/tests/unit/components/code/codeTab.test.ts
@@ -82,16 +82,11 @@ describe("CodeTab", () => {
         expect(statusIcon.classes()).toContain("text-danger");
     });
 
-    it("shows loading icon and code-loading when code is validating", () => {
+    it("shows greyed out icon and greyed out message when code is validating", () => {
         const wrapper = getWrapper(defaultModelState, true);
-        expect(wrapper.find("#code-loading").isVisible()).toBe(true);
-        expect(wrapper.find("#code-status").isVisible()).toBe(false);
-        const statusIcon = wrapper.find("#code-loading").find("span");
-        expect(statusIcon.classes()).toContain("text-warning");
-        expect(statusIcon.classes()).toContain("spinner-border");
-        expect(statusIcon.classes()).toContain("spinner-border-sm");
-        expect(statusIcon.classes()).toContain("me-2");
-        expect(wrapper.find("#code-loading").text()).toBe("Code is validating");
+        expect(wrapper.find("#code-status").classes()).toContain("code-validating-text");
+        const statusIcon = wrapper.find("#code-status").findComponent(VueFeather);
+        expect(statusIcon.classes()).toContain("code-validating-icon");
     });
 
     it("compile button dispatches compile action", () => {

--- a/app/static/tests/unit/components/code/codeTab.test.ts
+++ b/app/static/tests/unit/components/code/codeTab.test.ts
@@ -4,7 +4,7 @@ import VueFeather from "vue-feather";
 import CodeTab from "../../../../src/app/components/code/CodeTab.vue";
 import CodeEditor from "../../../../src/app/components/code/CodeEditor.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockModelState } from "../../../mocks";
+import { mockBasicState, mockCodeState, mockModelState } from "../../../mocks";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
 import { ModelState } from "../../../../src/app/store/model/state";
 import VerticalCollapse from "../../../../src/app/components/VerticalCollapse.vue";
@@ -28,7 +28,7 @@ describe("CodeTab", () => {
 
     const mockCompileModel = jest.fn();
 
-    const getWrapper = (odinModelState: Partial<ModelState> = defaultModelState) => {
+    const getWrapper = (odinModelState: Partial<ModelState> = defaultModelState, loading = false) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
                 configured: true
@@ -40,6 +40,10 @@ describe("CodeTab", () => {
                     actions: {
                         CompileModel: mockCompileModel
                     }
+                },
+                code: {
+                    namespaced: true,
+                    state: mockCodeState({ loading })
                 }
             }
         });
@@ -76,6 +80,18 @@ describe("CodeTab", () => {
         const statusIcon = wrapper.find("#code-status").findComponent(VueFeather);
         expect(statusIcon.attributes("type")).toBe("x");
         expect(statusIcon.classes()).toContain("text-danger");
+    });
+
+    it("shows loading icon and code-loading when code is validating", () => {
+        const wrapper = getWrapper(defaultModelState, true);
+        expect(wrapper.find("#code-loading").isVisible()).toBe(true);
+        expect(wrapper.find("#code-status").isVisible()).toBe(false);
+        const statusIcon = wrapper.find("#code-loading").find("span");
+        expect(statusIcon.classes()).toContain("text-warning");
+        expect(statusIcon.classes()).toContain("spinner-border");
+        expect(statusIcon.classes()).toContain("spinner-border-sm");
+        expect(statusIcon.classes()).toContain("me-2");
+        expect(wrapper.find("#code-loading").text()).toBe("Code is validating");
     });
 
     it("compile button dispatches compile action", () => {

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -267,7 +267,7 @@ describe("serialise", () => {
         language: langaugeState
     };
 
-    const expectedCode = { currentCode: ["some code"] };
+    const expectedCode = { currentCode: ["some code"], loading: false };
     const expectedModel = {
         compileRequired: true,
         odinModelResponse: modelState.odinModelResponse,

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -21,7 +21,8 @@ import { Language } from "../../src/app/types/languageTypes";
 
 describe("serialise", () => {
     const codeState = {
-        currentCode: ["some code"]
+        currentCode: ["some code"],
+        loading: false
     };
 
     const modelState = {

--- a/app/static/tests/unit/store/code/mutations.test.ts
+++ b/app/static/tests/unit/store/code/mutations.test.ts
@@ -8,4 +8,10 @@ describe("Code mutations", () => {
         mutations.SetCurrentCode(state, code);
         expect(state.currentCode).toBe(code);
     });
+
+    it("sets loading", () => {
+        const state = mockCodeState();
+        mutations.SetLoading(state, true);
+        expect(state.loading).toBe(true);
+    });
 });


### PR DESCRIPTION
## Problems/motivation:
- Code validation from the back-end takes time so we want a loading state for it

## New features/solutions:
- Add loading property to `CodeState`
- Toggle loading state when code changes in the editor or when code is validated
- Loading spinner for code validation
- Changed valid and invalid icon for consistent styling

## How PR should behave when tested:
- Type something into the code editor, it should show loading for a bit

## How to run app:
1. Run the app according to the README