### PR TITLE
gh-169 Style fix to display help icon if reset code button is not rendered

### DIFF
--- a/app/static/src/app/components/code/CodeEditor.vue
+++ b/app/static/src/app/components/code/CodeEditor.vue
@@ -6,7 +6,7 @@
                 v-help="'resetCode'"
                 @click="resetCode">Reset
         </button>
-        <div class="editor-container mb-2">
+        <div class="editor-container mb-2" style="clear:both;">
             <div class="editor" ref="editor"></div>
         </div>
     </div>

--- a/app/static/src/app/components/help/GenericHelp.vue
+++ b/app/static/src/app/components/help/GenericHelp.vue
@@ -1,7 +1,7 @@
 <template>
   <vue-feather type="help-circle"
                v-tooltip="'Display help'"
-               class="generic-help-icon float-end clickable"
+               class="generic-help-icon float-end clickable mb-2"
                @click="toggleDialog(true)"></vue-feather>
   <draggable-dialog v-if="show"
                     :title = "title"

--- a/config/apps/day1_nocode.config.json
+++ b/config/apps/day1_nocode.config.json
@@ -1,0 +1,7 @@
+{
+  "appType": "basic",
+  "title": "Day 1 - Basic Mode, no default code",
+  "basicProp": "day1 basic value",
+  "readOnlyCode": false,
+  "stateUploadIntervalMillis": 2000
+}

--- a/config/index.html
+++ b/config/index.html
@@ -31,6 +31,7 @@
         <h2>Day 1</h2>
         <p>An example of a basic model app.</p>
         <p><a href="apps/day1">Go to app</a></p>
+        <p>Here is a variant with no default code: <a href="apps/day1_nocode">go to app</a></p>
 
 
         <h2>Day 2</h2>


### PR DESCRIPTION
The help icon was actually being rendered to the page but was hidden behind the code editor in the case where the reset button was not being rendered, because it is styled to float. Setting clear style on the subsequent element fixes this.

Also added a variant of the Day1 app with no default code to the default config so this case is easy to test locally. 

