### PR TITLE
Allow bom markers

### DIFF
--- a/app/server/src/configReader.ts
+++ b/app/server/src/configReader.ts
@@ -15,9 +15,22 @@ export class ConfigReader {
         const fullPath = [this.rootDir, ...filePath];
         const filename = path.join(...fullPath);
         if (fs.existsSync(filename)) {
-            const configText = fs.readFileSync(filename, { encoding: "utf-8" });
+            const configText = readFile(filename);
             return { ...JSON.parse(configText), ...this.overrides };
         }
         return null;
     }
+}
+
+export function stripBom(str: string): string {
+    // Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
+    // conversion translates it to FEFF (UTF-16 BOM).
+    if (str.charCodeAt(0) === 0xFEFF) {
+	return str.slice(1);
+    }
+    return str;
+}
+
+export function readFile(filename: string): string {
+    return stripBom(fs.readFileSync(filename, { encoding: "utf-8" }));
 }

--- a/app/server/src/configReader.ts
+++ b/app/server/src/configReader.ts
@@ -1,6 +1,19 @@
 import * as fs from "fs";
 import * as path from "path";
 
+export function stripBom(str: string): string {
+    // Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
+    // conversion translates it to FEFF (UTF-16 BOM).
+    if (str.charCodeAt(0) === 0xFEFF) {
+        return str.slice(1);
+    }
+    return str;
+}
+
+export function readFile(filename: string): string {
+    return stripBom(fs.readFileSync(filename, { encoding: "utf-8" }));
+}
+
 export class ConfigReader {
     rootDir: string;
 
@@ -20,17 +33,4 @@ export class ConfigReader {
         }
         return null;
     }
-}
-
-export function stripBom(str: string): string {
-    // Catches EFBBBF (UTF-8 BOM) because the buffer-to-string
-    // conversion translates it to FEFF (UTF-16 BOM).
-    if (str.charCodeAt(0) === 0xFEFF) {
-	return str.slice(1);
-    }
-    return str;
-}
-
-export function readFile(filename: string): string {
-    return stripBom(fs.readFileSync(filename, { encoding: "utf-8" }));
 }

--- a/app/server/tests/configReader.test.ts
+++ b/app/server/tests/configReader.test.ts
@@ -3,13 +3,7 @@ import { ConfigReader } from "../src/configReader";
 
 describe("configReader", () => {
     beforeEach(() => {
-        jest.resetAllMocks();
-    });
-
-    it("copes with BOM markers", () => {
-        // This test needs to go before the mocks below
-        const res: any = new ConfigReader(__dirname).readConfigFile("examples/bom.json");
-        expect((res as any).title).toBe("Ebola Project");
+        jest.restoreAllMocks();
     });
 
     it("returns null when config not found", () => {
@@ -36,5 +30,10 @@ describe("configReader", () => {
         expect(mockReadFileSync.mock.calls.length).toBe(1);
         expect(mockReadFileSync.mock.calls[0][0]).toBe("root/test.config");
         expect(mockReadFileSync.mock.calls[0][1]).toStrictEqual({ encoding: "utf-8" });
+    });
+
+    it("copes with BOM markers", () => {
+        const res: any = new ConfigReader(__dirname).readConfigFile("examples/bom.json");
+        expect((res as any).title).toBe("Ebola Project");
     });
 });

--- a/app/server/tests/configReader.test.ts
+++ b/app/server/tests/configReader.test.ts
@@ -6,6 +6,12 @@ describe("configReader", () => {
         jest.resetAllMocks();
     });
 
+    it("copes with BOM markers", () => {
+        // This test needs to go before the mocks below
+        const res: any = new ConfigReader(__dirname).readConfigFile("examples/bom.json");
+        expect((res as any).title).toBe("Ebola Project");
+    });
+
     it("returns null when config not found", () => {
         const mockExistsSync = jest.spyOn(fs, "existsSync").mockReturnValue(false);
 

--- a/app/server/tests/examples/bom.json
+++ b/app/server/tests/examples/bom.json
@@ -1,0 +1,6 @@
+﻿{
+  "appType": "fit",
+  "title": "Ebola Project",
+  "fitProp": "",
+  "readOnlyCode": false
+}


### PR DESCRIPTION
A bit of a fight here. There is a package that does this (https://www.npmjs.com/package/strip-bom) but pulling that in requires changing the tsconfig to allow module interop and that breaks some mocks.  The code is very simple though so I pulled it in. See https://github.com/nodejs/node-v0.x-archive/issues/1918 for an issue where others have struggled with the underlying issue.

Deployed at https://wodin-dev.dide.ic.ac.uk/infectiousdiseasemodels-2023/apps/ebola/ where it works ok
