### PR TITLE
Mrc 3701 Resizable Panel

### DIFF
--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -40,7 +40,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, onUnmounted, ref } from "vue";
+import {
+    computed, defineComponent, onMounted, onUnmounted, ref
+} from "vue";
 import VueFeather from "vue-feather";
 
 export enum PanelsMode {
@@ -65,8 +67,8 @@ export default defineComponent({
         VueFeather
     },
     setup() {
-        let windowWidth = ref(window.innerWidth);
-        let panelsWindow = ref<null | HTMLElement>(null);
+        const windowWidth = ref(window.innerWidth);
+        const panelsWindow = ref<null | HTMLElement>(null);
         /*
             Window boundary variables are the points on either side at which the the
             panel doesn't display content anymore and if they mouseup at that region
@@ -76,12 +78,25 @@ export default defineComponent({
             Snap tolerance variables are points on either side at which the panel snaps
             even if they haven't emitted a mouseup event (let go of the drag). In general,
             we divide by a factor of 3 to get the snap tolerance from the boundary
-        */ 
+        */
         const windowBoundaryLeft = computed(() => Math.max(windowWidth.value / 8, 200));
         const windowMinRightPanelWidth = computed(() => Math.max(windowWidth.value / 4, 400));
         const windowBoundaryRight = computed(() => windowWidth.value - windowMinRightPanelWidth.value);
         const snapToleranceLeft = computed(() => windowBoundaryLeft.value / 3);
         const snapToleranceRight = computed(() => windowWidth.value - windowMinRightPanelWidth.value / 3);
+
+        const optionsWidth = ref<WidthStyle>({});
+        const chartsWidth = ref<WidthStyle>({});
+
+        const mode = ref<PanelsMode>(PanelsMode.Both);
+        const modeClassMap: Record<PanelsMode, string> = {
+            [PanelsMode.Both]: "wodin-mode-both",
+            [PanelsMode.Left]: "wodin-mode-left",
+            [PanelsMode.Right]: "wodin-mode-right"
+        };
+        const modeClass = computed(() => modeClassMap[mode.value]);
+        const dragStart = ref<DragStart | null>(null);
+        const hidePanelMode = ref<HidePanelContent>(HidePanelContent.None);
 
         const resize = () => {
             // complete reset to avoid the panel being across
@@ -93,7 +108,7 @@ export default defineComponent({
             chartsWidth.value.width = `calc(100% - ${optionsWidth.value.width})`;
         };
 
-        let resizeObserver = new ResizeObserver(resize);
+        const resizeObserver = new ResizeObserver(resize);
         onMounted(() => {
             if (panelsWindow.value) {
                 resizeObserver.observe(panelsWindow.value);
@@ -104,21 +119,6 @@ export default defineComponent({
                 resizeObserver.disconnect();
             }
         });
-
-        const mode = ref<PanelsMode>(PanelsMode.Both);
-        const modeClassMap: Record<PanelsMode, string> = {
-            [PanelsMode.Both]: "wodin-mode-both",
-            [PanelsMode.Left]: "wodin-mode-left",
-            [PanelsMode.Right]: "wodin-mode-right"
-        };
-
-        const modeClass = computed(() => modeClassMap[mode.value]);
-
-        const optionsWidth = ref<WidthStyle>({});
-        const chartsWidth = ref<WidthStyle>({});
-        const dragStart = ref<DragStart | null>(null);
-
-        const hidePanelMode = ref<HidePanelContent>(HidePanelContent.None);
 
         const getTouchEvent = (event: Event) => {
             return (event as TouchEvent).touches?.length > 0 ? (event as TouchEvent).touches[0] : event;

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -157,6 +157,7 @@ export default defineComponent({
         left: 0;
         top: 0;
         margin-top: 3.5rem;
+        cursor: col-resize;
     }
 
     .drag-overlay-hidden {

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -1,4 +1,8 @@
 <template>
+    <div :class="isDragging ? 'drag-overlay' : 'drag-overlay-hidden'">
+        <div class="divider-line-left"></div>
+        <div class="divider-line-right"></div>
+    </div>
     <div :class="modeClass">
         <div class="wodin-left" :style="panelWidth">
             <span class="wodin-collapse-controls">
@@ -46,10 +50,13 @@ export default defineComponent({
             [PanelsMode.Right]: "wodin-mode-right"
         };
 
-        const modeClass = computed(() => modeClassMap[mode.value]);
+        const modeClass = computed(() => {
+            return modeClassMap[mode.value]
+        });
 
         const panelWidth = ref<any>({});
         const plotWidth = ref<any>({});
+        const isDragging = ref<boolean>(false);
 
         const getTouchEvent = (event: Event) => {
             return (event as TouchEvent).touches?.length > 0 ? (event as TouchEvent).touches[0] : event;
@@ -95,9 +102,11 @@ export default defineComponent({
         };
 
         const handleDragEnd = () => {
+            isDragging.value = false;
             removeDragListeners(handleDragMove, handleDragEnd);
         };
         const handleDragStart = () => {
+            isDragging.value = true;
             addDragListeners(handleDragMove, handleDragEnd);
         };
 
@@ -115,7 +124,8 @@ export default defineComponent({
             handleDragStart,
             handleDragEnd,
             openCollapsedView,
-            handleDragMove
+            handleDragMove,
+            isDragging
         };
     }
 });
@@ -130,6 +140,40 @@ export default defineComponent({
     $animationDuration: 0.5s;
 
     $dark-grey: #777;
+
+    $widthToleranceLeft: calc(100% / 8);
+    $widthToleranceRight: calc(100% - calc(100% / 4));
+
+    .drag-overlay {
+        position: fixed;
+        background-color: rgba($color: #000000, $alpha: 0.25);
+        z-index: 9999;
+        width: 100vw;
+        max-width: 100%;
+        height: 100vh;
+        left: 0;
+        top: 0;
+        margin-top: 3.5rem;
+    }
+
+    .drag-overlay-hidden {
+        position: fixed;
+        visibility: hidden;
+    }
+
+    .divider-line-left {
+        position: fixed;
+        border-left: 5px dashed #fff;
+        height: 100%;
+        left: $widthToleranceLeft
+    }
+
+    .divider-line-right {
+        position: fixed;
+        border-left: 5px dashed #fff;
+        height: 100%;
+        left: $widthToleranceRight
+    }
 
     .wodin-left, .wodin-right {
         float: left;

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -7,7 +7,8 @@
         <div class="wodin-left" :style="panelWidth">
             <span class="wodin-collapse-controls">
                 <span @mousedown="handleDragStart" @mouseup="handleDragEnd" id="resize-panel-control">
-                    <vue-feather type="maximize-2" style="transform: rotate(45deg);"></vue-feather>
+                    <vue-feather type="maximize-2"
+                                 style="transform: rotate(45deg); color: grey;"></vue-feather>
                 </span>
             </span>
             <div class="view-left" @click="openCollapsedView">

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -50,9 +50,7 @@ export default defineComponent({
             [PanelsMode.Right]: "wodin-mode-right"
         };
 
-        const modeClass = computed(() => {
-            return modeClassMap[mode.value]
-        });
+        const modeClass = computed(() => modeClassMap[mode.value]);
 
         const panelWidth = ref<any>({});
         const plotWidth = ref<any>({});

--- a/app/static/src/app/components/WodinPanels.vue
+++ b/app/static/src/app/components/WodinPanels.vue
@@ -4,7 +4,7 @@
         <div class="divider-line-right"></div>
     </div>
     <div :class="modeClass">
-        <div class="wodin-left" :style="panelWidth">
+        <div class="wodin-left" :style="optionsWidth">
             <span class="wodin-collapse-controls">
                 <span @mousedown="handleDragStart" @mouseup="handleDragEnd" id="resize-panel-control">
                     <vue-feather type="maximize-2"
@@ -18,7 +18,7 @@
                 <slot name="left"></slot>
             </div>
         </div>
-        <div class="wodin-right" :style="plotWidth">
+        <div class="wodin-right" :style="chartsWidth">
             <div class="view-right" @click="openCollapsedView">
                 View Charts
             </div>
@@ -38,6 +38,10 @@ export enum PanelsMode {
     Left, Right, Both
 }
 
+type WidthStyle = {
+    width?: string
+}
+
 export default defineComponent({
     name: "WodinPanels",
     components: {
@@ -53,8 +57,8 @@ export default defineComponent({
 
         const modeClass = computed(() => modeClassMap[mode.value]);
 
-        const panelWidth = ref<any>({});
-        const plotWidth = ref<any>({});
+        const optionsWidth = ref<WidthStyle>({});
+        const chartsWidth = ref<WidthStyle>({});
         const isDragging = ref<boolean>(false);
 
         const getTouchEvent = (event: Event) => {
@@ -95,8 +99,8 @@ export default defineComponent({
                 mode.value = PanelsMode.Both;
             }
 
-            panelWidth.value.width = `calc(${clientX}px + 1.4rem)`;
-            plotWidth.value.width = `calc(100vw - ${clientX}px - 5rem)`;
+            optionsWidth.value.width = `calc(${clientX}px + 1.4rem)`;
+            chartsWidth.value.width = `calc(100vw - ${clientX}px - 5rem)`;
             event.preventDefault();
         };
 
@@ -110,16 +114,16 @@ export default defineComponent({
         };
 
         const openCollapsedView = () => {
-            panelWidth.value.width = "30%";
-            plotWidth.value.width = "70%";
+            optionsWidth.value.width = "30%";
+            chartsWidth.value.width = "70%";
             mode.value = PanelsMode.Both;
         };
 
         return {
             mode,
             modeClass,
-            plotWidth,
-            panelWidth,
+            chartsWidth,
+            optionsWidth,
             handleDragStart,
             handleDragEnd,
             openCollapsedView,

--- a/app/static/tests/e2e/panels.etest.ts
+++ b/app/static/tests/e2e/panels.etest.ts
@@ -1,16 +1,25 @@
-import { expect, test, Page } from "@playwright/test";
+import {
+    expect,
+    test,
+    Page,
+    Locator
+} from "@playwright/test";
 
 test.describe("Wodin App panels tests", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/apps/day1");
     });
 
+    // playwright default screen size is 1280x720
+    const windowWidth = 1280;
+    const rightBoundary = windowWidth - windowWidth / 4;
+    const leftBoundary = windowWidth / 8;
+
     const expectBothMode = async (page: Page) => {
         await expect(await page.innerText(".wodin-mode-both .wodin-left .wodin-content .nav-tabs .active"))
             .toBe("Code");
         await expect(await page.locator(".wodin-mode-both .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
-        await expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
-        await expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #resize-panel-control")).toBeVisible();
         await expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
         await expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
     };
@@ -18,8 +27,7 @@ test.describe("Wodin App panels tests", () => {
     const expectRightMode = async (page: Page) => {
         await expect(await page.locator(".wodin-mode-right .wodin-right .wodin-content .js-plotly-plot")).toBeVisible();
         await expect(await page.locator(".wodin-mode-right .wodin-left .wodin-content").isHidden()).toBe(true);
-        await expect(await page.locator(".wodin-collapse-controls #collapse-left").isHidden()).toBe(true);
-        await expect(await page.locator(".wodin-collapse-controls #collapse-right")).toBeVisible();
+        await expect(await page.locator(".wodin-collapse-controls #resize-panel-control")).toBeVisible();
         await expect(await page.locator(".wodin-left .view-left")).toBeVisible();
         await expect(await page.locator(".wodin-right .view-right").isHidden()).toBe(true);
     };
@@ -27,34 +35,65 @@ test.describe("Wodin App panels tests", () => {
     const expectLeftMode = async (page: Page) => {
         await expect(await page.locator(".wodin-mode-left .wodin-right .wodin-content").isHidden()).toBe(true);
         await expect(await page.locator(".wodin-mode-left .wodin-left .wodin-content")).toBeVisible();
-        await expect(await page.locator(".wodin-collapse-controls #collapse-left")).toBeVisible();
-        await expect(await page.locator(".wodin-collapse-controls #collapse-right").isHidden()).toBe(true);
+        await expect(await page.locator(".wodin-collapse-controls #resize-panel-control")).toBeVisible();
         await expect(await page.locator(".wodin-left .view-left").isHidden()).toBe(true);
         await expect(await page.locator(".wodin-right .view-right")).toBeVisible();
     };
 
+    interface Point {
+        x: number,
+        y:number
+    }
+
+    const dragTo = async (page: Page, locatorToDrag: Locator, locatorDragTarget: Point) => {
+        const toDragBox = await locatorToDrag.boundingBox();
+
+        await page.mouse.move(
+            toDragBox!.x + toDragBox!.width / 2,
+            toDragBox!.y + toDragBox!.height / 2
+        );
+        await page.mouse.down();
+        await page.mouse.move(
+            locatorDragTarget.x,
+            locatorDragTarget.y
+        );
+        await page.mouse.up();
+    };
+
     test("can collapse and expand left panel", async ({ page }) => {
         await expectBothMode(page);
+        const panelResizer = page.locator("#resize-panel-control");
 
-        await page.click("#collapse-left");
+        await dragTo(page, panelResizer, { x: leftBoundary, y: 0 });
+        await expectBothMode(page);
+
+        // beyond collapse boundary so panel should collapse
+        await dragTo(page, panelResizer, { x: leftBoundary - 1, y: 0 });
         await expectRightMode(page);
 
-        await page.click("#collapse-right");
+        await dragTo(page, panelResizer, { x: leftBoundary, y: 0 });
         await expectBothMode(page);
     });
 
     test("can collapse and expand right panel", async ({ page }) => {
         await expectBothMode(page);
+        const panelResizer = page.locator("#resize-panel-control");
 
-        await page.click("#collapse-right");
+        await dragTo(page, panelResizer, { x: rightBoundary, y: 0 });
+        await expectBothMode(page);
+
+        // beyond collapse boundary so panel should collapse
+        await dragTo(page, panelResizer, { x: rightBoundary + 1, y: 0 });
         await expectLeftMode(page);
 
-        await page.click("#collapse-left");
+        await dragTo(page, panelResizer, { x: rightBoundary, y: 0 });
         await expectBothMode(page);
     });
 
     test("'View Options' shows both panels", async ({ page }) => {
-        await page.click("#collapse-left");
+        const panelResizer = page.locator("#resize-panel-control");
+        await dragTo(page, panelResizer, { x: leftBoundary - 1, y: 0 });
+        await expectRightMode(page);
 
         await expect(await page.innerText(".view-left")).toBe("View Options");
         await page.click(".view-left");
@@ -62,7 +101,9 @@ test.describe("Wodin App panels tests", () => {
     });
 
     test("'View Charts' shows both panels", async ({ page }) => {
-        await page.click("#collapse-right");
+        const panelResizer = page.locator("#resize-panel-control");
+        await dragTo(page, panelResizer, { x: rightBoundary + 1, y: 0 });
+        await expectLeftMode(page);
 
         await expect(await page.innerText(".view-right")).toBe("View Charts");
         await page.click(".view-right");

--- a/app/static/tests/e2e/panels.etest.ts
+++ b/app/static/tests/e2e/panels.etest.ts
@@ -12,12 +12,10 @@ test.describe("Wodin App panels tests", () => {
 
     // playwright default screen size is 1280x720
     const windowWidth = 1280;
-    const widthToleranceLeft = windowWidth / 8;
-    const widthToleranceRight = windowWidth / 4;
+    const widthToleranceLeft = Math.max(windowWidth / 8, 200);
+    const widthToleranceRight = Math.max(windowWidth / 4, 400);
     const leftBoundary = widthToleranceLeft;
     const rightBoundary = windowWidth - widthToleranceRight;
-    const snapToleranceLeft = windowWidth / 25;
-    const snapToleranceRight = windowWidth - windowWidth / 13;
 
     const expectBothMode = async (page: Page) => {
         await expect(await page.innerText(".wodin-mode-both .wodin-left .wodin-content .nav-tabs .active"))

--- a/app/static/tests/unit/components/basic/basicApp.test.ts
+++ b/app/static/tests/unit/components/basic/basicApp.test.ts
@@ -31,6 +31,12 @@ import { AppConfig } from "../../../../src/app/types/responseTypes";
 
 const mockTooltipDirective = jest.fn();
 
+function mockResizeObserver(this: any) {
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+}
+(global.ResizeObserver as any) = mockResizeObserver;
+
 describe("BasicApp", () => {
     const getWrapper = (mockSetOpenVisualisationTab = jest.fn(), config: Partial<AppConfig> = {}) => {
         const state = mockBasicState({ config: config as any, configured: true });

--- a/app/static/tests/unit/components/fit/fitApp.test.ts
+++ b/app/static/tests/unit/components/fit/fitApp.test.ts
@@ -34,6 +34,12 @@ import { AppStateMutation } from "../../../../src/app/store/appState/mutations";
 import { ModelFitGetter } from "../../../../src/app/store/modelFit/getters";
 import { AppConfig } from "../../../../src/app/types/responseTypes";
 
+function mockResizeObserver(this: any) {
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+}
+(global.ResizeObserver as any) = mockResizeObserver;
+
 describe("FitApp", () => {
     const mockTooltipDirective = jest.fn();
 

--- a/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
+++ b/app/static/tests/unit/components/stochastic/stochasticApp.test.ts
@@ -32,6 +32,12 @@ import { AppConfig } from "../../../../src/app/types/responseTypes";
 const mockSetOpenVisualisationTab = jest.fn();
 const mockTooltipDirective = jest.fn();
 
+function mockResizeObserver(this: any) {
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+}
+(global.ResizeObserver as any) = mockResizeObserver;
+
 describe("StochasticApp", () => {
     const getWrapper = (config: Partial<AppConfig> = {}) => {
         const store = new Vuex.Store<StochasticState>({

--- a/app/static/tests/unit/components/wodinApp.test.ts
+++ b/app/static/tests/unit/components/wodinApp.test.ts
@@ -7,6 +7,12 @@ import WodinPanels from "../../../src/app/components/WodinPanels.vue";
 import ErrorsAlert from "../../../src/app/components/ErrorsAlert.vue";
 import WodinApp from "../../../src/app/components/WodinApp.vue";
 
+function mockResizeObserver(this: any) {
+    this.observe = jest.fn();
+    this.disconnect = jest.fn();
+}
+(global.ResizeObserver as any) = mockResizeObserver;
+
 describe("WodinApp", () => {
     const getWrapper = (includeConfig = true) => {
         const config = includeConfig ? { basicProp: "Test basic prop value" } : null;

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -48,8 +48,8 @@ describe("WodinPanels", () => {
         const {
             mode,
             modeClass,
-            panelWidth,
-            plotWidth
+            optionsWidth,
+            chartsWidth
         } = (wrapper.vm as any);
         const modeClassMap: Record<PanelsMode, string> = {
             [PanelsMode.Both]: "wodin-mode-both",
@@ -59,8 +59,8 @@ describe("WodinPanels", () => {
         expect(mode).toBe(expectedMode);
         expect(modeClass).toBe(modeClassMap[expectedMode]);
         if (position) {
-            expect(panelWidth).toStrictEqual({ width: `calc(${position}px + 1.4rem)` });
-            expect(plotWidth).toStrictEqual({ width: `calc(100vw - ${position}px - 5rem)` });
+            expect(optionsWidth).toStrictEqual({ width: `calc(${position}px + 1.4rem)` });
+            expect(chartsWidth).toStrictEqual({ width: `calc(100vw - ${position}px - 5rem)` });
         }
         expect(mockPreventDefault).toBeCalledTimes(expectedPreventDefault);
     };

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -266,7 +266,7 @@ describe("WodinPanels", () => {
 
     it("resize function resets the panel split", async () => {
         const wrapper = getWrapper();
-        const vm = wrapper.vm;
+        const { vm } = wrapper;
         window.innerWidth = 1000;
         vm.windowWidth = 2000;
         vm.mode = PanelsMode.Left;

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -169,4 +169,22 @@ describe("WodinPanels", () => {
         await wrapper.find(".view-right").trigger("click");
         testBothMode(wrapper);
     });
+
+    it("drag overlay renders as expected", async () => {
+        const wrapper = getWrapper();
+        wrapper.vm.isDragging = false;
+        await nextTick();
+        const overlayHidden = wrapper.find(".drag-overlay-hidden");
+        expect(overlayHidden.exists()).toBe(true);
+        wrapper.vm.isDragging = true;
+        await nextTick();
+        const overlayShown = wrapper.find(".drag-overlay");
+        expect(overlayShown.exists()).toBe(true);
+
+        const verticalLines = overlayShown.findAll("div");
+        // overlayShown itself is a div + 2 lines
+        expect(verticalLines.length).toBe(3);
+        expect(verticalLines[1].classes()).toStrictEqual(["divider-line-left"]);
+        expect(verticalLines[2].classes()).toStrictEqual(["divider-line-right"]);
+    });
 });

--- a/app/static/tests/unit/components/wodinPanels.test.ts
+++ b/app/static/tests/unit/components/wodinPanels.test.ts
@@ -1,5 +1,22 @@
+import { nextTick } from "vue";
 import { shallowMount, VueWrapper } from "@vue/test-utils";
 import WodinPanels from "../../../src/app/components/WodinPanels.vue";
+
+const docAddListenerSpy = jest.spyOn(document, "addEventListener");
+const docRemoveListenerSpy = jest.spyOn(document, "removeEventListener");
+
+enum PanelsMode {
+    Left, Right, Both
+}
+
+// vue test utils window width
+const windowWidth = 1024;
+const widthToleranceLeft = windowWidth / 8;
+const widthToleranceRight = windowWidth / 4;
+const windowBoundaryLeft = widthToleranceLeft;
+const windowBoundaryRight = windowWidth - widthToleranceRight;
+
+const mockPreventDefault = jest.fn();
 
 describe("WodinPanels", () => {
     const getWrapper = () => {
@@ -15,16 +32,56 @@ describe("WodinPanels", () => {
         collapsibleRight: boolean) => {
         const containerDiv = wrapper.find(`div.${containerClass}`);
         expect(containerDiv.exists()).toBe(true);
-
-        expect(containerDiv.find("#collapse-left").exists()).toBe(collapsibleLeft);
-        expect(containerDiv.find("#collapse-right").exists()).toBe(collapsibleRight);
+        expect(containerDiv.find(".wodin-right .wodin-content").isVisible()).toBe(collapsibleRight);
+        expect(containerDiv.find(".wodin-left .wodin-content").isVisible()).toBe(collapsibleLeft);
+        expect(containerDiv.find("#resize-panel-control").exists()).toBe(true);
     };
 
     const testBothMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-both", true, true);
 
-    const testRightMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-right", false, true);
+    const expectDragMoveResult = (
+        wrapper: VueWrapper,
+        expectedMode: PanelsMode,
+        expectedPreventDefault: number,
+        position: number | null = null
+    ) => {
+        const {
+            mode,
+            modeClass,
+            panelWidth,
+            plotWidth
+        } = (wrapper.vm as any);
+        const modeClassMap: Record<PanelsMode, string> = {
+            [PanelsMode.Both]: "wodin-mode-both",
+            [PanelsMode.Left]: "wodin-mode-left",
+            [PanelsMode.Right]: "wodin-mode-right"
+        };
+        expect(mode).toBe(expectedMode);
+        expect(modeClass).toBe(modeClassMap[expectedMode]);
+        if (position) {
+            expect(panelWidth).toStrictEqual({ width: `calc(${position}px + 1.4rem)` });
+            expect(plotWidth).toStrictEqual({ width: `calc(100vw - ${position}px - 5rem)` });
+        }
+        expect(mockPreventDefault).toBeCalledTimes(expectedPreventDefault);
+    };
 
-    const testLeftMode = (wrapper: VueWrapper) => testMode(wrapper, "wodin-mode-left", true, false);
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    const mouseMove = (wrapper: VueWrapper, position: number) => {
+        (wrapper.vm as any).handleDragMove({
+            clientX: position,
+            preventDefault: mockPreventDefault
+        });
+    };
+
+    const touchMove = (wrapper: VueWrapper, position: number) => {
+        (wrapper.vm as any).handleDragMove({
+            touches: [{ clientX: position }],
+            preventDefault: mockPreventDefault
+        });
+    };
 
     it("has expected slot content", () => {
         const wrapper = getWrapper();
@@ -39,40 +96,76 @@ describe("WodinPanels", () => {
         expect(wrapper.find(".wodin-right").classes()).toStrictEqual(["wodin-right"]);
     });
 
-    it("clicking left then right buttons switches mode as expected", async () => {
+    it("handleDragStart adds correct listeners", () => {
         const wrapper = getWrapper();
-        await wrapper.find("#collapse-left").trigger("click");
-        testRightMode(wrapper);
-        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-collapse-full");
-        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-expand-full");
-        await wrapper.find("#collapse-right").trigger("click");
-        testBothMode(wrapper);
-        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-expand-partial");
-        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-collapse-partial");
+        (wrapper.vm as any).handleDragStart();
+        const { handleDragMove, handleDragEnd } = (wrapper.vm as any);
+        expect(docAddListenerSpy).toHaveBeenCalledTimes(4);
+        expect(docAddListenerSpy.mock.calls[0][0]).toBe("mousemove");
+        expect(docAddListenerSpy.mock.calls[0][1]).toBe(handleDragMove);
+        expect(docAddListenerSpy.mock.calls[1][0]).toBe("touchmove");
+        expect(docAddListenerSpy.mock.calls[1][1]).toBe(handleDragMove);
+        expect(docAddListenerSpy.mock.calls[2][0]).toBe("mouseup");
+        expect(docAddListenerSpy.mock.calls[2][1]).toBe(handleDragEnd);
+        expect(docAddListenerSpy.mock.calls[3][0]).toBe("touchend");
+        expect(docAddListenerSpy.mock.calls[3][1]).toBe(handleDragEnd);
+        expect(docRemoveListenerSpy).toHaveBeenCalledTimes(0);
     });
 
-    it("clicking right then left buttons switches mode as expected", async () => {
+    it("handleDragEnd removes correct listeners", () => {
         const wrapper = getWrapper();
-        await wrapper.find("#collapse-right").trigger("click");
-        testLeftMode(wrapper);
-        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-expand-full");
-        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-collapse-full");
-        await wrapper.find("#collapse-left").trigger("click");
-        testBothMode(wrapper);
-        expect(wrapper.find(".wodin-left").classes()).toContain("slide-l-panel-collapse-partial");
-        expect(wrapper.find(".wodin-right").classes()).toContain("slide-r-panel-expand-partial");
+        (wrapper.vm as any).handleDragEnd();
+        const { handleDragMove, handleDragEnd } = (wrapper.vm as any);
+        expect(docRemoveListenerSpy).toHaveBeenCalledTimes(4);
+        expect(docRemoveListenerSpy.mock.calls[0][0]).toBe("mousemove");
+        expect(docRemoveListenerSpy.mock.calls[0][1]).toBe(handleDragMove);
+        expect(docRemoveListenerSpy.mock.calls[1][0]).toBe("touchmove");
+        expect(docRemoveListenerSpy.mock.calls[1][1]).toBe(handleDragMove);
+        expect(docRemoveListenerSpy.mock.calls[2][0]).toBe("mouseup");
+        expect(docRemoveListenerSpy.mock.calls[2][1]).toBe(handleDragEnd);
+        expect(docRemoveListenerSpy.mock.calls[3][0]).toBe("touchend");
+        expect(docRemoveListenerSpy.mock.calls[3][1]).toBe(handleDragEnd);
+        expect(docAddListenerSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("handleDragMove works as expected with mouseevents", async () => {
+        const wrapper = getWrapper();
+        expectDragMoveResult(wrapper, PanelsMode.Both, 0);
+        mouseMove(wrapper, windowBoundaryLeft);
+        expectDragMoveResult(wrapper, PanelsMode.Both, 1, windowBoundaryLeft);
+        mouseMove(wrapper, windowBoundaryLeft - 1);
+        expectDragMoveResult(wrapper, PanelsMode.Right, 2, windowBoundaryLeft - 1);
+        mouseMove(wrapper, windowBoundaryRight);
+        expectDragMoveResult(wrapper, PanelsMode.Both, 3, windowBoundaryRight);
+        mouseMove(wrapper, windowBoundaryRight + 1);
+        expectDragMoveResult(wrapper, PanelsMode.Left, 4, windowBoundaryRight + 1);
+    });
+
+    it("handleDragMove works as expected with touchevents", async () => {
+        const wrapper = getWrapper();
+        expectDragMoveResult(wrapper, PanelsMode.Both, 0);
+        touchMove(wrapper, windowBoundaryLeft);
+        expectDragMoveResult(wrapper, PanelsMode.Both, 1, windowBoundaryLeft);
+        touchMove(wrapper, windowBoundaryLeft - 1);
+        expectDragMoveResult(wrapper, PanelsMode.Right, 2, windowBoundaryLeft - 1);
+        touchMove(wrapper, windowBoundaryRight);
+        expectDragMoveResult(wrapper, PanelsMode.Both, 3, windowBoundaryRight);
+        touchMove(wrapper, windowBoundaryRight + 1);
+        expectDragMoveResult(wrapper, PanelsMode.Left, 4, windowBoundaryRight + 1);
     });
 
     it("clicking on 'View Options' switches mode as expected", async () => {
         const wrapper = getWrapper();
-        await wrapper.find("#collapse-left").trigger("click");
+        (wrapper.vm as any).mode = PanelsMode.Right;
+        await nextTick();
         await wrapper.find(".view-left").trigger("click");
         testBothMode(wrapper);
     });
 
     it("clicking on 'View Charts' switches mode as expected", async () => {
         const wrapper = getWrapper();
-        await wrapper.find("#collapse-right").trigger("click");
+        (wrapper.vm as any).mode = PanelsMode.Left;
+        await nextTick();
         await wrapper.find(".view-right").trigger("click");
         testBothMode(wrapper);
     });


### PR DESCRIPTION
## Problems/motivation:
- Users would like finer control over the size of the wodin panel, especially those with smaller screens since the space is limited

## New features/solutions:
- Replaced two arrows with one vue feather that mimics the resize icon (could not actually find this icon so have rotated a maximise icon)
- Clicking and dragging this icon will resize the panel

## How PR should behave when tested:
- Hovering over the icon should change cursor to resize cursor
- Clicking and dragging should resize the panel
- Dragging within `windowWidth / 8` on the left side of the screen will snap the panel to the left
- Dragging within `windowWidth / 4` on the right side of the screen will snap panel to the right
- Dragging on any collapsed view should not change anything until your cursor gets beyond the collapse threshold for either side
- Clicking "View Options" or "ViewCharts" should reset the panel and plot to 30% 70% split

## How to run app:
1. Run the app according to the README

~~Note: Apologies, I have just realised I forked off `mrc-3924` while doing this ticket accidentally but should be alright since that will be merged in soon~~