### PR TITLE
mrc-4520 Prevent SetLoading reactivity loop in summary plot

### DIFF
--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -91,6 +91,12 @@ export default defineComponent({
         });
         const lineStylesForParamSets = computed(() => store.getters[`run/${RunGetter.lineStylesForParameterSets}`]);
 
+        const finishLoading = () => {
+            if (store.state.sensitivity.loading) {
+                store.commit(`sensitivity/${SensitivityMutation.SetLoading}`, false);
+            }
+        };
+
         const plotData = computed(() => {
             if (batch.value) {
                 let data: null | OdinSeriesSet;
@@ -128,10 +134,10 @@ export default defineComponent({
                     });
                     result.push(...psPlotData);
                 });
-                store.commit(`sensitivity/${SensitivityMutation.SetLoading}`, false);
+                finishLoading();
                 return result;
             }
-            store.commit(`sensitivity/${SensitivityMutation.SetLoading}`, false);
+            finishLoading();
             return [];
         });
         const hasPlotData = computed(() => !!(plotData.value?.length));

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -247,7 +247,8 @@ test.describe("Code Tab tests", () => {
         );
         await expect(await page.innerText(".wodin-left .wodin-content #code-status")).toContain("Code is not valid");
         await expect(await page.innerText(".wodin-left .wodin-content #error-info"))
-            .toBe("Code error: Error on line 1: Every line must contain an assignment");
+            .toBe("Code error: Error on line 1: Every line must contain an assignment, a compare statement "
+                + "or a debug statement");
     });
 
     test("can display model error message when running model", async ({ page }) => {

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryPlot.test.ts
@@ -113,7 +113,8 @@ describe("SensitivitySummaryPlot", () => {
 
     const getWrapper = (hasData = true, plotSettings: SensitivityPlotSettings = defaultPlotSettings,
         fadePlot = false, paramSettings: SensitivityParameterSettings = defaultParamSettings,
-        logScaleYAxis = false, selectedVariables = defaultSelectedVariables, includeParameterSets = false) => {
+        logScaleYAxis = false, selectedVariables = defaultSelectedVariables, includeParameterSets = false,
+        isLoading = false) => {
         const visibleParameterSetNames = includeParameterSets ? ["Set1", "Set2"] : [];
         const parameterSetResults = includeParameterSets ? {
             Set1: {
@@ -157,6 +158,7 @@ describe("SensitivitySummaryPlot", () => {
                 sensitivity: {
                     namespaced: true,
                     state: {
+                        loading: isLoading,
                         result: {
                             batch: hasData ? mockBatch : null
                         },
@@ -503,12 +505,19 @@ describe("SensitivitySummaryPlot", () => {
         expectDataToHaveBeenPlotted(wrapper);
     });
 
-    it("commits set loading when plotData is computed", async () => {
-        const wrapper = getWrapper();
+    it("commits set loading when plotData is computed, if loading is true", async () => {
+        const wrapper = getWrapper(true, defaultPlotSettings, false,
+            defaultParamSettings, false, defaultSelectedVariables, false, true);
         // drawPlot on mount
         expect(mockSetLoading).toHaveBeenCalledTimes(1);
         store!.state.sensitivity.plotSettings.time = 50;
         await nextTick();
         expect(mockSetLoading).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not commit set loading when plotData is computed, if loading is false", async () => {
+        const wrapper = getWrapper();
+        store!.state.sensitivity.plotSettings.time = 50;
+        expect(mockSetLoading).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Fixes the bug where legend visibility could not be toggled in the Sensitivity Summary Plot, by breaking the reactivity loop where every update caused an unnecessary mutation to set loading to false. 

Also contains unrelated fix for test - new code error message expected from latest version of odin. 