### PR TITLE
Mrc 4481 Allow an array of values in the tcrit advanced option

### DIFF
--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -25,6 +25,7 @@
         "vue": "^3.2.29",
         "vue-feather": "^2.0.0",
         "vue-router": "^4.1.5",
+        "vue3-tags-input": "^1.0.12",
         "vuex": "^4.0.2",
         "xlsx": "^0.18.5"
       },
@@ -9613,6 +9614,14 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/click-outside-vue3": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/click-outside-vue3/-/click-outside-vue3-4.0.1.tgz",
+      "integrity": "sha512-sbplNecrup5oGqA3o4bo8XmvHRT6q9fvw21Z67aDbTqB9M6LF7CuYLTlLvNtOgKU6W3zst5H5zJuEh4auqA34g==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/clipboardy": {
@@ -28327,6 +28336,20 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "node_modules/vue3-tags-input": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vue3-tags-input/-/vue3-tags-input-1.0.12.tgz",
+      "integrity": "sha512-s5rG+1W3M8+be0nd9H1nv/8WLjJOO6pShgVz8ALAqOiz3tDH5QhGrDH6fzD14ZjJNRWSa3bRBSXQwHEXffPQ6g==",
+      "dependencies": {
+        "click-outside-vue3": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.5"
+      }
+    },
     "node_modules/vuex": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
@@ -37521,6 +37544,11 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
+    },
+    "click-outside-vue3": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/click-outside-vue3/-/click-outside-vue3-4.0.1.tgz",
+      "integrity": "sha512-sbplNecrup5oGqA3o4bo8XmvHRT6q9fvw21Z67aDbTqB9M6LF7CuYLTlLvNtOgKU6W3zst5H5zJuEh4auqA34g=="
     },
     "clipboardy": {
       "version": "2.3.0",
@@ -52536,6 +52564,14 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue3-tags-input": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vue3-tags-input/-/vue3-tags-input-1.0.12.tgz",
+      "integrity": "sha512-s5rG+1W3M8+be0nd9H1nv/8WLjJOO6pShgVz8ALAqOiz3tDH5QhGrDH6fzD14ZjJNRWSa3bRBSXQwHEXffPQ6g==",
+      "requires": {
+        "click-outside-vue3": "^4.0.1"
+      }
     },
     "vuex": {
       "version": "4.0.2",

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -40,6 +40,7 @@
     "vue": "^3.2.29",
     "vue-feather": "^2.0.0",
     "vue-router": "^4.1.5",
+    "vue3-tags-input": "^1.0.12",
     "vuex": "^4.0.2",
     "xlsx": "^0.18.5"
   },

--- a/app/static/src/app/components/options/AdvancedSettings.vue
+++ b/app/static/src/app/components/options/AdvancedSettings.vue
@@ -16,8 +16,7 @@
                 <tag-input v-if="config.type === AdSettingCompType.tag"
                                :tags="config.val"
                                :placeholder="config.defaults"
-                               @select="(n) => selectTag(n, option)"
-                               @deselect="(n) => removeTag(n, option)" />
+                               @update="(n) => updateOption(n, option)"/>
             </div>
         </div>
     </div>
@@ -27,7 +26,7 @@ import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
 import NumericInput from "./NumericInput.vue";
 import StandardFormInput from "./StandardFormInput.vue";
-import { AdSettingCompType, Tag } from "../../store/run/state";
+import { AdSettingCompType } from "../../store/run/state";
 import { RunMutation } from "../../store/run/mutations";
 import { AdvancedOptions } from "../../types/responseTypes";
 import TagInput from "./TagInput.vue";
@@ -44,77 +43,14 @@ export default defineComponent({
 
         const advancedSettings = computed(() => store.state.run.advancedSettings);
 
-        const paramValues = computed(() => store.state.run.parameterValues);
-
         const updateOption = (newVal: number | null | [number|null, number|null], option: AdvancedOptions) => {
             store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal });
-        };
-
-        const isNumeric = (num: any) => {
-            return num.trim() !== "" && !isNaN(num as number);
-        };
-
-        const selectTag = (newVal: string, option: AdvancedOptions) => {
-            let tag: Tag | number | null = null;
-            const currTags = advancedSettings.value[option].val as Tag[] | null;
-
-            if (isNumeric(newVal)) {
-                tag = parseFloat(newVal);
-            } else {
-                if (paramValues.value && paramValues.value.hasOwnProperty(newVal)) {
-                    tag = {
-                        id: newVal,
-                        value: paramValues.value[newVal]
-                    };
-                }
-            }
-
-            let newTags: Tag[] | null = null;
-            if (tag === null) {
-                //handle error
-                if (currTags) {
-                    newTags = [...currTags];
-                } else {
-                    newTags = null;
-                }
-            } else {
-                if (currTags) {
-                    const tagVariables = currTags.map((tag) => {
-                        if (typeof tag === "number") {
-                            return tag
-                        } else {
-                            return tag.id
-                        }
-                    });
-                    if (typeof tag !== "number" && tagVariables.includes(tag.id)
-                        || typeof tag === "number" && tagVariables.includes(tag)) {
-                        newTags = [...currTags];
-                    } else {
-                        newTags = [...currTags, tag];
-                    }
-                } else {
-                    newTags = [tag];
-                }
-            }
-
-            store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal: newTags });
-        };
-
-        const removeTag = (index: number, option: AdvancedOptions) => {
-            if (advancedSettings.value[option].val) {
-                const copy = [...advancedSettings.value[option].val as Tag[]];
-                copy.splice(index, 1);
-                console.log(copy)
-                store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal: copy });
-            }
         };
 
         return {
             advancedSettings,
             updateOption,
-            AdSettingCompType,
-            selectTag,
-            removeTag
+            AdSettingCompType
         };
     }
 });

--- a/app/static/src/app/components/options/AdvancedSettings.vue
+++ b/app/static/src/app/components/options/AdvancedSettings.vue
@@ -5,14 +5,19 @@
             <label class="col-form-label">{{ option }}</label>
             </div>
             <div class="col-6">
-                <standard-form-input v-if="config.standardForm"
+                <standard-form-input v-if="config.type === AdSettingCompType.stdf"
                                      :value="config.val"
                                      :placeholder="config.defaults"
                                      @update="(n) => updateOption(n, option)"/>
-                <numeric-input v-else
+                <numeric-input v-if="config.type === AdSettingCompType.num"
                                :value="config.val"
                                :placeholder="config.defaults"
                                @update="(n) => updateOption(n, option)"/>
+                <tag-input v-if="config.type === AdSettingCompType.tag"
+                               :tags="config.val"
+                               :placeholder="config.defaults"
+                               @select="(n) => selectTag(n, option)"
+                               @deselect="(n) => removeTag(n, option)" />
             </div>
         </div>
     </div>
@@ -22,27 +27,94 @@ import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
 import NumericInput from "./NumericInput.vue";
 import StandardFormInput from "./StandardFormInput.vue";
-import { AdvancedSettings } from "../../store/run/state";
+import { AdSettingCompType, Tag } from "../../store/run/state";
 import { RunMutation } from "../../store/run/mutations";
 import { AdvancedOptions } from "../../types/responseTypes";
+import TagInput from "./TagInput.vue";
+import { AppState } from "../../store/appState/state";
 
 export default defineComponent({
     components: {
         NumericInput,
-        StandardFormInput
+        StandardFormInput,
+        TagInput
     },
     setup() {
-        const store = useStore();
+        const store = useStore<AppState>();
 
-        const advancedSettings = computed(() => store.state.run.advancedSettings as AdvancedSettings);
+        const advancedSettings = computed(() => store.state.run.advancedSettings);
+
+        const paramValues = computed(() => store.state.run.parameterValues);
 
         const updateOption = (newVal: number | null | [number|null, number|null], option: AdvancedOptions) => {
             store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal });
         };
 
+        const isNumeric = (num: any) => {
+            return num.trim() !== "" && !isNaN(num as number);
+        };
+
+        const selectTag = (newVal: string, option: AdvancedOptions) => {
+            let tag: Tag | number | null = null;
+            const currTags = advancedSettings.value[option].val as Tag[] | null;
+
+            if (isNumeric(newVal)) {
+                tag = parseFloat(newVal);
+            } else {
+                if (paramValues.value && paramValues.value.hasOwnProperty(newVal)) {
+                    tag = {
+                        id: newVal,
+                        value: paramValues.value[newVal]
+                    };
+                }
+            }
+
+            let newTags: Tag[] | null = null;
+            if (tag === null) {
+                //handle error
+                if (currTags) {
+                    newTags = [...currTags];
+                } else {
+                    newTags = null;
+                }
+            } else {
+                if (currTags) {
+                    const tagVariables = currTags.map((tag) => {
+                        if (typeof tag === "number") {
+                            return tag
+                        } else {
+                            return tag.id
+                        }
+                    });
+                    if (typeof tag !== "number" && tagVariables.includes(tag.id)
+                        || typeof tag === "number" && tagVariables.includes(tag)) {
+                        newTags = [...currTags];
+                    } else {
+                        newTags = [...currTags, tag];
+                    }
+                } else {
+                    newTags = [tag];
+                }
+            }
+
+            store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal: newTags });
+        };
+
+        const removeTag = (index: number, option: AdvancedOptions) => {
+            if (advancedSettings.value[option].val) {
+                const copy = [...advancedSettings.value[option].val as Tag[]];
+                copy.splice(index, 1);
+                console.log(copy)
+                store.commit(`run/${RunMutation.UpdateAdvancedSettings}`, { option, newVal: copy });
+            }
+        };
+
         return {
             advancedSettings,
-            updateOption
+            updateOption,
+            AdSettingCompType,
+            selectTag,
+            removeTag
         };
     }
 });

--- a/app/static/src/app/components/options/AdvancedSettings.vue
+++ b/app/static/src/app/components/options/AdvancedSettings.vue
@@ -15,7 +15,6 @@
                                @update="(n) => updateOption(n, option)"/>
                 <tag-input v-if="config.type === AdSettingCompType.tag"
                                :tags="config.val"
-                               :placeholder="config.defaults"
                                @update="(n) => updateOption(n, option)"/>
             </div>
         </div>

--- a/app/static/src/app/components/options/TagInput.vue
+++ b/app/static/src/app/components/options/TagInput.vue
@@ -1,7 +1,7 @@
 <template>
     <vue-tags-input style="border-color: #d7dce1;"
                     :tags="computedTags"
-                    :placeholder="JSON.stringify(placeholder)"
+                    :placeholder="'...'"
                     :validate="validate"
                     @on-tags-changed="handleTagsChanged"/>
 </template>
@@ -18,8 +18,7 @@ export default defineComponent({
         VueTagsInput
     },
     props: {
-        tags: Array as PropType<Tag[] | null>,
-        placeholder: Array
+        tags: Array as PropType<Tag[] | null>
     },
     setup(props, { emit }) {
         const store = useStore();

--- a/app/static/src/app/components/options/TagInput.vue
+++ b/app/static/src/app/components/options/TagInput.vue
@@ -1,0 +1,65 @@
+<template>
+    <vue-tags-input style="border-color: #d7dce1;"
+                    :v-model="value"
+                    :tags="tags"
+                    :add-tag-on-keys-when-select="true"
+                    :allow-duplicates="false"
+                    @on-remove="handleRemoveTag"
+                    @on-new-tag="handleNewTag"/>
+</template>
+<script lang="ts">
+import { PropType, computed, defineComponent, ref, watch } from 'vue';
+import VueTagsInput from "vue3-tags-input";
+import { Tag } from "../../store/run/state"
+
+export default defineComponent({
+    components: {
+        VueTagsInput
+    },
+    props: {
+        tags: Array as PropType<Tag[] | null>,
+        placeholder: Array
+    },
+    setup(props, { emit }) {
+        const value = ref("");
+
+        const tags = computed(() => {
+            if (props.tags?.length === 0 || !props.tags) {
+                return [];
+            } else {
+                return props.tags.map((tag) => {
+                    if (typeof tag === "number") {
+                        return `${tag}`
+                    } else {
+                        return `${tag.id}: ${tag.value}`
+                    }
+                });
+            }
+        });
+
+        const handleNewTag = (newTag: string) => {
+            emit("select", newTag);
+        };
+
+        const handleRemoveTag = (index: number) => {
+            emit("deselect", index);
+        };
+
+        return {
+            value,
+            tags,
+            handleNewTag,
+            handleRemoveTag
+        }
+    },
+})
+</script>
+<style>
+.v3ti-tag {
+    background: #479fb6 !important;
+}
+
+.v3ti-tag .v3ti-remove-tag {
+    text-decoration: none !important;
+}
+</style>

--- a/app/static/src/app/components/options/TagInput.vue
+++ b/app/static/src/app/components/options/TagInput.vue
@@ -60,7 +60,8 @@ export default defineComponent({
             const parsedTags = tags.map((tag) => {
                 if (isNumeric(tag)) {
                     return parseFloat(tag);
-                } else if (tag.includes(":")) {
+                }
+                if (tag.includes(":")) {
                     const variableTag = tag.split(":");
                     const varId = variableTag[0];
                     if (isParameterName(varId)) {

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -160,7 +160,7 @@ export const serialiseState = (state: AppState) => {
 const deserialiseAdvancedSettings = (settings: SerialisedAdvancedSettings) => {
     Object.keys(settings).forEach((key) => {
         const entry = settings[key as AdvancedOptions] as any;
-        if (!entry.standardForm) {
+        if (entry.type === AdSettingCompType.num) {
             if (entry.defaults === "Infinity") {
                 entry.defaults = Infinity;
             }

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -2,7 +2,7 @@ import { AppState, AppType } from "./store/appState/state";
 import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
-import { AdvancedSettings, RunState } from "./store/run/state";
+import { AdSettingCompType, AdvancedSettings, RunState } from "./store/run/state";
 import { SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
@@ -55,7 +55,7 @@ function serialiseDiscreteResult(result: OdinRunResultDiscrete | null): Serialis
 const serialiseAdvancedSettings = (settings: AdvancedSettings) => {
     return Object.fromEntries(
         Object.entries(settings).map(([key, value]) => {
-            if (!value.standardForm) {
+            if (value.type === AdSettingCompType.num) {
                 if (!Number.isFinite(value.defaults)) {
                     const copy = { ...value } as any;
                     copy.defaults = "Infinity";

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -48,7 +48,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             };
 
             const { advancedSettings } = rootState.run;
-            const advancedSettingsOdin = convertAdvancedSettingsToOdin(advancedSettings);
+            const advancedSettingsOdin = convertAdvancedSettingsToOdin(advancedSettings, pars.base);
 
             const simplex = odinRunnerOde!.wodinFit(
                 odin!,

--- a/app/static/src/app/store/run/actions.ts
+++ b/app/static/src/app/store/run/actions.ts
@@ -30,7 +30,7 @@ const runOdeModel = (parameterValues: OdinUserType, startTime: number, endTime: 
         error: null
     };
 
-    const advancedSettingsOdin = convertAdvancedSettingsToOdin(advancedSettings);
+    const advancedSettingsOdin = convertAdvancedSettingsToOdin(advancedSettings, parameterValues);
 
     try {
         const solution = runner.wodinRun(odin, parameterValues, startTime, endTime, advancedSettingsOdin);

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -69,16 +69,20 @@ export const mutations: MutationTree<RunState> = {
 
     [RunMutation.UpdateAdvancedSettings](state: RunState, payload: SetAdvancedSettingPayload) {
         if (state.advancedSettings[payload.option].type === AdSettingCompType.tag
-            && payload.newVal && typeof payload.newVal !== "number") {
+            && payload.newVal) {
             const sortedTags = (payload.newVal as Tag[]).sort((tag1, tag2) => {
-                const tag1Val = typeof tag1 === "number" ? tag1 : tag1.value;
-                const tag2Val = typeof tag2 === "number" ? tag2 : tag2.value;
-                return (tag1Val > tag2Val) ? 1 : (tag1Val < tag2Val) ? -1 : 0;
+                const tag1Val = typeof tag1 === "number" ? tag1 : state.parameterValues![tag1];
+                const tag2Val = typeof tag2 === "number" ? tag2 : state.parameterValues![tag2];
+                if (tag1Val > tag2Val) {
+                    return 1;
+                }
+                if (tag1Val < tag2Val) {
+                    return -1;
+                }
+                return 0;
             });
-            console.log(sortedTags)
             state.advancedSettings[payload.option].val = sortedTags;
         } else {
-            console.log(payload.newVal)
             state.advancedSettings[payload.option].val = payload.newVal;
         }
         state.runRequired = {

--- a/app/static/src/app/store/run/mutations.ts
+++ b/app/static/src/app/store/run/mutations.ts
@@ -1,6 +1,7 @@
 import { MutationTree } from "vuex";
 import {
-    ParameterSet, RunState, RunUpdateRequiredReasons
+    AdSettingCompType,
+    ParameterSet, RunState, RunUpdateRequiredReasons, Tag
 } from "./state";
 import { OdinUserType } from "../../types/responseTypes";
 import { OdinRunResultDiscrete, OdinRunResultOde } from "../../types/wrapperTypes";
@@ -67,7 +68,19 @@ export const mutations: MutationTree<RunState> = {
     },
 
     [RunMutation.UpdateAdvancedSettings](state: RunState, payload: SetAdvancedSettingPayload) {
-        state.advancedSettings[payload.option].val = payload.newVal;
+        if (state.advancedSettings[payload.option].type === AdSettingCompType.tag
+            && payload.newVal && typeof payload.newVal !== "number") {
+            const sortedTags = (payload.newVal as Tag[]).sort((tag1, tag2) => {
+                const tag1Val = typeof tag1 === "number" ? tag1 : tag1.value;
+                const tag2Val = typeof tag2 === "number" ? tag2 : tag2.value;
+                return (tag1Val > tag2Val) ? 1 : (tag1Val < tag2Val) ? -1 : 0;
+            });
+            console.log(sortedTags)
+            state.advancedSettings[payload.option].val = sortedTags;
+        } else {
+            console.log(payload.newVal)
+            state.advancedSettings[payload.option].val = payload.newVal;
+        }
         state.runRequired = {
             ...state.runRequired,
             advancedSettingsChanged: true

--- a/app/static/src/app/store/run/run.ts
+++ b/app/static/src/app/store/run/run.ts
@@ -1,4 +1,4 @@
-import { RunState } from "./state";
+import { AdSettingCompType, RunState } from "./state";
 import { mutations } from "./mutations";
 import { actions } from "./actions";
 import { getters } from "./getters";
@@ -23,11 +23,11 @@ export const defaultState: RunState = {
     parameterSets: [],
     parameterSetResults: {},
     advancedSettings: {
-        [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], standardForm: true },
-        [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false },
-        [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false },
-        [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true },
-        [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false }
+        [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+        [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+        [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+        [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+        [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
     }
 };
 

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -16,19 +16,38 @@ export interface ParameterSet {
     hidden: boolean
 }
 
+export enum AdSettingCompType {
+    num = "numeric",
+    stdf = "standard form",
+    tag = "tag input"
+}
+
 type AdConfStandardForm = {
     val: [number|null, number|null],
     defaults: number[],
-    standardForm: true
+    type: AdSettingCompType.stdf
 }
 
 type AdConfNumeric = {
     val: number | null,
     defaults: number,
-    standardForm: false
+    type: AdSettingCompType.num
 }
 
-export type AdvancedConfig = AdConfNumeric | AdConfStandardForm
+type VariableTag = {
+    id: string,
+    value: number
+}
+export type Tag = number | VariableTag
+
+
+type AdConfTCrit = {
+    val: Tag[] | null,
+    defaults: number[],
+    type: AdSettingCompType.tag
+}
+
+export type AdvancedConfig = AdConfNumeric | AdConfStandardForm | AdConfTCrit
 
 export type AdvancedSettings = Record<AdvancedOptions, AdvancedConfig>
 

--- a/app/static/src/app/store/run/state.ts
+++ b/app/static/src/app/store/run/state.ts
@@ -34,12 +34,7 @@ type AdConfNumeric = {
     type: AdSettingCompType.num
 }
 
-type VariableTag = {
-    id: string,
-    value: number
-}
-export type Tag = number | VariableTag
-
+export type Tag = number | string
 
 type AdConfTCrit = {
     val: Tag[] | null,

--- a/app/static/src/app/types/payloadTypes.ts
+++ b/app/static/src/app/types/payloadTypes.ts
@@ -1,6 +1,7 @@
 import { OdinRunResultOde } from "./wrapperTypes";
 import { Language } from "./languageTypes";
 import { AdvancedOptions } from "./responseTypes";
+import { Tag } from "../store/run/state";
 
 export interface SetAppPayload {
     appName: string
@@ -21,5 +22,5 @@ export interface SetParameterSetResultPayload {
 
 export interface SetAdvancedSettingPayload {
     option: AdvancedOptions,
-    newVal: number | null
+    newVal: number | null | Tag[]
 }

--- a/app/static/src/app/types/responseTypes.ts
+++ b/app/static/src/app/types/responseTypes.ts
@@ -180,7 +180,7 @@ export enum AdvancedOptions {
     "maxSteps" = "Max steps",
     "stepSizeMax" = "Max step size",
     "stepSizeMin" = "Min step size",
-    "tcrit" = "Critical time"
+    "tcrit" = "Critical times"
 }
 
 export interface OdinRunnerOde {

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -5,6 +5,7 @@ import {
     WodinError
 } from "./responseTypes";
 import {
+    AdSettingCompType,
     ParameterSet, RunUpdateRequiredReasons
 } from "../store/run/state";
 import { OdinFitInputs, OdinRunInputs, OdinSensitivityInputs } from "./wrapperTypes";
@@ -30,7 +31,7 @@ export interface SerialisedRunResult {
 type SerialisedAdvancedConfig = {
     val: number | null | (number|null)[],
     defaults: number | string | (number|string)[],
-    standardForm: boolean
+    type: AdSettingCompType
 }
 
 export type SerialisedAdvancedSettings = Record<AdvancedOptions, SerialisedAdvancedConfig>

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -247,7 +247,7 @@ export const convertAdvancedSettingsToOdin = (advancedSettings: AdvancedSettings
         maxSteps: flattenedObject["Max steps"],
         stepSizeMax: flattenedObject["Max step size"],
         stepSizeMin: flattenedObject["Min step size"],
-        tcrit: flattenedObject["Critical time"]
+        tcrit: flattenedObject["Critical times"]
     };
 
     return advancedSettingsOdin;

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -16,7 +16,7 @@ import {
     SensitivityVariationType
 } from "./store/sensitivity/state";
 import { AppState } from "./store/appState/state";
-import { AdvancedSettings } from "./store/run/state";
+import { AdSettingCompType, AdvancedSettings, Tag } from "./store/run/state";
 
 export const freezer = {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -215,18 +215,30 @@ export const runPlaceholderMessage = (selectedVariables: string[], sensitivity: 
     return selectedVariables.length ? notRunYet : userMessages.model.noVariablesSelected;
 };
 
+const extractValuesFromTags = (values: Tag[]) => {
+    return values.map((val) => {
+        if (typeof val === "number") {
+            return val
+        } else {
+            return val.value
+        }
+    });
+};
+
 export const convertAdvancedSettingsToOdin = (advancedSettings: AdvancedSettings) => {
     const flattenedObject = Object.fromEntries(Object.entries(advancedSettings)
         .map(([key, value]) => {
-            let numericVal: number | null;
-            if (value.standardForm) {
+            let cleanVal: number | number[] | null;
+            if (value.type === AdSettingCompType.stdf) {
                 const firstValue = value.val[0] !== null ? value.val[0] : value.defaults[0];
                 const secondValue = value.val[1] !== null ? value.val[1] : value.defaults[1];
-                numericVal = firstValue * 10 ** secondValue;
+                cleanVal = firstValue * 10 ** secondValue;
+            } else if (value.type === AdSettingCompType.num) {
+                cleanVal = value.val !== null ? value.val : value.defaults;
             } else {
-                numericVal = value.val !== null ? value.val : value.defaults;
+                cleanVal = value.val !== null ? extractValuesFromTags(value.val) : value.defaults;
             }
-            return [key, numericVal];
+            return [key, cleanVal];
         })) as Record<AdvancedOptions, number>;
 
     const advancedSettingsOdin: AdvancedSettingsOdin = {

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -215,17 +215,17 @@ export const runPlaceholderMessage = (selectedVariables: string[], sensitivity: 
     return selectedVariables.length ? notRunYet : userMessages.model.noVariablesSelected;
 };
 
-const extractValuesFromTags = (values: Tag[]) => {
-    return values.map((val) => {
+const extractValuesFromTags = (values: Tag[], paramValues: OdinUserType | null) => {
+    const extracted = values.map((val) => {
         if (typeof val === "number") {
-            return val
-        } else {
-            return val.value
+            return val;
         }
+        return paramValues ? paramValues[val] : undefined;
     });
+    return extracted.filter((x) => x !== undefined) as number[];
 };
 
-export const convertAdvancedSettingsToOdin = (advancedSettings: AdvancedSettings) => {
+export const convertAdvancedSettingsToOdin = (advancedSettings: AdvancedSettings, paramValues: OdinUserType | null) => {
     const flattenedObject = Object.fromEntries(Object.entries(advancedSettings)
         .map(([key, value]) => {
             let cleanVal: number | number[] | null;
@@ -236,7 +236,7 @@ export const convertAdvancedSettingsToOdin = (advancedSettings: AdvancedSettings
             } else if (value.type === AdSettingCompType.num) {
                 cleanVal = value.val !== null ? value.val : value.defaults;
             } else {
-                cleanVal = value.val !== null ? extractValuesFromTags(value.val) : value.defaults;
+                cleanVal = value.val !== null ? extractValuesFromTags(value.val, paramValues) : value.defaults;
             }
             return [key, cleanVal];
         })) as Record<AdvancedOptions, number>;

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -247,7 +247,8 @@ test.describe("Code Tab tests", () => {
         );
         await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
         await expect(await page.innerText(".wodin-left .wodin-content #error-info"))
-            .toBe("Code error: Error on line 1: Every line must contain an assignment");
+            .toBe("Code error: Error on line 1: Every line must contain an assignment"
+            + ", a compare statement or a debug statement");
     });
 
     test("can display model error message when running model", async ({ page }) => {

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -247,8 +247,7 @@ test.describe("Code Tab tests", () => {
         );
         await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
         await expect(await page.innerText(".wodin-left .wodin-content #error-info"))
-            .toBe("Code error: Error on line 1: Every line must contain an assignment"
-            + ", a compare statement or a debug statement");
+            .toBe("Code error: Error on line 1: Every line must contain an assignment");
     });
 
     test("can display model error message when running model", async ({ page }) => {

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -247,7 +247,8 @@ test.describe("Code Tab tests", () => {
         );
         await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
         await expect(await page.innerText(".wodin-left .wodin-content #error-info"))
-            .toBe("Code error: Error on line 1: Every line must contain an assignment");
+            .toBe("Code error: Error on line 1: Every line must contain an assignment"
+                + ", a compare statement or a debug statement");
     });
 
     test("can display model error message when running model", async ({ page }) => {

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -8,7 +8,7 @@ import {
     BatchPars, OdinUserType, ResponseFailure, ResponseSuccess, WodinError
 } from "../src/app/types/responseTypes";
 import { ModelState } from "../src/app/store/model/state";
-import { RunState } from "../src/app/store/run/state";
+import { AdSettingCompType, RunState } from "../src/app/store/run/state";
 import { CodeState } from "../src/app/store/code/state";
 import { FitDataState } from "../src/app/store/fitData/state";
 import { AppType, VisualisationTab } from "../src/app/store/appState/state";
@@ -90,11 +90,11 @@ export const mockRunState = (state: Partial<RunState> = {}): RunState => {
         parameterSets: [],
         parameterSetResults: {},
         advancedSettings: {
-            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], standardForm: true as const },
-            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false as const },
-            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false as const },
-            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true as const },
-            [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false as const }
+            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+            [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
         },
         ...state
     };

--- a/app/static/tests/unit/components/options/advancedSettings.test.ts
+++ b/app/static/tests/unit/components/options/advancedSettings.test.ts
@@ -65,7 +65,6 @@ describe("Advanced Settings", () => {
         expectValueAndPlaceholder(standardFormInputs[1], [null, null], [1, -8]);
         expect(labels[4].text()).toBe("Critical time");
         expect(tagsInput[0].props("tags")).toBe(null);
-        expect(tagsInput[0].props("placeholder")).toStrictEqual([]);
     });
 
     it("commits update advanced settings without standard form", () => {

--- a/app/static/tests/unit/components/options/advancedSettings.test.ts
+++ b/app/static/tests/unit/components/options/advancedSettings.test.ts
@@ -6,6 +6,7 @@ import { RunMutation } from "../../../../src/app/store/run/mutations";
 import NumericInput from "../../../../src/app/components/options/NumericInput.vue";
 import StandardFormInput from "../../../../src/app/components/options/StandardFormInput.vue";
 import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
+import TagInput from "../../../../src/app/components/options/TagInput.vue";
 
 describe("Advanced Settings", () => {
     const mockUpdateAdvancedSettings = jest.fn();
@@ -46,9 +47,11 @@ describe("Advanced Settings", () => {
         const wrapper = getWrapper();
 
         const inputs = wrapper.findAllComponents(NumericInput);
-        expect(inputs.length).toBe(3);
+        expect(inputs.length).toBe(2);
         const standardFormInputs = wrapper.findAllComponents(StandardFormInput);
         expect(standardFormInputs.length).toBe(2);
+        const tagsInput = wrapper.findAllComponents(TagInput);
+        expect(tagsInput.length).toBe(1);
         const labels = wrapper.findAll("label");
         expect(labels.length).toBe(5);
 
@@ -61,7 +64,8 @@ describe("Advanced Settings", () => {
         expect(labels[3].text()).toBe("Min step size");
         expectValueAndPlaceholder(standardFormInputs[1], [null, null], [1, -8]);
         expect(labels[4].text()).toBe("Critical time");
-        expectValueAndPlaceholder(inputs[2], null, Infinity);
+        expect(tagsInput[0].props("tags")).toBe(null);
+        expect(tagsInput[0].props("placeholder")).toStrictEqual([]);
     });
 
     it("commits update advanced settings without standard form", () => {

--- a/app/static/tests/unit/components/options/advancedSettings.test.ts
+++ b/app/static/tests/unit/components/options/advancedSettings.test.ts
@@ -63,7 +63,7 @@ describe("Advanced Settings", () => {
         expectValueAndPlaceholder(inputs[1], null, Infinity);
         expect(labels[3].text()).toBe("Min step size");
         expectValueAndPlaceholder(standardFormInputs[1], [null, null], [1, -8]);
-        expect(labels[4].text()).toBe("Critical time");
+        expect(labels[4].text()).toBe("Critical times");
         expect(tagsInput[0].props("tags")).toBe(null);
     });
 

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -1,9 +1,9 @@
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import VueTagsInput from "vue3-tags-input";
-import { nextTick } from "vue";
 import TagInput from "../../../../src/app/components/options/TagInput.vue";
 import { mockRunState } from "../../../mocks";
+import { nextTick } from "vue";
 
 describe("Tag Input", () => {
     const createStore = () => {
@@ -19,9 +19,6 @@ describe("Tag Input", () => {
     const defaultProps = {
         tags: [1, 2, "p1", "p2", "p3"]
     };
-
-    const mockValidate = jest.fn();
-    const mockHandleTagsChanged = jest.fn();
 
     const getWrapper = (props = defaultProps) => {
         return shallowMount(TagInput, { props, global: { plugins: [createStore()] } });
@@ -59,5 +56,21 @@ describe("Tag Input", () => {
         } as any);
         const tagsInput = wrapper.findComponent(VueTagsInput);
         expect(tagsInput.props("tags")).toStrictEqual([]);
+    });
+
+    it("emits update if paramValues change", async () => {
+        const store = createStore();
+        const wrapper = shallowMount(TagInput, {
+            global: {
+                plugins: [store]
+            },
+            props: {
+                tags: ["1", "hey"],
+                placeholder: []
+            }
+        });
+        store.state.run.parameterValues = { a: 2 };
+        await nextTick();
+        expect(wrapper.emitted("update")![0]).toStrictEqual([["1", "hey"]]);
     });
 });

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -17,8 +17,7 @@ describe("Tag Input", () => {
     };
 
     const defaultProps = {
-        tags: [1, 2, "p1", "p2", "p3"],
-        placeholder: []
+        tags: [1, 2, "p1", "p2", "p3"]
     };
 
     const mockValidate = jest.fn();
@@ -34,7 +33,7 @@ describe("Tag Input", () => {
         expect(tagsInput.exists()).toBe(true);
         expect(tagsInput.attributes("style")).toBe("border-color: #d7dce1;");
         expect(tagsInput.props("tags")).toStrictEqual(["1", "2", "p1: 1.1", "p2: 2.2"]);
-        expect(tagsInput.props("placeholder")).toBe("[]");
+        expect(tagsInput.props("placeholder")).toBe("...");
     });
 
     it("parses tags correctly when changed", () => {

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -1,0 +1,64 @@
+import Vuex from 'vuex';
+import { mockRunState } from '../../../mocks';
+import { shallowMount } from '@vue/test-utils';
+import TagInput from '../../../../src/app/components/options/TagInput.vue';
+import VueTagsInput from "vue3-tags-input";
+import { nextTick } from 'vue';
+
+describe("Tag Input", () => {
+    const createStore = () => {
+        return new Vuex.Store({
+            state: {
+                run: mockRunState({
+                    parameterValues: { p1: 1.1, p2: 2.2 }
+                })
+            }
+        });
+    };
+
+    const defaultProps = {
+        tags: [1, 2, "p1", "p2", "p3"],
+        placeholder: []
+    };
+
+    const mockValidate = jest.fn();
+    const mockHandleTagsChanged = jest.fn();
+
+    const getWrapper = (props = defaultProps) => {
+        return shallowMount(TagInput, { props, global: { plugins: [createStore()] } });
+    };
+
+    it("renders as expected", () => {
+        const wrapper = getWrapper();
+        const tagsInput = wrapper.findComponent(VueTagsInput);
+        expect(tagsInput.exists()).toBe(true);
+        expect(tagsInput.attributes("style")).toBe("border-color: #d7dce1;");
+        expect(tagsInput.props("tags")).toStrictEqual(["1", "2", "p1: 1.1", "p2: 2.2"]);
+        expect(tagsInput.props("placeholder")).toBe("[]");
+    });
+
+    it("parses tags correctly when changed", () => {
+        const wrapper = getWrapper();
+        const tagsInput = wrapper.findComponent(VueTagsInput);
+        (tagsInput.vm as any).$emit("on-tags-changed", ["1", "2", "p2", "p1: 1.1", "p3"]);
+        expect(wrapper.emitted("update")![0]).toStrictEqual([[1, 2, "p2", "p1"]]);
+    });
+
+    it("validate function works as expected", () => {
+        const wrapper = getWrapper();
+        expect((wrapper.vm as any).validate("p1")).toBe(false);
+        expect((wrapper.vm as any).validate("1")).toBe(false);
+        expect((wrapper.vm as any).validate("p2: 2.2")).toBe(false);
+        expect((wrapper.vm as any).validate("3")).toBe(true);
+        expect((wrapper.vm as any).validate("p3")).toBe(false);
+    });
+
+    it("tags as empty array if no tags", () => {
+        const wrapper = getWrapper({
+            tags: null,
+            placeholder: []
+        } as any);
+        const tagsInput = wrapper.findComponent(VueTagsInput);
+        expect(tagsInput.props("tags")).toStrictEqual([]);
+    });
+});

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -1,9 +1,9 @@
-import Vuex from 'vuex';
-import { mockRunState } from '../../../mocks';
-import { shallowMount } from '@vue/test-utils';
-import TagInput from '../../../../src/app/components/options/TagInput.vue';
+import Vuex from "vuex";
+import { shallowMount } from "@vue/test-utils";
 import VueTagsInput from "vue3-tags-input";
-import { nextTick } from 'vue';
+import { nextTick } from "vue";
+import TagInput from "../../../../src/app/components/options/TagInput.vue";
+import { mockRunState } from "../../../mocks";
 
 describe("Tag Input", () => {
     const createStore = () => {

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -1,9 +1,9 @@
+import { nextTick } from "vue";
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import VueTagsInput from "vue3-tags-input";
 import TagInput from "../../../../src/app/components/options/TagInput.vue";
 import { mockRunState } from "../../../mocks";
-import { nextTick } from "vue";
 
 describe("Tag Input", () => {
     const createStore = () => {

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -121,7 +121,7 @@ describe("serialise", () => {
             [AdvancedOptions.stepSizeMin]: {
                 val: [null, null] as [number|null, number|null],
                 defaults: [1, -8],
-                type: AdSettingCompType.stdf  as const
+                type: AdSettingCompType.stdf as const
             },
             [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag as const }
         }

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -19,6 +19,7 @@ import {
 import { defaultState as defaultGraphSettingsState } from "../../src/app/store/graphSettings/graphSettings";
 import { Language } from "../../src/app/types/languageTypes";
 import { AdvancedOptions } from "../../src/app/types/responseTypes";
+import { AdSettingCompType } from "../../src/app/store/run/state";
 
 describe("serialise", () => {
     const codeState = {
@@ -113,16 +114,16 @@ describe("serialise", () => {
             [AdvancedOptions.tol]: {
                 val: [null, null] as [number|null, number|null],
                 defaults: [1, -6],
-                standardForm: true as const
+                type: AdSettingCompType.stdf as const
             },
-            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false as const },
-            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false as const },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num as const },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num as const },
             [AdvancedOptions.stepSizeMin]: {
                 val: [null, null] as [number|null, number|null],
                 defaults: [1, -8],
-                standardForm: true as const
+                type: AdSettingCompType.stdf  as const
             },
-            [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false as const }
+            [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag as const }
         }
     };
 
@@ -326,11 +327,11 @@ describe("serialise", () => {
         },
         // serialises Infinity to string because JSON serialises Infinity to null by default
         advancedSettings: {
-            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], standardForm: true as const },
-            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false as const },
-            [AdvancedOptions.stepSizeMax]: { val: null, defaults: "Infinity", standardForm: false as const },
-            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true as const },
-            [AdvancedOptions.tcrit]: { val: null, defaults: "Infinity", standardForm: false as const }
+            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: "Infinity", type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+            [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
         }
     };
     const expectedSensitivity = {

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -21,7 +21,8 @@ describe("ModelFit actions", () => {
     const mockOdin = {} as any;
     const parameterValues = { p1: 1.1, p2: 2.2 };
     const advancedSettings = {
-        [AdvancedOptions.tol]: { val: [null, null] as [number|null, number|null],
+        [AdvancedOptions.tol]: {
+            val: [null, null] as [number|null, number|null],
             defaults: [1, -6],
             type: AdSettingCompType.stdf as const
         },
@@ -33,7 +34,7 @@ describe("ModelFit actions", () => {
             type: AdSettingCompType.stdf as const
         },
         [AdvancedOptions.tcrit]: { val: [0, "p1", "p2"], defaults: [], type: AdSettingCompType.tag as const }
-    }
+    };
     const modelState = mockModelState({
         odin: mockOdin,
         odinRunnerOde: mockOdinRunner

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -7,6 +7,8 @@ import { actions, ModelFitAction } from "../../../../src/app/store/modelFit/acti
 import { ModelMutation } from "../../../../src/app/store/model/mutations";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
+import { AdSettingCompType } from "../../../../src/app/store/run/state";
 
 describe("ModelFit actions", () => {
     const mockSimplex = {} as any;
@@ -18,11 +20,28 @@ describe("ModelFit actions", () => {
     } as any;
     const mockOdin = {} as any;
     const parameterValues = { p1: 1.1, p2: 2.2 };
+    const advancedSettings = {
+        [AdvancedOptions.tol]: { val: [null, null] as [number|null, number|null],
+            defaults: [1, -6],
+            type: AdSettingCompType.stdf as const
+        },
+        [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num as const },
+        [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num as const },
+        [AdvancedOptions.stepSizeMin]: {
+            val: [null, null] as [number|null, number|null],
+            defaults: [1, -8],
+            type: AdSettingCompType.stdf as const
+        },
+        [AdvancedOptions.tcrit]: { val: [0, "p1", "p2"], defaults: [], type: AdSettingCompType.tag as const }
+    }
     const modelState = mockModelState({
         odin: mockOdin,
         odinRunnerOde: mockOdinRunner
     });
-    const runState = mockRunState({ parameterValues });
+    const runState = mockRunState({
+        parameterValues,
+        advancedSettings
+    });
 
     const fitDataState = mockFitDataState({
         data: [
@@ -97,7 +116,7 @@ describe("ModelFit actions", () => {
             rtol: 0.000001,
             stepSizeMax: Infinity,
             stepSizeMin: 1e-8,
-            tcrit: Infinity
+            tcrit: [0, 1.1, 2.2]
         });
         expect(mockWodinFit.mock.calls[0][5]).toStrictEqual({});
     });

--- a/app/static/tests/unit/store/run/actions.test.ts
+++ b/app/static/tests/unit/store/run/actions.test.ts
@@ -10,6 +10,7 @@ import { ModelFitAction } from "../../../../src/app/store/modelFit/actions";
 import { RunGetter } from "../../../../src/app/store/run/getters";
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
+import { AdSettingCompType } from "../../../../src/app/store/run/state";
 
 jest.mock("../../../../src/app/wodinExcelDownload");
 
@@ -119,7 +120,7 @@ describe("Run actions", () => {
             maxSteps: 10000,
             stepSizeMax: Infinity,
             stepSizeMin: 1e-8,
-            tcrit: Infinity
+            tcrit: []
         });
 
         expect(commit.mock.calls.length).toBe(1);
@@ -155,11 +156,11 @@ describe("Run actions", () => {
             endTime: 99,
             parameterSets,
             advancedSettings: {
-                [AdvancedOptions.tol]: { val: [0.6, -1], defaults: [1, -6], standardForm: true },
-                [AdvancedOptions.maxSteps]: { val: 1, defaults: 10000, standardForm: false },
-                [AdvancedOptions.stepSizeMax]: { val: 2, defaults: Infinity, standardForm: false },
-                [AdvancedOptions.stepSizeMin]: { val: [0.5, -2], defaults: [1, -8], standardForm: true },
-                [AdvancedOptions.tcrit]: { val: 3, defaults: Infinity, standardForm: false }
+                [AdvancedOptions.tol]: { val: [0.6, -1], defaults: [1, -6], type: AdSettingCompType.stdf },
+                [AdvancedOptions.maxSteps]: { val: 1, defaults: 10000, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMax]: { val: 2, defaults: Infinity, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMin]: { val: [0.5, -2], defaults: [1, -8], type: AdSettingCompType.stdf },
+                [AdvancedOptions.tcrit]: { val: [0, "p1", "p2"], defaults: [], type: AdSettingCompType.tag }
             }
         });
         const commit = jest.fn();
@@ -180,7 +181,7 @@ describe("Run actions", () => {
             maxSteps: 1,
             stepSizeMax: 2,
             stepSizeMin: 0.005,
-            tcrit: 3
+            tcrit: [0, 1, 2]
         });
 
         expect(commit.mock.calls.length).toBe(1);

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -149,13 +149,13 @@ describe("Run mutations", () => {
                 [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
             }
         });
-        mutations.UpdateAdvancedSettings(state, { option: AdvancedOptions.tcrit, newVal: [2, 1, 0] });
+        mutations.UpdateAdvancedSettings(state, { option: AdvancedOptions.tcrit, newVal: [2, 1, 0, 0] });
         expect(state.advancedSettings).toStrictEqual({
             [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
             [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
             [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
             [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
-            [AdvancedOptions.tcrit]: { val: [0, 1, 2], defaults: [], type: AdSettingCompType.tag }
+            [AdvancedOptions.tcrit]: { val: [0, 0, 1, 2], defaults: [], type: AdSettingCompType.tag }
         });
     });
 

--- a/app/static/tests/unit/store/run/mutations.test.ts
+++ b/app/static/tests/unit/store/run/mutations.test.ts
@@ -1,4 +1,5 @@
 import { mutations } from "../../../../src/app/store/run/mutations";
+import { AdSettingCompType } from "../../../../src/app/store/run/state";
 import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
 import { mockRunState } from "../../../mocks";
 
@@ -113,21 +114,21 @@ describe("Run mutations", () => {
     it("updates advanced settings and sets runRequired to true", () => {
         const state = mockRunState({
             advancedSettings: {
-                [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], standardForm: true },
-                [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false },
-                [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false },
-                [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true },
-                [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false }
+                [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+                [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+                [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
             },
             runRequired: noRunRequired
         });
         mutations.UpdateAdvancedSettings(state, { option: AdvancedOptions.tol, newVal: [1, 2] });
         expect(state.advancedSettings).toStrictEqual({
-            [AdvancedOptions.tol]: { val: [1, 2], defaults: [1, -6], standardForm: true },
-            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false },
-            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false },
-            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true },
-            [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false }
+            [AdvancedOptions.tol]: { val: [1, 2], defaults: [1, -6], type: AdSettingCompType.stdf },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+            [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
         });
         expect(state.runRequired).toStrictEqual({
             endTimeChanged: false,
@@ -135,6 +136,47 @@ describe("Run mutations", () => {
             parameterValueChanged: false,
             numberOfReplicatesChanged: false,
             advancedSettingsChanged: true
+        });
+    });
+
+    it("updates and sorts tcrit when updating advanced settings", () => {
+        const state = mockRunState({
+            advancedSettings: {
+                [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+                [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+                [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
+            }
+        });
+        mutations.UpdateAdvancedSettings(state, { option: AdvancedOptions.tcrit, newVal: [2, 1, 0] });
+        expect(state.advancedSettings).toStrictEqual({
+            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+            [AdvancedOptions.tcrit]: { val: [0, 1, 2], defaults: [], type: AdSettingCompType.tag }
+        });
+    });
+
+    it("updates and sorts tcrit when updating advanced settings with param values", () => {
+        const state = mockRunState({
+            advancedSettings: {
+                [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+                [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+                [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+                [AdvancedOptions.tcrit]: { val: null, defaults: [], type: AdSettingCompType.tag }
+            },
+            parameterValues: { a: 2, b: 3 }
+        });
+        mutations.UpdateAdvancedSettings(state, { option: AdvancedOptions.tcrit, newVal: ["a", 0, "b", 1] });
+        expect(state.advancedSettings).toStrictEqual({
+            [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+            [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+            [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+            [AdvancedOptions.tcrit]: { val: [0, 1, "a", "b"], defaults: [], type: AdSettingCompType.tag }
         });
     });
 

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -4,6 +4,7 @@ import { ModelGetter } from "../../../../src/app/store/model/getters";
 import { AppType } from "../../../../src/app/store/appState/state";
 import { RunAction } from "../../../../src/app/store/run/actions";
 import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
+import { AdSettingCompType } from "../../../../src/app/store/run/state";
 
 const mockBatch = {};
 const mockRunnerOde = {
@@ -28,12 +29,13 @@ const mockRunState = {
     endTime: 99,
     numberOfReplicates: 5,
     advancedSettings: {
-        [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], standardForm: true },
-        [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, standardForm: false },
-        [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, standardForm: false },
-        [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], standardForm: true },
-        [AdvancedOptions.tcrit]: { val: null, defaults: Infinity, standardForm: false }
-    }
+        [AdvancedOptions.tol]: { val: [null, null], defaults: [1, -6], type: AdSettingCompType.stdf },
+        [AdvancedOptions.maxSteps]: { val: null, defaults: 10000, type: AdSettingCompType.num },
+        [AdvancedOptions.stepSizeMax]: { val: null, defaults: Infinity, type: AdSettingCompType.num },
+        [AdvancedOptions.stepSizeMin]: { val: [null, null], defaults: [1, -8], type: AdSettingCompType.stdf },
+        [AdvancedOptions.tcrit]: { val: [0, "p1"], defaults: [], type: AdSettingCompType.tag }
+    },
+    parameterValues: { p1: 3.14 }
 };
 
 const defaultAdvanced = {
@@ -42,7 +44,7 @@ const defaultAdvanced = {
     rtol: 0.000001,
     stepSizeMax: Infinity,
     stepSizeMin: 1e-8,
-    tcrit: Infinity
+    tcrit: [0, 3.14]
 };
 
 const mockBatchPars = {};

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -191,7 +191,6 @@ describe("processFitData", () => {
             { a: "9", b: "1" }
         ];
         const result = processFitData(data, "Error occurred");
-        console.log(result);
         expect(result.data).toBe(null);
         expect(result.error).toStrictEqual({
             error: "Error occurred",

--- a/app/static/vue-shims.d.ts
+++ b/app/static/vue-shims.d.ts
@@ -9,3 +9,4 @@ declare module "vue-monaco";
 declare module "csv-parse";
 declare module "markdown-it-mathjax";
 declare module "raw-loader!*";
+declare module "vue3-tags-input";


### PR DESCRIPTION
## Problems/motivation:
- We want to allow users to enter an array of critical times in the advanced settings to allow them to cope with discontinuous derivatives

## New features/solutions:
- Changed advanced settings config to type instead of standard form boolean since we had 3 different types of input now
- TagInput component that parses and cleans tag inputs

## How PR should behave when tested:
- Can input numbers into the tag input and render a tag when you press Space, Enter or ","
- Can input parameter names into the tag input and it will format according to the values of the parameter
- Can change parameters and the tag should update
- Will not accept a non-parameter name string
- Will not accept repeats including parameter names however will accept "sigma" and "2" even if the value of sigma is 2
- Removing a parameter value in the code and compiling should remove it from the tags input too
- Tags should automatically sort when you add in a new tag
- Backspace removes tags
- When you enter the code
```R
deriv(N) <- rt
initial(N) <- N0
rt <- if(t >= time_start && t < time_end) r else 0
N0 <- user(1)
r <- 1 / (time_end - time_start)
time_start <- user(35)
time_end <- user(50)
```
note the shape of the graph, (horizontal, diagonal, horizontal). Now go to options tab, change the value of `time_start` to 40 and run, should see just a horizontal line. If you put `time_start` and `time_end` in tcrit, you should see original shape of graph instead of straight line

~## How to run app:~
~1. Run the app according to the README, however please is odin-api:mrc-4432 docker container with this branch. (If this gets merged into main/master by the time you see this @richfitz then feel free to edit this comment)~