### PR TITLE
mrc-4522 Allow user-specified parameter values in Sensitivity

### DIFF
--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -18,7 +18,7 @@
                  </select>
                </div>
              </div>
-             <div v-if="settingsInternal.variationType !== 'User'"  class="row mt-2" id="edit-scale-type">
+             <div v-if="settingsInternal.variationType !== 'Custom'"  class="row mt-2" id="edit-scale-type">
                <div class="col-6">
                  <label class="col-form-label">Scale type</label>
                </div>
@@ -77,18 +77,18 @@
                 </div>
               </div>
             </template>
-            <template v-if="settingsInternal.variationType === 'User'">
+            <template v-if="settingsInternal.variationType === 'Custom'">
               <div id="edit-values" class="row mt-2">
                 <div class="col-6">
                   <label class="col-form-label">Values</label>
                 </div>
                 <div class="col-6">
-                  <tag-input :tags="settingsInternal.userValues" :numeric-only="true" @update="updateUserValues">
+                  <tag-input :tags="settingsInternal.customValues" :numeric-only="true" @update="updateUserValues">
                   </tag-input>
                 </div>
               </div>
             </template>
-            <div v-if="settingsInternal.variationType !== 'User'" id="edit-runs" class="row mt-2">
+            <div v-if="settingsInternal.variationType !== 'Custom'" id="edit-runs" class="row mt-2">
               <div class="col-6">
                 <label class="col-form-label">Number of runs</label>
               </div>
@@ -102,7 +102,7 @@
                 <error-info :error="batchParsError"></error-info>
               </div>
             </div>
-            <sensitivity-param-values v-if="settingsInternal.variationType !== 'User'" :batch-pars="batchPars">
+            <sensitivity-param-values v-if="settingsInternal.variationType !== 'Custom'" :batch-pars="batchPars">
             </sensitivity-param-values>
           </div>
           <div class="modal-footer">
@@ -176,16 +176,16 @@ export default defineComponent({
 
         const paramValues = computed(() => store.state.run.parameterValues);
         const batchParsResult = computed(() => {
-            if (settingsInternal.variationType === SensitivityVariationType.User) {
+            if (settingsInternal.variationType === SensitivityVariationType.Custom) {
                 return null;
             }
             return generateBatchPars(store.state, settingsInternal, paramValues.value);
         });
         const batchPars = computed(() => batchParsResult.value?.batchPars);
         const batchParsError = computed(() => {
-            if (settingsInternal.variationType === SensitivityVariationType.User) {
-                // Minimum of two user values
-                return settingsInternal.userValues.length < 2
+            if (settingsInternal.variationType === SensitivityVariationType.Custom) {
+                // Minimum of two custom values
+                return settingsInternal.customValues.length < 2
                     ? { error: "Invalid settings", detail: "Must include at least 2 traces in the batch" } : null;
             }
             return batchParsResult.value?.error;
@@ -193,7 +193,7 @@ export default defineComponent({
         const updateUserValues = (newValues: number[]) => {
             // sort and remove duplicates
             const cleaned = Array.from(new Set(newValues)).sort((a, b) => a - b);
-            settingsInternal.userValues = cleaned;
+            settingsInternal.customValues = cleaned;
         };
 
         const close = () => { emit("close"); };

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -192,12 +192,13 @@ export default defineComponent({
         });
         const updateUserValues = (newValues: number[]) => {
             // sort and remove duplicates
-            const cleaned = [...new Set(newValues)].sort((a, b) => a - b);
+            const cleaned = Array.from(new Set(newValues)).sort((a, b) => a - b);
             settingsInternal.userValues = cleaned;
         };
 
         const close = () => { emit("close"); };
         const updateSettings = () => {
+            console.log("updating settings")
             store.commit(`sensitivity/${SensitivityMutation.SetParamSettings}`, { ...settingsInternal });
             close();
         };

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -83,7 +83,8 @@
                   <label class="col-form-label">Values</label>
                 </div>
                 <div class="col-6">
-                  <tag-input :tags="settingsInternal.userValues" @update="updateUserValues"></tag-input>
+                  <tag-input :tags="[...settingsInternal.userValues]" :numeric-only="true" @update="updateUserValues">
+                  </tag-input>
                 </div>
               </div>
             </template>
@@ -185,7 +186,7 @@ export default defineComponent({
         const updateUserValues = (newValues: number[]) => {
             console.log(`updating to: ${JSON.stringify(newValues)}`);
             // sort and remove duplicates
-            const cleaned = [...new Set(newValues)].sort();
+            const cleaned = [...new Set(newValues)].sort((a, b) => a - b);
             settingsInternal.userValues = cleaned;
         };
 

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -88,7 +88,7 @@
                 </div>
               </div>
             </template>
-            <div v-if="settingsInternal.variationType !== 'User'" class="row mt-2 edit-runs">
+            <div v-if="settingsInternal.variationType !== 'User'" id="edit-runs" class="row mt-2">
               <div class="col-6">
                 <label class="col-form-label">Number of runs</label>
               </div>
@@ -198,7 +198,6 @@ export default defineComponent({
 
         const close = () => { emit("close"); };
         const updateSettings = () => {
-            console.log("updating settings")
             store.commit(`sensitivity/${SensitivityMutation.SetParamSettings}`, { ...settingsInternal });
             close();
         };

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -49,34 +49,33 @@
                                @update="(n) => settingsInternal.variationPercentage = n"></numeric-input>
               </div>
             </div>
-            <template v-if="settingsInternal.variationType === 'Range'">
-              <div class="row mt-2" id="edit-from">
-                <div class="col-6">
-                  <label class="col-form-label">From</label>
-                </div>
-                <div class="col-6">
-                  <numeric-input :value="settingsInternal.rangeFrom"
-                                 @update="(n) => settingsInternal.rangeFrom = n"></numeric-input>
-                </div>
+            <div v-if="settingsInternal.variationType === 'Range'" class="row mt-2" id="edit-from">
+              <div class="col-6">
+                <label class="col-form-label">From</label>
               </div>
-              <div class="row mt-2 text-muted" id="param-central">
-                <div class="col-6">
-                  Central value
-                </div>
-                <div class="col-6">
-                  {{ centralValue }}
-                </div>
+              <div class="col-6">
+                <numeric-input :value="settingsInternal.rangeFrom"
+                               @update="(n) => settingsInternal.rangeFrom = n"></numeric-input>
               </div>
-              <div class="row mt-2" id="edit-to">
-                <div class="col-6">
-                  <label class="col-form-label">To</label>
-                </div>
-                <div class="col-6">
-                  <numeric-input :value="settingsInternal.rangeTo"
-                                 @update="(n) => settingsInternal.rangeTo = n"></numeric-input>
-                </div>
+            </div>
+            <div v-if="['Range', 'Custom'].includes(settingsInternal.variationType)"
+                 class="row mt-2 text-muted" id="param-central">
+              <div class="col-6">
+                Central value
               </div>
-            </template>
+              <div class="col-6">
+                {{ centralValue }}
+              </div>
+            </div>
+            <div v-if="settingsInternal.variationType === 'Range'" class="row mt-2" id="edit-to">
+              <div class="col-6">
+                <label class="col-form-label">To</label>
+              </div>
+              <div class="col-6">
+                <numeric-input :value="settingsInternal.rangeTo"
+                               @update="(n) => settingsInternal.rangeTo = n"></numeric-input>
+              </div>
+            </div>
             <template v-if="settingsInternal.variationType === 'Custom'">
               <div id="edit-values" class="row mt-2">
                 <div class="col-6">

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -18,18 +18,6 @@
                  </select>
                </div>
              </div>
-             <div v-if="settingsInternal.variationType !== 'Custom'"  class="row mt-2" id="edit-scale-type">
-               <div class="col-6">
-                 <label class="col-form-label">Scale type</label>
-               </div>
-               <div class="col-6">
-                 <select class="form-select" v-model="settingsInternal.scaleType">
-                   <option v-for="scale in scaleValues" :key="scale">{{scale}}</option>
-                 </select>
-               </div>
-               <div class="col-6">
-             </div>
-             </div>
             <div class="row mt-2" id="edit-variation-type">
               <div class="col-6">
                 <label class="col-form-label">Variation type</label>
@@ -38,6 +26,18 @@
                 <select class="form-select" v-model="settingsInternal.variationType">
                   <option v-for="variation in variationTypeValues" :key="variation">{{variation}}</option>
                 </select>
+              </div>
+            </div>
+            <div v-if="settingsInternal.variationType !== 'Custom'"  class="row mt-2" id="edit-scale-type">
+              <div class="col-6">
+                <label class="col-form-label">Scale type</label>
+              </div>
+              <div class="col-6">
+                <select class="form-select" v-model="settingsInternal.scaleType">
+                  <option v-for="scale in scaleValues" :key="scale">{{scale}}</option>
+                </select>
+              </div>
+              <div class="col-6">
               </div>
             </div>
             <div v-if="settingsInternal.variationType === 'Percentage'" class="row mt-2" id="edit-percent">

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -78,12 +78,12 @@
               </div>
             </template>
             <template v-if="settingsInternal.variationType === 'User'">
-              <div class="row mt-2 edit-from">
+              <div id="edit-values" class="row mt-2">
                 <div class="col-6">
                   <label class="col-form-label">Values</label>
                 </div>
                 <div class="col-6">
-                  <tag-input :tags="[...settingsInternal.userValues]" :numeric-only="true" @update="updateUserValues">
+                  <tag-input :tags="settingsInternal.userValues" :numeric-only="true" @update="updateUserValues">
                   </tag-input>
                 </div>
               </div>

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -191,13 +191,15 @@ export default defineComponent({
         });
         const updateUserValues = (newValues: number[]) => {
             // sort and remove duplicates
-            const cleaned = Array.from(new Set(newValues)).sort((a, b) => a - b);
-            settingsInternal.customValues = cleaned;
+            settingsInternal.customValues = newValues;
         };
 
         const close = () => { emit("close"); };
         const updateSettings = () => {
-            store.commit(`sensitivity/${SensitivityMutation.SetParamSettings}`, { ...settingsInternal });
+            // sort custom values
+            const customValues = settingsInternal.customValues.sort((a, b) => a - b);
+            store.commit(`sensitivity/${SensitivityMutation.SetParamSettings}`,
+                { ...settingsInternal, customValues });
             close();
         };
 

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -18,7 +18,7 @@
                  </select>
                </div>
              </div>
-             <div class="row mt-2" id="edit-scale-type">
+             <div v-if="settingsInternal.variationType !== 'User'"  class="row mt-2" id="edit-scale-type">
                <div class="col-6">
                  <label class="col-form-label">Scale type</label>
                </div>

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -182,9 +182,15 @@ export default defineComponent({
             return generateBatchPars(store.state, settingsInternal, paramValues.value);
         });
         const batchPars = computed(() => batchParsResult.value?.batchPars);
-        const batchParsError = computed(() => batchParsResult.value?.error); // TODO: roll our own error for User type
+        const batchParsError = computed(() => {
+            if (settingsInternal.variationType === SensitivityVariationType.User) {
+                // Minimum of two user values
+                return settingsInternal.userValues.length < 2
+                    ? { error: "Invalid settings", detail: "Must include at least 2 traces in the batch" } : null;
+            }
+            return batchParsResult.value?.error;
+        });
         const updateUserValues = (newValues: number[]) => {
-            console.log(`updating to: ${JSON.stringify(newValues)}`);
             // sort and remove duplicates
             const cleaned = [...new Set(newValues)].sort((a, b) => a - b);
             settingsInternal.userValues = cleaned;

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -5,8 +5,8 @@
         <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
         <ul>
           <li><strong>Parameter:</strong> {{settings.parameterToVary}}</li>
-          <li v-if="settings.variationType !== 'Custom'"><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
           <li><strong>Variation Type:</strong> {{ settings.variationType }}</li>
+          <li v-if="settings.variationType !== 'Custom'"><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
           <li v-if="settings.variationType === 'Percentage'">
             <strong>Variation (%):</strong> {{ settings.variationPercentage }}
           </li>

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -10,13 +10,20 @@
           <li v-if="settings.variationType === 'Percentage'">
             <strong>Variation (%):</strong> {{ settings.variationPercentage }}
           </li>
-          <template v-else>
+          <template v-if="settings.variationType === 'Range'">
             <li><strong>From:</strong> {{ settings.rangeFrom }}</li>
             <li><strong>To:</strong> {{ settings.rangeTo }}</li>
           </template>
-          <li><strong>Number of runs:</strong> {{ settings.numberOfRuns}}</li>
+          <li v-if="settings.variationType === 'User'">
+            <strong>Values:</strong>
+            {{ settings.userValues.join(", ") }}
+          </li>
+          <li v-if="settings.variationType !== 'User'">
+            <strong>Number of runs:</strong> {{ settings.numberOfRuns}}
+          </li>
         </ul>
-        <sensitivity-param-values :batch-pars="batchPars"></sensitivity-param-values>
+        <sensitivity-param-values v-if="settings.variationType !== 'User'" :batch-pars="batchPars">
+        </sensitivity-param-values>
       </div>
       <hr/>
       <sensitivity-plot-options></sensitivity-plot-options>

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -5,7 +5,7 @@
         <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
         <ul>
           <li><strong>Parameter:</strong> {{settings.parameterToVary}}</li>
-          <li><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
+          <li v-if="settings.variationType !== 'User'"><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
           <li><strong>Variation Type:</strong> {{ settings.variationType }}</li>
           <li v-if="settings.variationType === 'Percentage'">
             <strong>Variation (%):</strong> {{ settings.variationPercentage }}

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -5,7 +5,7 @@
         <button class="btn btn-primary mb-4 float-end" @click="toggleEdit(true)">Edit</button>
         <ul>
           <li><strong>Parameter:</strong> {{settings.parameterToVary}}</li>
-          <li v-if="settings.variationType !== 'User'"><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
+          <li v-if="settings.variationType !== 'Custom'"><strong>Scale Type:</strong> {{ settings.scaleType }}</li>
           <li><strong>Variation Type:</strong> {{ settings.variationType }}</li>
           <li v-if="settings.variationType === 'Percentage'">
             <strong>Variation (%):</strong> {{ settings.variationPercentage }}
@@ -14,15 +14,15 @@
             <li><strong>From:</strong> {{ settings.rangeFrom }}</li>
             <li><strong>To:</strong> {{ settings.rangeTo }}</li>
           </template>
-          <li v-if="settings.variationType === 'User'">
+          <li v-if="settings.variationType === 'Custom'">
             <strong>Values:</strong>
-            {{ settings.userValues.join(", ") }}
+            {{ settings.customValues.join(", ") }}
           </li>
-          <li v-if="settings.variationType !== 'User'">
+          <li v-if="settings.variationType !== 'Custom'">
             <strong>Number of runs:</strong> {{ settings.numberOfRuns}}
           </li>
         </ul>
-        <sensitivity-param-values v-if="settings.variationType !== 'User'" :batch-pars="batchPars">
+        <sensitivity-param-values v-if="settings.variationType !== 'Custom'" :batch-pars="batchPars">
         </sensitivity-param-values>
       </div>
       <hr/>

--- a/app/static/src/app/components/options/TagInput.vue
+++ b/app/static/src/app/components/options/TagInput.vue
@@ -20,7 +20,12 @@ export default defineComponent({
         VueTagsInput
     },
     props: {
-        tags: Array as PropType<Tag[] | null>
+        tags: Array as PropType<Tag[] | null>,
+        numericOnly: {
+            type: Boolean,
+            required: false,
+            default: false
+        }
     },
     setup(props, { emit }) {
         const store = useStore();
@@ -39,7 +44,7 @@ export default defineComponent({
             }
             const cleanTags = props.tags.filter((tag) => {
                 if (typeof tag === "number") return true;
-                return paramValues.value[tag] !== undefined;
+                return !props.numericOnly && paramValues.value[tag] !== undefined;
             });
             return cleanTags.map((tag) => {
                 if (typeof tag === "number") return `${tag}`;
@@ -61,14 +66,16 @@ export default defineComponent({
                 if (isNumeric(tag)) {
                     return parseFloat(tag);
                 }
-                if (tag.includes(":")) {
-                    const variableTag = tag.split(":");
-                    const varId = variableTag[0];
-                    if (isParameterName(varId)) {
-                        return varId;
+                if (!props.numericOnly) {
+                    if (tag.includes(":")) {
+                        const variableTag = tag.split(":");
+                        const varId = variableTag[0];
+                        if (isParameterName(varId)) {
+                            return varId;
+                        }
+                    } else if (isParameterName(tag)) {
+                        return tag;
                     }
-                } else if (isParameterName(tag)) {
-                    return tag;
                 }
                 return undefined;
             });

--- a/app/static/src/app/components/options/TagInput.vue
+++ b/app/static/src/app/components/options/TagInput.vue
@@ -1,15 +1,17 @@
 <template>
     <vue-tags-input style="border-color: #d7dce1;"
+                    v-model="currentTag"
                     :tags="computedTags"
                     :placeholder="'...'"
                     :validate="validate"
                     :add-tag-on-blur="true"
                     :add-tag-on-keys="[13, ',', 32, ':']"
+                    @on-error="handleError"
                     @on-tags-changed="handleTagsChanged"/>
 </template>
 <script lang="ts">
 import {
-    PropType, computed, defineComponent, watch
+    PropType, computed, defineComponent, watch, ref
 } from "vue";
 import VueTagsInput from "vue3-tags-input";
 import { useStore } from "vuex";
@@ -29,6 +31,8 @@ export default defineComponent({
     },
     setup(props, { emit }) {
         const store = useStore();
+
+        const currentTag = ref("");
 
         const paramValues = computed(() => store.state.run.parameterValues);
 
@@ -59,6 +63,11 @@ export default defineComponent({
 
         const isParameterName = (tag: string) => {
             return paramValues.value && tag in paramValues.value;
+        };
+
+        const handleError = () => {
+            // remove duplicate current tag
+            currentTag.value = "";
         };
 
         const handleTagsChanged = (tags: string[]) => {
@@ -97,7 +106,9 @@ export default defineComponent({
         };
 
         return {
+            currentTag,
             computedTags,
+            handleError,
             handleTagsChanged,
             validate
         };
@@ -111,5 +122,10 @@ export default defineComponent({
 
 .v3ti-tag .v3ti-remove-tag {
     text-decoration: none !important;
+}
+
+.v3ti-new-tag--error {
+  text-decoration: none !important;
+  color: #000 !important;
 }
 </style>

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -17,7 +17,8 @@ export const defaultState: SensitivityState = {
         variationPercentage: 10,
         rangeFrom: 0,
         rangeTo: 0,
-        numberOfRuns: 10
+        numberOfRuns: 10,
+        userValues: []
     },
     plotSettings: {
         plotType: SensitivityPlotType.TraceOverTime,

--- a/app/static/src/app/store/sensitivity/sensitivity.ts
+++ b/app/static/src/app/store/sensitivity/sensitivity.ts
@@ -18,7 +18,7 @@ export const defaultState: SensitivityState = {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 10,
-        userValues: []
+        customValues: []
     },
     plotSettings: {
         plotType: SensitivityPlotType.TraceOverTime,

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -9,7 +9,7 @@ export enum SensitivityScaleType {
 export enum SensitivityVariationType {
     Percentage = "Percentage",
     Range = "Range",
-    User = "User"
+    Custom = "Custom"
 }
 
 export interface SensitivityParameterSettings {
@@ -20,7 +20,7 @@ export interface SensitivityParameterSettings {
     rangeFrom: number,
     rangeTo: number,
     numberOfRuns: number,
-    userValues: number[]
+    customValues: number[]
 }
 
 export enum SensitivityPlotType {

--- a/app/static/src/app/store/sensitivity/state.ts
+++ b/app/static/src/app/store/sensitivity/state.ts
@@ -8,7 +8,8 @@ export enum SensitivityScaleType {
 
 export enum SensitivityVariationType {
     Percentage = "Percentage",
-    Range = "Range"
+    Range = "Range",
+    User = "User"
 }
 
 export interface SensitivityParameterSettings {
@@ -18,7 +19,8 @@ export interface SensitivityParameterSettings {
     variationPercentage: number,
     rangeFrom: number,
     rangeTo: number,
-    numberOfRuns: number
+    numberOfRuns: number,
+    userValues: number[]
 }
 
 export enum SensitivityPlotType {

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -1,5 +1,5 @@
-import { uid } from "uid";
-import { Dict } from "./types/utilTypes";
+import {uid} from "uid";
+import {Dict} from "./types/utilTypes";
 import {
     AdvancedOptions,
     AdvancedSettingsOdin,
@@ -10,13 +10,9 @@ import {
 } from "./types/responseTypes";
 import userMessages from "./userMessages";
 import settings from "./settings";
-import {
-    SensitivityParameterSettings,
-    SensitivityScaleType,
-    SensitivityVariationType
-} from "./store/sensitivity/state";
-import { AppState } from "./store/appState/state";
-import { AdvancedComponentType, AdvancedSettings, Tag } from "./store/run/state";
+import {SensitivityParameterSettings, SensitivityScaleType, SensitivityVariationType} from "./store/sensitivity/state";
+import {AppState} from "./store/appState/state";
+import {AdvancedComponentType, AdvancedSettings, Tag} from "./store/run/state";
 
 export const freezer = {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -134,10 +130,10 @@ export interface GenerateBatchParsResult {
     error: WodinError | null
 }
 
-export function generateBatchPars(
+function generateBatchParsFromOdin(
     rootState: AppState,
     paramSettings: SensitivityParameterSettings,
-    paramValues: OdinUserType | null
+    paramValues: OdinUserType
 ): GenerateBatchParsResult {
     let batchPars = null;
     let errorDetail = null;
@@ -148,14 +144,10 @@ export function generateBatchPars(
     } = paramSettings;
     const logarithmic = scaleType === SensitivityScaleType.Logarithmic;
 
-    if (!parameterToVary) {
-        errorDetail = "Parameter to vary is not set";
-    } else if (!runner || !paramValues) {
-        errorDetail = "Model is not initialised";
-    } else if (variationType === SensitivityVariationType.Percentage) {
+    if (variationType === SensitivityVariationType.Percentage) {
         try {
-            batchPars = runner.batchParsDisplace(
-                paramValues, parameterToVary,
+            batchPars = runner!.batchParsDisplace(
+                paramValues, parameterToVary!,
                 numberOfRuns, logarithmic,
                 variationPercentage
             );
@@ -164,9 +156,9 @@ export function generateBatchPars(
         }
     } else {
         try {
-            batchPars = runner.batchParsRange(
+            batchPars = runner!.batchParsRange(
                 paramValues,
-                parameterToVary,
+                parameterToVary!,
                 numberOfRuns,
                 logarithmic,
                 rangeFrom,
@@ -182,6 +174,40 @@ export function generateBatchPars(
         batchPars,
         error
     };
+}
+
+export function generateBatchPars(
+    rootState: AppState,
+    paramSettings: SensitivityParameterSettings,
+    paramValues: OdinUserType | null
+): GenerateBatchParsResult {
+    let errorDetail = null;
+    if (!paramSettings.parameterToVary) {
+        errorDetail = "Parameter to vary is not set";
+    }
+    else if (!rootState.model.odinRunnerOde || !paramValues) {
+        errorDetail = "Model is not initialised";
+    }
+    if (errorDetail) {
+        return {
+            batchPars: null,
+            error: { error: userMessages.sensitivity.invalidSettings, detail: errorDetail }
+        };
+    }
+
+    if (paramSettings.variationType === SensitivityVariationType.User) {
+        const batchPars: BatchPars = {
+            base: paramValues!,
+            name: paramSettings.parameterToVary!,
+            values: paramSettings.userValues
+        };
+        return {
+            batchPars,
+            error: null
+        };
+    } else {
+        return generateBatchParsFromOdin(rootState, paramSettings, paramValues!);
+    }
 }
 
 export const newSessionId = (): string => uid(32);

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -195,11 +195,11 @@ export function generateBatchPars(
         };
     }
 
-    if (paramSettings.variationType === SensitivityVariationType.User) {
+    if (paramSettings.variationType === SensitivityVariationType.Custom) {
         const batchPars: BatchPars = {
             base: paramValues!,
             name: paramSettings.parameterToVary!,
-            values: paramSettings.userValues
+            values: paramSettings.customValues
         };
         return {
             batchPars,

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -1,5 +1,5 @@
-import {uid} from "uid";
-import {Dict} from "./types/utilTypes";
+import { uid } from "uid";
+import { Dict } from "./types/utilTypes";
 import {
     AdvancedOptions,
     AdvancedSettingsOdin,
@@ -10,9 +10,10 @@ import {
 } from "./types/responseTypes";
 import userMessages from "./userMessages";
 import settings from "./settings";
-import {SensitivityParameterSettings, SensitivityScaleType, SensitivityVariationType} from "./store/sensitivity/state";
-import {AppState} from "./store/appState/state";
-import {AdvancedComponentType, AdvancedSettings, Tag} from "./store/run/state";
+import { SensitivityParameterSettings, SensitivityScaleType, SensitivityVariationType }
+    from "./store/sensitivity/state";
+import { AppState } from "./store/appState/state";
+import { AdvancedComponentType, AdvancedSettings, Tag } from "./store/run/state";
 
 export const freezer = {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -184,8 +185,7 @@ export function generateBatchPars(
     let errorDetail = null;
     if (!paramSettings.parameterToVary) {
         errorDetail = "Parameter to vary is not set";
-    }
-    else if (!rootState.model.odinRunnerOde || !paramValues) {
+    } else if (!rootState.model.odinRunnerOde || !paramValues) {
         errorDetail = "Model is not initialised";
     }
     if (errorDetail) {
@@ -205,9 +205,8 @@ export function generateBatchPars(
             batchPars,
             error: null
         };
-    } else {
-        return generateBatchParsFromOdin(rootState, paramSettings, paramValues!);
     }
+    return generateBatchParsFromOdin(rootState, paramSettings, paramValues!);
 }
 
 export const newSessionId = (): string => uid(32);

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -246,7 +246,7 @@ test.describe("Sensitivity tests", () => {
         await tagInput.press("3");
         await tagInput.press(",");
 
-        await page.waitForTimeout(100)
+        await page.waitForTimeout(100);
         await expect(await page.locator("#invalid-msg").count()).toBe(0);
         await expect(await page.locator(".modal .alert-success").count()).toBe(0);
 
@@ -263,6 +263,5 @@ test.describe("Sensitivity tests", () => {
         await expectSummaryValues(page, 7, "S (beta=3.000)", 1000, "#2e5cb8");
         await expectSummaryValues(page, 8, "I (beta=3.000)", 1000, "#cccc00");
         await expectSummaryValues(page, 9, "R (beta=3.000)", 1000, "#cc0044");
-
     });
 });

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -16,7 +16,7 @@ test.describe("Sensitivity tests", () => {
     test("can edit Sensitivity options", async ({ page }) => {
         // Default settings are visible
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 1)")).toBe("Parameter: beta");
-        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Variation Type: Percentage")
+        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Variation Type: Percentage");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 3)")).toBe("Scale Type: Arithmetic");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 4)")).toBe("Variation (%): 10");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 5)")).toBe("Number of runs: 10");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -16,8 +16,8 @@ test.describe("Sensitivity tests", () => {
     test("can edit Sensitivity options", async ({ page }) => {
         // Default settings are visible
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 1)")).toBe("Parameter: beta");
-        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Scale Type: Arithmetic");
-        await expect(await page.innerText(":nth-match(#sensitivity-options li, 3)")).toBe("Variation Type: Percentage");
+        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Variation Type: Percentage")
+        await expect(await page.innerText(":nth-match(#sensitivity-options li, 3)")).toBe("Scale Type: Arithmetic");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 4)")).toBe("Variation (%): 10");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 5)")).toBe("Number of runs: 10");
         await expect(await page.innerText("#sensitivity-options .alert-success"))
@@ -54,8 +54,8 @@ test.describe("Sensitivity tests", () => {
 
         // New settings are visible
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 1)")).toBe("Parameter: sigma");
-        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Scale Type: Logarithmic");
-        await expect(await page.innerText(":nth-match(#sensitivity-options li, 3)")).toBe("Variation Type: Range");
+        await expect(await page.innerText(":nth-match(#sensitivity-options li, 2)")).toBe("Variation Type: Range");
+        await expect(await page.innerText(":nth-match(#sensitivity-options li, 3)")).toBe("Scale Type: Logarithmic");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 4)")).toBe("From: 1");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 5)")).toBe("To: 5");
         await expect(await page.innerText(":nth-match(#sensitivity-options li, 6)")).toBe("Number of runs: 12");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -230,11 +230,11 @@ test.describe("Sensitivity tests", () => {
         await expectSummaryValues(page, 66, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
     });
 
-    test("can change sensitivity settings to User variation, and see values in Sensitivity plot", async ({ page }) => {
+    test("can change sensitivity settings to Custom variation, and see values in plot", async ({ page }) => {
         await page.click("#sensitivity-options .btn-primary");
         await expect(await page.locator("#edit-param .modal")).toBeVisible();
         const varSelect = await page.locator("#edit-variation-type select");
-        await varSelect.selectOption("User");
+        await varSelect.selectOption("Custom");
         await expect(await page.innerText("#invalid-msg"))
             .toBe("Invalid settings: Must include at least 2 traces in the batch");
 

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -238,6 +238,8 @@ test.describe("Sensitivity tests", () => {
         await expect(await page.innerText("#invalid-msg"))
             .toBe("Invalid settings: Must include at least 2 traces in the batch");
 
+        await expect(await page.innerText(":nth-match(.modal #param-central div, 1)")).toBe("Central value");
+        await expect(await page.innerText(":nth-match(.modal #param-central div, 2)")).toBe("4");
         const tagInput = await page.locator("#edit-values input");
         await tagInput.press("1");
         await tagInput.press(",");

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -229,4 +229,40 @@ test.describe("Sensitivity tests", () => {
         await expectSummaryValues(page, 65, "I (Set 1)", 1000, "#cccc00", "dot", "0", "100", "0", "0");
         await expectSummaryValues(page, 66, "R (Set 1)", 1000, "#cc0044", "dot", "0", "100", "0", "0");
     });
+
+    test("can change sensitivity settings to User variation, and see values in Sensitivity plot", async ({ page }) => {
+        await page.click("#sensitivity-options .btn-primary");
+        await expect(await page.locator("#edit-param .modal")).toBeVisible();
+        const varSelect = await page.locator("#edit-variation-type select");
+        await varSelect.selectOption("User");
+        await expect(await page.innerText("#invalid-msg"))
+            .toBe("Invalid settings: Must include at least 2 traces in the batch");
+
+        const tagInput = await page.locator("#edit-values input");
+        await tagInput.press("1");
+        await tagInput.press(",");
+        await tagInput.press("2");
+        await tagInput.press(",");
+        await tagInput.press("3");
+        await tagInput.press(",");
+
+        await page.waitForTimeout(100)
+        await expect(await page.locator("#invalid-msg").count()).toBe(0);
+        await expect(await page.locator(".modal .alert-success").count()).toBe(0);
+
+        await page.click("#ok-settings");
+
+        // run and see traces summary
+        await page.click("#run-sens-btn");
+        await expectSummaryValues(page, 1, "S (beta=1.000)", 1000, "#2e5cb8");
+        await expectSummaryValues(page, 2, "I (beta=1.000)", 1000, "#cccc00");
+        await expectSummaryValues(page, 3, "R (beta=1.000)", 1000, "#cc0044");
+        await expectSummaryValues(page, 4, "S (beta=2.000)", 1000, "#2e5cb8");
+        await expectSummaryValues(page, 5, "I (beta=2.000)", 1000, "#cccc00");
+        await expectSummaryValues(page, 6, "R (beta=2.000)", 1000, "#cc0044");
+        await expectSummaryValues(page, 7, "S (beta=3.000)", 1000, "#2e5cb8");
+        await expectSummaryValues(page, 8, "I (beta=3.000)", 1000, "#cccc00");
+        await expectSummaryValues(page, 9, "R (beta=3.000)", 1000, "#cc0044");
+
+    });
 });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -157,7 +157,8 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
             variationPercentage: 10,
             rangeFrom: 0,
             rangeTo: 0,
-            numberOfRuns: 10
+            numberOfRuns: 10,
+            userValues: []
         },
         plotSettings: {
             plotType: SensitivityPlotType.TraceOverTime,

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -158,7 +158,7 @@ export const mockSensitivityState = (state: Partial<SensitivityState> = {}): Sen
             rangeFrom: 0,
             rangeTo: 0,
             numberOfRuns: 10,
-            userValues: []
+            customValues: []
         },
         plotSettings: {
             plotType: SensitivityPlotType.TraceOverTime,

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -14,6 +14,7 @@ import NumericInput from "../../../../src/app/components/options/NumericInput.vu
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivityParamValues from "../../../../src/app/components/options/SensitivityParamValues.vue";
 import { expectCloseNumericArray } from "../../../testUtils";
+import TagInput from "../../../../src/app/components/options/TagInput.vue";
 
 const mockTooltipDirective = jest.fn();
 
@@ -41,14 +42,14 @@ describe("EditParamSettings", () => {
     };
 
     const userSettings = {
-        parameterToVary: "B",
+        parameterToVary: "C",
         scaleType: SensitivityScaleType.Arithmetic,
         variationType: SensitivityVariationType.User,
         variationPercentage: 10,
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 5,
-        userValues: [1,2,3]
+        userValues: [1, 2, 3]
     };
 
     const mockRunner = {
@@ -56,7 +57,7 @@ describe("EditParamSettings", () => {
         batchParsRange: mockBatchParsRange
     } as any;
 
-    const parameterValues = { A: 1, B: 2 };
+    const parameterValues = { A: 1, B: 2, C: 3 };
 
     const getWrapper = async (paramSettings: SensitivityParameterSettings, open = true,
         mockSetParamSettings = jest.fn()) => {
@@ -183,8 +184,21 @@ describe("EditParamSettings", () => {
         expect(wrapper.find("#invalid-msg").exists()).toBe(false);
     });
 
-    it("renders as expected when variation type is User", () => {
-
+    it("renders as expected when variation type is User", async () => {
+        const wrapper = await getWrapper(userSettings);
+        const paramSelect = wrapper.find("#edit-param-to-vary select");
+        expect((paramSelect.element as HTMLSelectElement).value).toBe("C");
+        const varSelect = wrapper.find("#edit-variation-type select");
+        expect((varSelect.element as HTMLSelectElement).value).toBe(SensitivityVariationType.User);
+        const tagInput = wrapper.find("#edit-values").findComponent(TagInput);
+        expect(tagInput.props().tags).toStrictEqual([1, 2, 3]);
+        expect(tagInput.props().numericOnly).toBe(true);
+        expect(wrapper.find("#edit-scale-type").exists()).toBe(false);
+        expect(wrapper.find("#edit-percent").exists()).toBe(false);
+        expect(wrapper.find("#edit-from").exists()).toBe(false);
+        expect(wrapper.find("#edit-to").exists()).toBe(false);
+        expect(wrapper.find("#edit-runs").exists()).toBe(false);
+        expect(wrapper.findComponent(SensitivityParamValues).exists()).toBe(false);
     });
 
     it("disables OK and renders message when settings are invalid", async () => {

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -25,7 +25,8 @@ describe("EditParamSettings", () => {
         variationPercentage: 10,
         rangeFrom: 0,
         rangeTo: 0,
-        numberOfRuns: 5
+        numberOfRuns: 5,
+        userValues: []
     };
 
     const rangeSettings = {
@@ -35,7 +36,19 @@ describe("EditParamSettings", () => {
         variationPercentage: 0,
         rangeFrom: 2,
         rangeTo: 6,
-        numberOfRuns: 5
+        numberOfRuns: 5,
+        userValues: []
+    };
+
+    const userSettings = {
+        parameterToVary: "B",
+        scaleType: SensitivityScaleType.Arithmetic,
+        variationType: SensitivityVariationType.User,
+        variationPercentage: 10,
+        rangeFrom: 0,
+        rangeTo: 0,
+        numberOfRuns: 5,
+        userValues: [1,2,3]
     };
 
     const mockRunner = {
@@ -168,6 +181,10 @@ describe("EditParamSettings", () => {
 
         expect(wrapper.find(".modal-footer button.btn-primary").attributes("disabled")).toBe(undefined);
         expect(wrapper.find("#invalid-msg").exists()).toBe(false);
+    });
+
+    it("renders as expected when variation type is User", () => {
+
     });
 
     it("disables OK and renders message when settings are invalid", async () => {

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -1,5 +1,6 @@
 import Vuex from "vuex";
 import { mount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
 import {
     SensitivityParameterSettings,
     SensitivityScaleType,
@@ -16,7 +17,6 @@ import SensitivityParamValues from "../../../../src/app/components/options/Sensi
 import { expectCloseNumericArray } from "../../../testUtils";
 import TagInput from "../../../../src/app/components/options/TagInput.vue";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
-import {nextTick} from "vue";
 
 const mockTooltipDirective = jest.fn();
 
@@ -314,7 +314,7 @@ describe("EditParamSettings", () => {
     });
 
     it("test set", () => {
-        const cleaned = [...new Set([1, 2, 1])].sort()
-        expect(cleaned).toStrictEqual([1, 2])
+        const cleaned = [...new Set([1, 2, 1])].sort();
+        expect(cleaned).toStrictEqual([1, 2]);
     });
 });

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -301,11 +301,11 @@ describe("EditParamSettings", () => {
         expect(wrapper.findComponent(ErrorInfo).exists()).toBe(false);
     });
 
-    it("updates values from TagInput, dedupes and sorts", async () => {
+    it("updates values from TagInput", async () => {
         const mockSetParamSettings = jest.fn();
         const wrapper = await getWrapper(customSettings, true, mockSetParamSettings);
-        wrapper.findComponent(TagInput).vm.$emit("update", [5, 1, 5, 0, -1, -2, 1]);
-        const expectedValues = [-2, -1, 0, 1, 5];
+        const expectedValues = [-1, 0, 1];
+        wrapper.findComponent(TagInput).vm.$emit("update", expectedValues);
         await nextTick();
         expect((wrapper.vm as any).settingsInternal.customValues).toStrictEqual(expectedValues);
         await wrapper.find("#ok-settings").trigger("click");
@@ -314,8 +314,14 @@ describe("EditParamSettings", () => {
         expect(committed.customValues).toStrictEqual(expectedValues);
     });
 
-    it("test set", () => {
-        const cleaned = [...new Set([1, 2, 1])].sort();
-        expect(cleaned).toStrictEqual([1, 2]);
+    it("sorts custom values on commit", async () => {
+        const mockSetParamSettings = jest.fn();
+        const wrapper = await getWrapper(customSettings, true, mockSetParamSettings);
+        wrapper.findComponent(TagInput).vm.$emit("update", [5, 1, 0, -2, -1]);
+        await wrapper.find("#ok-settings").trigger("click");
+        expect(mockSetParamSettings.mock.calls[0][1]).toStrictEqual({
+            ...customSettings,
+            customValues: [-2, -1, 0, 1, 5]
+        });
     });
 });

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -123,9 +123,10 @@ describe("EditParamSettings", () => {
         const paramSelect = wrapper.find("#edit-param-to-vary select");
         expect((paramSelect.element as HTMLSelectElement).value).toBe("B");
         const paramOptions = paramSelect.findAll("option");
-        expect(paramOptions.length).toBe(2);
+        expect(paramOptions.length).toBe(3);
         expect(paramOptions.at(0)!.text()).toBe("A");
         expect(paramOptions.at(1)!.text()).toBe("B");
+        expect(paramOptions.at(2)!.text()).toBe("C");
 
         expect(wrapper.find("#edit-scale-type label").text()).toBe("Scale type");
         const scaleSelect = wrapper.find("#edit-scale-type select");
@@ -139,9 +140,10 @@ describe("EditParamSettings", () => {
         const varSelect = wrapper.find("#edit-variation-type select");
         expect((varSelect.element as HTMLSelectElement).value).toBe(SensitivityVariationType.Percentage);
         const varOptions = varSelect.findAll("option");
-        expect(varOptions.length).toBe(2);
+        expect(varOptions.length).toBe(3);
         expect(varOptions.at(0)!.text()).toBe(SensitivityVariationType.Percentage);
         expect(varOptions.at(1)!.text()).toBe(SensitivityVariationType.Range);
+        expect(varOptions.at(2)!.text()).toBe(SensitivityVariationType.User);
 
         expect(wrapper.find("#edit-percent label").text()).toBe("Variation (%)");
         expect(wrapper.find("#edit-percent").findComponent(NumericInput).props("value")).toBe(10);
@@ -253,7 +255,8 @@ describe("EditParamSettings", () => {
             variationPercentage: 15,
             rangeFrom: 1,
             rangeTo: 3,
-            numberOfRuns: 11
+            numberOfRuns: 11,
+            userValues: []
         });
     });
 

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -29,7 +29,7 @@ describe("EditParamSettings", () => {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 5,
-        userValues: []
+        customValues: []
     };
 
     const rangeSettings = {
@@ -40,18 +40,18 @@ describe("EditParamSettings", () => {
         rangeFrom: 2,
         rangeTo: 6,
         numberOfRuns: 5,
-        userValues: []
+        customValues: []
     };
 
-    const userSettings = {
+    const customSettings = {
         parameterToVary: "C",
         scaleType: SensitivityScaleType.Arithmetic,
-        variationType: SensitivityVariationType.User,
+        variationType: SensitivityVariationType.Custom,
         variationPercentage: 10,
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 5,
-        userValues: [1, 2, 3]
+        customValues: [1, 2, 3]
     };
 
     const mockRunner = {
@@ -143,7 +143,7 @@ describe("EditParamSettings", () => {
         expect(varOptions.length).toBe(3);
         expect(varOptions.at(0)!.text()).toBe(SensitivityVariationType.Percentage);
         expect(varOptions.at(1)!.text()).toBe(SensitivityVariationType.Range);
-        expect(varOptions.at(2)!.text()).toBe(SensitivityVariationType.User);
+        expect(varOptions.at(2)!.text()).toBe(SensitivityVariationType.Custom);
 
         expect(wrapper.find("#edit-percent label").text()).toBe("Variation (%)");
         expect(wrapper.find("#edit-percent").findComponent(NumericInput).props("value")).toBe(10);
@@ -188,12 +188,12 @@ describe("EditParamSettings", () => {
         expect(wrapper.find("#invalid-msg").exists()).toBe(false);
     });
 
-    it("renders as expected when variation type is User", async () => {
-        const wrapper = await getWrapper(userSettings);
+    it("renders as expected when variation type is Custom", async () => {
+        const wrapper = await getWrapper(customSettings);
         const paramSelect = wrapper.find("#edit-param-to-vary select");
         expect((paramSelect.element as HTMLSelectElement).value).toBe("C");
         const varSelect = wrapper.find("#edit-variation-type select");
-        expect((varSelect.element as HTMLSelectElement).value).toBe(SensitivityVariationType.User);
+        expect((varSelect.element as HTMLSelectElement).value).toBe(SensitivityVariationType.Custom);
         const tagInput = wrapper.find("#edit-values").findComponent(TagInput);
         expect(tagInput.props().tags).toStrictEqual([1, 2, 3]);
         expect(tagInput.props().numericOnly).toBe(true);
@@ -256,7 +256,7 @@ describe("EditParamSettings", () => {
             rangeFrom: 1,
             rangeTo: 3,
             numberOfRuns: 11,
-            userValues: []
+            customValues: []
         });
     });
 
@@ -287,30 +287,30 @@ describe("EditParamSettings", () => {
         expect(rangeSpy.mock.calls[2][5]).toBe(3);
     });
 
-    it("displays error when User variation type, and there are less than 2 values", async () => {
+    it("displays error when Custom variation type, and there are less than 2 values", async () => {
         const expectError = (wrapper: VueWrapper<any>) => {
             expect(wrapper.findComponent(ErrorInfo).props().error).toStrictEqual({
                 error: "Invalid settings", detail: "Must include at least 2 traces in the batch"
             });
         };
-        expectError(await getWrapper({ ...userSettings, userValues: [] }));
-        expectError(await getWrapper({ ...userSettings, userValues: [1] }));
+        expectError(await getWrapper({ ...customSettings, customValues: [] }));
+        expectError(await getWrapper({ ...customSettings, customValues: [1] }));
 
-        const wrapper = await getWrapper({ ...userSettings, userValues: [1, 2] });
+        const wrapper = await getWrapper({ ...customSettings, customValues: [1, 2] });
         expect(wrapper.findComponent(ErrorInfo).exists()).toBe(false);
     });
 
     it("updates values from TagInput, dedupes and sorts", async () => {
         const mockSetParamSettings = jest.fn();
-        const wrapper = await getWrapper(userSettings, true, mockSetParamSettings);
+        const wrapper = await getWrapper(customSettings, true, mockSetParamSettings);
         wrapper.findComponent(TagInput).vm.$emit("update", [5, 1, 5, 0, -1, -2, 1]);
         const expectedValues = [-2, -1, 0, 1, 5];
         await nextTick();
-        expect((wrapper.vm as any).settingsInternal.userValues).toStrictEqual(expectedValues);
+        expect((wrapper.vm as any).settingsInternal.customValues).toStrictEqual(expectedValues);
         await wrapper.find("#ok-settings").trigger("click");
         expect(mockSetParamSettings).toHaveBeenCalledTimes(1);
         const committed = mockSetParamSettings.mock.calls[0][1];
-        expect(committed.userValues).toStrictEqual(expectedValues);
+        expect(committed.customValues).toStrictEqual(expectedValues);
     });
 
     it("test set", () => {

--- a/app/static/tests/unit/components/options/editParamSettings.test.ts
+++ b/app/static/tests/unit/components/options/editParamSettings.test.ts
@@ -194,6 +194,7 @@ describe("EditParamSettings", () => {
         expect((paramSelect.element as HTMLSelectElement).value).toBe("C");
         const varSelect = wrapper.find("#edit-variation-type select");
         expect((varSelect.element as HTMLSelectElement).value).toBe(SensitivityVariationType.Custom);
+        expect(wrapper.find("#param-central").text()).toBe("Central value 3");
         const tagInput = wrapper.find("#edit-values").findComponent(TagInput);
         expect(tagInput.props().tags).toStrictEqual([1, 2, 3]);
         expect(tagInput.props().numericOnly).toBe(true);

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -73,8 +73,8 @@ describe("SensitivityOptions", () => {
         const listItems = wrapper.findAll("ul li");
         expect(listItems.length).toBe(5);
         expect(listItems.at(0)!.text()).toBe("Parameter: B");
-        expect(listItems.at(1)!.text()).toBe("Scale Type: Arithmetic");
-        expect(listItems.at(2)!.text()).toBe("Variation Type: Percentage");
+        expect(listItems.at(1)!.text()).toBe("Variation Type: Percentage");
+        expect(listItems.at(2)!.text()).toBe("Scale Type: Arithmetic");
         expect(listItems.at(3)!.text()).toBe("Variation (%): 10");
         expect(listItems.at(4)!.text()).toBe("Number of runs: 5");
 
@@ -104,8 +104,8 @@ describe("SensitivityOptions", () => {
         const listItems = wrapper.findAll("ul li");
         expect(listItems.length).toBe(6);
         expect(listItems.at(0)!.text()).toBe("Parameter: B");
-        expect(listItems.at(1)!.text()).toBe("Scale Type: Logarithmic");
-        expect(listItems.at(2)!.text()).toBe("Variation Type: Range");
+        expect(listItems.at(1)!.text()).toBe("Variation Type: Range");
+        expect(listItems.at(2)!.text()).toBe("Scale Type: Logarithmic");
         expect(listItems.at(3)!.text()).toBe("From: 1");
         expect(listItems.at(4)!.text()).toBe("To: 3");
         expect(listItems.at(5)!.text()).toBe("Number of runs: 5");

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -60,7 +60,8 @@ describe("SensitivityOptions", () => {
         variationPercentage: 10,
         rangeFrom: 0,
         rangeTo: 0,
-        numberOfRuns: 5
+        numberOfRuns: 5,
+        userValues: []
     };
 
     it("displays percentage variance as expected", () => {
@@ -96,7 +97,8 @@ describe("SensitivityOptions", () => {
             variationPercentage: 10,
             rangeFrom: 1,
             rangeTo: 3,
-            numberOfRuns: 5
+            numberOfRuns: 5,
+            userValues: []
         });
 
         const listItems = wrapper.findAll("ul li");
@@ -107,6 +109,25 @@ describe("SensitivityOptions", () => {
         expect(listItems.at(3)!.text()).toBe("From: 1");
         expect(listItems.at(4)!.text()).toBe("To: 3");
         expect(listItems.at(5)!.text()).toBe("Number of runs: 5");
+    });
+
+    it("displays user-specified values as expected", () => {
+        const wrapper = getWrapper({
+            parameterToVary: "C",
+            scaleType: SensitivityScaleType.Logarithmic,
+            variationType: SensitivityVariationType.User,
+            variationPercentage: 10,
+            rangeFrom: 1,
+            rangeTo: 3,
+            numberOfRuns: 5,
+            userValues: [1, 2, 3]
+        });
+
+        const listItems = wrapper.findAll("ul li");
+        expect(listItems.length).toBe(3);
+        expect(listItems.at(0)!.text()).toBe("Parameter: C");
+        expect(listItems.at(1)!.text()).toBe("Variation Type: User");
+        expect(listItems.at(2)!.text()).toBe("Values: 1, 2, 3");
     });
 
     it("opens and closes edit dialog", async () => {

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -61,7 +61,7 @@ describe("SensitivityOptions", () => {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 5,
-        userValues: []
+        customValues: []
     };
 
     it("displays percentage variance as expected", () => {
@@ -98,7 +98,7 @@ describe("SensitivityOptions", () => {
             rangeFrom: 1,
             rangeTo: 3,
             numberOfRuns: 5,
-            userValues: []
+            customValues: []
         });
 
         const listItems = wrapper.findAll("ul li");
@@ -111,22 +111,22 @@ describe("SensitivityOptions", () => {
         expect(listItems.at(5)!.text()).toBe("Number of runs: 5");
     });
 
-    it("displays user-specified values as expected", () => {
+    it("displays custom values as expected", () => {
         const wrapper = getWrapper({
             parameterToVary: "C",
             scaleType: SensitivityScaleType.Logarithmic,
-            variationType: SensitivityVariationType.User,
+            variationType: SensitivityVariationType.Custom,
             variationPercentage: 10,
             rangeFrom: 1,
             rangeTo: 3,
             numberOfRuns: 5,
-            userValues: [1, 2, 3]
+            customValues: [1, 2, 3]
         });
 
         const listItems = wrapper.findAll("ul li");
         expect(listItems.length).toBe(3);
         expect(listItems.at(0)!.text()).toBe("Parameter: C");
-        expect(listItems.at(1)!.text()).toBe("Variation Type: User");
+        expect(listItems.at(1)!.text()).toBe("Variation Type: Custom");
         expect(listItems.at(2)!.text()).toBe("Values: 1, 2, 3");
     });
 

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -89,4 +89,15 @@ describe("Tag Input", () => {
         (tagsInput.vm as any).$emit("on-tags-changed", ["1", "2", "p2", "p1: 1.1", "p3"]);
         expect(wrapper.emitted("update")![0]).toStrictEqual([[1, 2]]);
     });
+
+    it("resets input value model on error", async () => {
+        const wrapper = getWrapper();
+        const vm = wrapper.vm as any;
+        vm.currentTag = "blah";
+        await nextTick();
+        const vueTagsInput = wrapper.findComponent(VueTagsInput);
+        expect(vueTagsInput.props().modelValue).toBe("blah");
+        await vueTagsInput.vm.$emit("on-error");
+        expect(vueTagsInput.props().modelValue).toBe("");
+    });
 });

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -76,7 +76,7 @@ describe("Tag Input", () => {
     });
 
     it("renders as expected when numeric only is true", () => {
-        const wrapper = getWrapper({ ...defaultProps, numericOnly: true});
+        const wrapper = getWrapper({ ...defaultProps, numericOnly: true });
         const tagsInput = wrapper.findComponent(VueTagsInput);
         // should filter out non-numeric tags
         expect(tagsInput.props("tags")).toStrictEqual(["1", "2"]);

--- a/app/static/tests/unit/components/options/tagInput.test.ts
+++ b/app/static/tests/unit/components/options/tagInput.test.ts
@@ -17,7 +17,8 @@ describe("Tag Input", () => {
     };
 
     const defaultProps = {
-        tags: [1, 2, "p1", "p2", "p3"]
+        tags: [1, 2, "p1", "p2", "p3"],
+        numericOnly: false
     };
 
     const getWrapper = (props = defaultProps) => {
@@ -72,5 +73,20 @@ describe("Tag Input", () => {
         store.state.run.parameterValues = { a: 2 };
         await nextTick();
         expect(wrapper.emitted("update")![0]).toStrictEqual([["1", "hey"]]);
+    });
+
+    it("renders as expected when numeric only is true", () => {
+        const wrapper = getWrapper({ ...defaultProps, numericOnly: true});
+        const tagsInput = wrapper.findComponent(VueTagsInput);
+        // should filter out non-numeric tags
+        expect(tagsInput.props("tags")).toStrictEqual(["1", "2"]);
+        expect(tagsInput.props("placeholder")).toBe("...");
+    });
+
+    it("does not accept update with valid parameter tags when numericOnly is true", () => {
+        const wrapper = getWrapper({ ...defaultProps, numericOnly: true });
+        const tagsInput = wrapper.findComponent(VueTagsInput);
+        (tagsInput.vm as any).$emit("on-tags-changed", ["1", "2", "p2", "p1: 1.1", "p3"]);
+        expect(wrapper.emitted("update")![0]).toStrictEqual([[1, 2]]);
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -156,7 +156,8 @@ describe("serialise", () => {
             variationPercentage: 50,
             rangeFrom: 0,
             rangeTo: 1,
-            numberOfRuns: 5
+            numberOfRuns: 5,
+            userValues: []
         },
         sensitivityUpdateRequired: {
             modelChanged: false,

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -157,7 +157,7 @@ describe("serialise", () => {
             rangeFrom: 0,
             rangeTo: 1,
             numberOfRuns: 5,
-            userValues: []
+            customValues: []
         },
         sensitivityUpdateRequired: {
             modelChanged: false,

--- a/app/static/tests/unit/store/sensitivity/getters.test.ts
+++ b/app/static/tests/unit/store/sensitivity/getters.test.ts
@@ -10,7 +10,8 @@ describe("Sensitivity getters", () => {
         variationPercentage: 50,
         rangeFrom: 0,
         rangeTo: 0,
-        numberOfRuns: 3
+        numberOfRuns: 3,
+        userValues: []
     };
 
     it("generates batchPars", () => {

--- a/app/static/tests/unit/store/sensitivity/getters.test.ts
+++ b/app/static/tests/unit/store/sensitivity/getters.test.ts
@@ -11,7 +11,7 @@ describe("Sensitivity getters", () => {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 3,
-        userValues: []
+        customValues: []
     };
 
     it("generates batchPars", () => {

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -302,7 +302,7 @@ describe("processFitData", () => {
 });
 
 describe("generateBatchPars", () => {
-    const parameterValues = { A: 1, B: 2 };
+    const parameterValues = { A: 1, B: 2, C: 3 };
 
     const rootState = {
         model: {
@@ -330,7 +330,8 @@ describe("generateBatchPars", () => {
         variationPercentage: 50,
         rangeFrom: 0,
         rangeTo: 0,
-        numberOfRuns: 5
+        numberOfRuns: 5,
+        userValues: []
     };
 
     const rangeSettings = {
@@ -340,7 +341,19 @@ describe("generateBatchPars", () => {
         variationPercentage: 50,
         rangeFrom: 2,
         rangeTo: 6,
-        numberOfRuns: 9
+        numberOfRuns: 9,
+        userValues: []
+    };
+
+    const userSettings = {
+        parameterToVary: "C",
+        scaleType: SensitivityScaleType.Arithmetic,
+        variationType: SensitivityVariationType.User,
+        variationPercentage: 50,
+        rangeFrom: 2,
+        rangeTo: 6,
+        numberOfRuns: 9,
+        userValues: [1, 2, 3]
     };
 
     it("generates BatchPars for Percentage variation type", () => {
@@ -371,6 +384,16 @@ describe("generateBatchPars", () => {
         expect(spyBatchParsRange.mock.calls[0][3]).toStrictEqual(false);
         expect(spyBatchParsRange.mock.calls[0][4]).toStrictEqual(2);
         expect(spyBatchParsRange.mock.calls[0][5]).toStrictEqual(6);
+    });
+
+    it("generates BatchPars for User variation type", () => {
+        const result = generateBatchPars(rootState, userSettings, parameterValues)!;
+        expect(result.error).toBe(null);
+        expect(result.batchPars!.name).toBe("C");
+        expect(result.batchPars!.base).toBe(parameterValues);
+        expect(result.batchPars!.values).toStrictEqual([1, 2, 3]);
+        expect(spyBatchParsDisplace).not.toHaveBeenCalled();
+        expect(spyBatchParsRange).not.toHaveBeenCalled();
     });
 
     const expectedNotInitialisedError = { error: "Invalid settings", detail: "Model is not initialised" };

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -331,7 +331,7 @@ describe("generateBatchPars", () => {
         rangeFrom: 0,
         rangeTo: 0,
         numberOfRuns: 5,
-        userValues: []
+        customValues: []
     };
 
     const rangeSettings = {
@@ -342,18 +342,18 @@ describe("generateBatchPars", () => {
         rangeFrom: 2,
         rangeTo: 6,
         numberOfRuns: 9,
-        userValues: []
+        customValues: []
     };
 
-    const userSettings = {
+    const customSettings = {
         parameterToVary: "C",
         scaleType: SensitivityScaleType.Arithmetic,
-        variationType: SensitivityVariationType.User,
+        variationType: SensitivityVariationType.Custom,
         variationPercentage: 50,
         rangeFrom: 2,
         rangeTo: 6,
         numberOfRuns: 9,
-        userValues: [1, 2, 3]
+        customValues: [1, 2, 3]
     };
 
     it("generates BatchPars for Percentage variation type", () => {
@@ -386,8 +386,8 @@ describe("generateBatchPars", () => {
         expect(spyBatchParsRange.mock.calls[0][5]).toStrictEqual(6);
     });
 
-    it("generates BatchPars for User variation type", () => {
-        const result = generateBatchPars(rootState, userSettings, parameterValues)!;
+    it("generates BatchPars for Custom variation type", () => {
+        const result = generateBatchPars(rootState, customSettings, parameterValues)!;
         expect(result.error).toBe(null);
         expect(result.batchPars!.name).toBe("C");
         expect(result.batchPars!.base).toBe(parameterValues);


### PR DESCRIPTION
This branch adds a new sensitivity parameter settings variation type, "User", to the existing types ("Percentage" and "Range"). This allows the user to manually specify the parameter values to use in the sensitivity run.

On reflection, "User" maybe isn't a great term to surface to the, err, user. What would be better? "Values"? "Specific"?

This isn't doing any validation that the parameter's central value is between the lowest and highest values specified - should it?

Key changes:
- `userValues` number array added to the settings type to hold these values
- `EditParamSettings` dialog updated to support editing these values using the `TagInput`, plus read-only display in the options tab. The green alert showing generated values is not displayed for user values (as would be showing the same values twice) - I guess we could just show this in the read-only tab view but it feels better to have the user values displayed like the other user settings, and keep the green box for generated values. 
- We don't need to generate batchPars using odin's helper methods for this variation type as we already know the parameter values to use, so the validation and run sensitivity code has been modified to allow this. 
- To be consistent with the other variation types, a minimum of two user values are required. 
- Values are de-duped and sorted as they are entered. 
