### PR TITLE
mrc-4521 Default to i18n not enabled

### DIFF
--- a/app/server/src/controllers/appsController.ts
+++ b/app/server/src/controllers/appsController.ts
@@ -42,7 +42,7 @@ export class AppsController {
                     loadSessionId: sessionId || "",
                     shareNotFound: shareNotFound || "",
                     mathjaxSrc: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js",
-                    enableI18n: wodinConfig.enableI18n ?? true, // if option not set then true by default
+                    enableI18n: wodinConfig.enableI18n ?? false, // if option not set then false by default
                     defaultLanguage: wodinConfig?.defaultLanguage || "en"
                 };
                 res.render("app", viewOptions);

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -82,7 +82,7 @@ describe("appsController", () => {
             shareNotFound: "",
             mathjaxSrc,
             defaultLanguage: "en",
-            enableI18n: true
+            enableI18n: false
         });
         expect(mockStatus).not.toBeCalled();
     });

--- a/app/server/tests/controllers/appsController.test.ts
+++ b/app/server/tests/controllers/appsController.test.ts
@@ -104,7 +104,7 @@ describe("appsController", () => {
             shareNotFound: "",
             mathjaxSrc,
             defaultLanguage: "en",
-            enableI18n: true
+            enableI18n: false
         });
     });
 
@@ -130,7 +130,7 @@ describe("appsController", () => {
             shareNotFound: "",
             mathjaxSrc,
             defaultLanguage: "en",
-            enableI18n: true
+            enableI18n: false
         });
     });
 
@@ -154,7 +154,7 @@ describe("appsController", () => {
             shareNotFound: "tiny-mouse",
             mathjaxSrc,
             defaultLanguage: "en",
-            enableI18n: true
+            enableI18n: false
         });
     });
 

--- a/app/static/tests/e2e/tabs.etest.ts
+++ b/app/static/tests/e2e/tabs.etest.ts
@@ -9,8 +9,7 @@ test.describe("Wodin App tabs tests", () => {
         expect(await page.innerText("nav a.navbar-brand")).toBe("WODIN Example");
         expect(await page.getAttribute("nav a.navbar-brand", "href")).toBe("http://localhost:3000");
         expect(await page.innerText("nav .navbar-app")).toBe("Day 1 - Basic Model");
-        expect(await page.innerText("nav .navbar-version >> nth=1")).toMatch(/^WODIN v[0-9].[0-9].[0-9]$/);
-        expect(await page.innerText("nav span .navbar-text >> nth=0")).toBe("English");
+        expect(await page.innerText("nav .navbar-version >> nth=0")).toMatch(/^WODIN v[0-9].[0-9].[0-9]$/);
     });
 
     test("link in header navigates to index page", async ({ page }) => {
@@ -58,13 +57,5 @@ test.describe("Wodin App tabs tests", () => {
         await expect(await page.innerText(".wodin-right .wodin-content .nav-tabs .active")).toBe("Sensitivity");
         await expect(await page.innerText(".wodin-right .wodin-content div.mt-4 button"))
             .toBe("Run sensitivity");
-    });
-
-    test("can change language to French", async ({ page }) => {
-        const languageSwitcher = await page.locator("nav span .navbar-text >> nth=0");
-        await languageSwitcher.click();
-        const frenchMenuItem = await languageSwitcher.locator(".dropdown-item >> nth=1");
-        await frenchMenuItem.click();
-        expect(await page.innerText("nav span .navbar-text >> nth=0")).toBe("Français");
     });
 });

--- a/config/wodin.config.json
+++ b/config/wodin.config.json
@@ -6,6 +6,6 @@
     "baseUrl": "http://localhost:3000",
     "odinApi": "http://localhost:8001",
     "redisUrl": "redis://localhost:6379",
-    "enableI18n": true,
+    "enableI18n": false,
     "defaultLanguage": "en"
 }


### PR DESCRIPTION
Switches off i18n by default so language switcher will not be displayed if `enablei18n` is not included in `wodin.config.json`.

Also switches off i18n in the dev config. 