### PR TITLE
mrc-3710redo Enforced max number of replicates

### DIFF
--- a/app/server/src/controllers/configController.ts
+++ b/app/server/src/controllers/configController.ts
@@ -16,7 +16,7 @@ export const configDefaults = (appType: string) => {
         return {
             ...base,
             maxReplicatesRun: 1000,
-            maxReplicatesDisplay: 20
+            maxReplicatesDisplay: 50
         };
     }
     return base;

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -123,7 +123,11 @@ export default defineComponent({
 
         onMounted(drawPlot);
 
-        watch([() => props.redrawWatches, yAxisType], drawPlot);
+        watch([() => props.redrawWatches, yAxisType], () => {
+            if (plotStyle.value !== fadePlotStyle) {
+                drawPlot()
+            }
+        });
 
         onUnmounted(() => {
             if (resizeObserver) {

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -149,12 +149,12 @@ export default defineComponent({
 
         watch([() => props.redrawWatches, lockYAxis], () => {
             if (plotStyle.value !== fadePlotStyle) {
-                drawPlot()
+                drawPlot();
             }
         });
         watch(yAxisType, () => {
             if (plotStyle.value !== fadePlotStyle) {
-                drawPlot(true)
+                drawPlot(true);
             }
         });
 

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -125,7 +125,7 @@ export default defineComponent({
 
         watch([() => props.redrawWatches, yAxisType], () => {
             if (plotStyle.value !== fadePlotStyle) {
-                drawPlot()
+                drawPlot();
             }
         });
 

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -78,7 +78,7 @@ export default defineComponent({
                 // wrap tooltip props update with update to input box
                 // as the v-tooltip directive needs an update to actually
                 // hide the tooltip
-                textValue.value = textValue.value + " ";
+                textValue.value = `${textValue.value} `;
                 tooltipProps.value.content = "";
                 textValue.value = textValue.value.trim();
             }
@@ -108,9 +108,8 @@ export default defineComponent({
                 if (numeric > props.maxAllowed) {
                     tooltipProps.value.content = `Please enter a value no greater than ${props.maxAllowed}`;
                     return props.maxAllowed;
-                } else {
-                    tooltipProps.value.content = "";
                 }
+                tooltipProps.value.content = "";
             }
 
             if (typeof props.minAllowed === "number") {
@@ -118,15 +117,14 @@ export default defineComponent({
                     tooltipProps.value.content = (props.minAllowed === 0)
                         ? "Please enter a non-negative number"
                         : `Please enter a value no less than ${props.minAllowed}`;
-                    return props.minAllowed
-                } else {
-                    tooltipProps.value.content = "";
+                    return props.minAllowed;
                 }
+                tooltipProps.value.content = "";
             }
 
             if (Array.isArray(props.maxAllowed) && props.maxAllowed.length > 0) {
                 const maxesAllowed = [...props.maxAllowed] as BoundTooltip[];
-                validateArray(maxesAllowed, numeric, true)
+                validateArray(maxesAllowed, numeric, true);
 
                 if (numeric > maxesAllowed.at(-1)!.number) {
                     return maxesAllowed.at(-1)!.number;
@@ -170,7 +168,7 @@ export default defineComponent({
             const cleanedValue = newVal.replace(/,/g, "");
             const numeric = parseFloat(cleanedValue);
             if (!Number.isNaN(numeric)) {
-                let validatedNumeric = minMaxValidation(numeric);
+                const validatedNumeric = minMaxValidation(numeric);
                 lastNumericValueSet.value = validatedNumeric;
                 emit("update", validatedNumeric);
             } else if (props.placeholder) {

--- a/app/static/src/app/components/options/NumericInput.vue
+++ b/app/static/src/app/components/options/NumericInput.vue
@@ -121,7 +121,7 @@ export default defineComponent({
                 if (numeric > error.number) {
                     setMaxTooltip(error.number, error.message);
                     return error.number;
-                } else if (numeric > warning.number) {
+                } if (numeric > warning.number) {
                     setMaxTooltip(warning.number, warning.message, "warning");
                     return numeric;
                 }
@@ -132,7 +132,7 @@ export default defineComponent({
                 if (numeric < error.number) {
                     setMaxTooltip(error.number, error.message);
                     return error.number;
-                } else if (numeric < warning.number) {
+                } if (numeric < warning.number) {
                     setMaxTooltip(warning.number, warning.message, "warning");
                     return numeric;
                 }

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -62,10 +62,10 @@ export default defineComponent({
         const isStochasticApp = computed(() => store.state.appType === AppType.Stochastic);
 
         const maxReplicatesDisplay = computed(() => {
-            return (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
+            return (store.state.config as StochasticConfig)?.maxReplicatesDisplay;
         });
         const maxReplicatesRun = computed(() => {
-            return (store.state.config as StochasticConfig)?.maxReplicatesRun || 1000;
+            return (store.state.config as StochasticConfig)?.maxReplicatesRun;
         });
         const maxAllowedObj = computed(() => {
             return {

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -21,6 +21,7 @@
                 <numeric-input
                     :value="numberOfReplicates"
                     :min-allowed="0"
+                    :max-allowed="maxAllowedArray"
                     @update="updateNumberOfReplicates"></numeric-input>
             </div>
         </div>
@@ -33,8 +34,9 @@ import { useStore } from "vuex";
 import { RunMutation } from "../../store/run/mutations";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
 import { FitDataGetter } from "../../store/fitData/getters";
-import NumericInput from "./NumericInput.vue";
+import NumericInput, { BoundTooltip } from "./NumericInput.vue";
 import { AppType } from "../../store/appState/state";
+import { StochasticConfig } from "../../types/responseTypes";
 
 export default defineComponent({
     name: "RunOptions",
@@ -59,6 +61,26 @@ export default defineComponent({
         const numberOfReplicates = computed(() => store.state.run.numberOfReplicates);
         const isStochasticApp = computed(() => store.state.appType === AppType.Stochastic);
 
+        const maxReplicatesDisplay = computed(() => {
+            return (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
+        });
+        const maxReplicatesRun = computed(() => {
+            return (store.state.config as StochasticConfig)?.maxReplicatesRun || 1000;
+        });
+        const maxAllowedArray = computed(() => {
+            return [
+                {
+                    number: maxReplicatesDisplay.value,
+                    message: 'Individual traces will not be shown past this point',
+                    variant: 'warning'
+                },
+                {
+                    number: maxReplicatesRun.value,
+                    message: `Please enter a value less than ${maxReplicatesRun.value}`
+                }
+            ] as BoundTooltip[]
+        });
+
         const updateNumberOfReplicates = (newValue: number) => {
             store.commit(`run/${RunMutation.SetNumberOfReplicates}`, newValue);
             store.commit(`sensitivity/${SensitivityMutation.SetUpdateRequired}`, {
@@ -72,7 +94,8 @@ export default defineComponent({
             updateEndTime,
             isStochasticApp,
             numberOfReplicates,
-            updateNumberOfReplicates
+            updateNumberOfReplicates,
+            maxAllowedArray
         };
     }
 });

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -21,7 +21,7 @@
                 <numeric-input
                     :value="numberOfReplicates"
                     :min-allowed="0"
-                    :max-allowed="maxAllowedArray"
+                    :max-allowed="maxAllowedObj"
                     @update="updateNumberOfReplicates"></numeric-input>
             </div>
         </div>
@@ -67,18 +67,15 @@ export default defineComponent({
         const maxReplicatesRun = computed(() => {
             return (store.state.config as StochasticConfig)?.maxReplicatesRun || 1000;
         });
-        const maxAllowedArray = computed(() => {
-            return [
-                {
+        const maxAllowedObj = computed(() => {
+            return {
+                error: { number: maxReplicatesRun.value },
+                warning: {
                     number: maxReplicatesDisplay.value,
-                    message: "Individual traces will not be shown past this point",
-                    variant: "warning"
-                },
-                {
-                    number: maxReplicatesRun.value,
-                    message: `Please enter a value less than ${maxReplicatesRun.value}`
+                    message: `Individual traces will not be shown for `
+                        + `values greater than ${maxReplicatesDisplay.value}`
                 }
-            ] as BoundTooltip[];
+            } as BoundTooltip;
         });
 
         const updateNumberOfReplicates = (newValue: number) => {
@@ -95,7 +92,7 @@ export default defineComponent({
             isStochasticApp,
             numberOfReplicates,
             updateNumberOfReplicates,
-            maxAllowedArray
+            maxAllowedObj
         };
     }
 });

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -71,14 +71,14 @@ export default defineComponent({
             return [
                 {
                     number: maxReplicatesDisplay.value,
-                    message: 'Individual traces will not be shown past this point',
-                    variant: 'warning'
+                    message: "Individual traces will not be shown past this point",
+                    variant: "warning"
                 },
                 {
                     number: maxReplicatesRun.value,
                     message: `Please enter a value less than ${maxReplicatesRun.value}`
                 }
-            ] as BoundTooltip[]
+            ] as BoundTooltip[];
         });
 
         const updateNumberOfReplicates = (newValue: number) => {

--- a/app/static/src/app/components/options/RunOptions.vue
+++ b/app/static/src/app/components/options/RunOptions.vue
@@ -72,7 +72,7 @@ export default defineComponent({
                 error: { number: maxReplicatesRun.value },
                 warning: {
                     number: maxReplicatesDisplay.value,
-                    message: `Individual traces will not be shown for `
+                    message: "Individual traces will not be shown for "
                         + `values greater than ${maxReplicatesDisplay.value}`
                 }
             } as BoundTooltip;

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -45,7 +45,7 @@ export default defineComponent({
                 return [];
             }
             const replicates = store.state.run.numberOfReplicates;
-            const maxReplicatesDisplay = (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
+            const maxReplicatesDisplay = (store.state.config as StochasticConfig)?.maxReplicatesDisplay;
             const showIndividualTraces = replicates <= maxReplicatesDisplay;
 
             return discreteSeriesSetToPlotly(

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -48,10 +48,6 @@ export default defineComponent({
             const maxReplicatesDisplay = (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
             const showIndividualTraces = replicates <= maxReplicatesDisplay;
 
-            console.log(replicates)
-            console.log(maxReplicatesDisplay)
-            console.log(showIndividualTraces)
-
             return discreteSeriesSetToPlotly(
                 filterSeriesSet(result, selectedVariables.value),
                 palette.value,

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -48,6 +48,10 @@ export default defineComponent({
             const maxReplicatesDisplay = (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
             const showIndividualTraces = replicates <= maxReplicatesDisplay;
 
+            console.log(replicates)
+            console.log(maxReplicatesDisplay)
+            console.log(showIndividualTraces)
+
             return discreteSeriesSetToPlotly(
                 filterSeriesSet(result, selectedVariables.value),
                 palette.value,

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -15,6 +15,7 @@ import { useStore } from "vuex";
 import { WodinPlotData, discreteSeriesSetToPlotly, filterSeriesSet } from "../../plot";
 import WodinPlot from "../WodinPlot.vue";
 import { runPlaceholderMessage } from "../../utils";
+import { StochasticConfig } from "../../types/responseTypes";
 
 export default defineComponent({
     name: "RunStochasticPlot",
@@ -43,7 +44,15 @@ export default defineComponent({
             if (!result) {
                 return [];
             }
-            return discreteSeriesSetToPlotly(filterSeriesSet(result, selectedVariables.value), palette.value);
+            const replicates = store.state.run.numberOfReplicates;
+            const maxReplicatesDisplay = (store.state.config as StochasticConfig)?.maxReplicatesDisplay || 50;
+            const showIndividualTraces = replicates <= maxReplicatesDisplay;
+
+            return discreteSeriesSetToPlotly(
+                filterSeriesSet(result, selectedVariables.value),
+                palette.value,
+                showIndividualTraces
+            );
         };
 
         return {

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -49,7 +49,6 @@ export default {
 
             const isVariantSame = (tooltip as any)._config.customClass === oldCustomClass;
             if (!isVariantSame) {
-                console.log("creating new tooltips")
                 tooltip.dispose();
 
                 tooltip = new Tooltip(el, {

--- a/app/static/src/app/directives/tooltip.ts
+++ b/app/static/src/app/directives/tooltip.ts
@@ -41,7 +41,28 @@ export default {
     beforeUpdate(el: HTMLElement, binding: DirectiveBinding<string | ToolTipSettings>) {
         const { value } = binding;
 
-        const tooltip = Tooltip.getInstance(el);
+        let tooltip = Tooltip.getInstance(el);
+
+        if (typeof value !== "string" && tooltip) {
+            const variant = value?.variant || "text";
+            const oldCustomClass = (variant === "text") ? "" : `tooltip-${variant}`;
+
+            const isVariantSame = (tooltip as any)._config.customClass === oldCustomClass;
+            if (!isVariantSame) {
+                console.log("creating new tooltips")
+                tooltip.dispose();
+
+                tooltip = new Tooltip(el, {
+                    title: value?.content || "",
+                    placement: value?.placement || "top",
+                    trigger: value?.trigger || "hover",
+                    customClass: (variant === "text") ? "" : `tooltip-${variant}`,
+                    animation: false,
+                    delay: { show: value?.delayMs || 0, hide: 0 }
+                });
+            }
+        }
+
         const content = (typeof value === "string")
             ? value
             : value?.content || "";

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -89,7 +89,7 @@ export function discreteSeriesSetToPlotly(
 ): WodinPlotData {
     const individualLegends: string[] = [];
     const series = showIndividualTraces ? s.values
-        : s.values.filter((el) => el.description !== "Individual"); 
+        : s.values.filter((el) => el.description !== "Individual");
     return series.map(
         (values: OdinSeriesSetValues) => {
             const isIndividual = values.description === "Individual";

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -82,9 +82,15 @@ export function odinToPlotly(s: OdinSeriesSet, palette: Palette, options: Partia
     );
 }
 
-export function discreteSeriesSetToPlotly(s: DiscreteSeriesSet, palette: Palette): WodinPlotData {
+export function discreteSeriesSetToPlotly(
+    s: DiscreteSeriesSet,
+    palette: Palette,
+    showIndividualTraces: boolean
+): WodinPlotData {
     const individualLegends: string[] = [];
-    return s.values.map(
+    const series = showIndividualTraces ? s.values
+        : s.values.filter((el) => el.description !== "Individual"); 
+    return series.map(
         (values: OdinSeriesSetValues) => {
             const isIndividual = values.description === "Individual";
             // show legend if not individual or if individual legend is not yet being shown

--- a/app/static/tests/e2e/stochastic.etest.ts
+++ b/app/static/tests/e2e/stochastic.etest.ts
@@ -46,6 +46,38 @@ test.describe("stochastic app", () => {
         await expectSummaryValues(page, 16, "extinct", 1001, "#cc0044");
     });
 
+    test.only("traces are hidden if replicates are above maxReplicatesDisplay", async ({ page }) => {
+        await page.fill(":nth-match(#run-options input, 2)", "20");
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
+            "Plot is out of date: number of replicates has changed. Run model to update.", {
+                timeout
+            }
+        );
+
+        await page.click("#run-btn");
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText("");
+
+        const summary = ".wodin-plot-data-summary-series";
+        expect(await page.locator(summary).count()).toBe(44);
+
+        await page.fill(":nth-match(#run-options input, 2)", "21");
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
+            "Plot is out of date: number of replicates has changed. Run model to update.", {
+                timeout
+            }
+        );
+
+        await page.click("#run-btn");
+        await expect(await page.locator(".run-tab .action-required-msg")).toHaveText("");
+
+        expect(await page.locator(summary).count()).toBe(4);
+
+        await expectSummaryValues(page, 1, "I_det", 1001, "#2e5cb8");
+        await expectSummaryValues(page, 2, "I (mean)", 1001, "#6ab74d");
+        await expectSummaryValues(page, 3, "S (mean)", 1001, "#ee9f33");
+        await expectSummaryValues(page, 4, "extinct", 1001, "#cc0044");
+    });
+
     test("can run stochastic sensitivity", async ({ page }) => {
         // Open Sensitivity tab
         await page.click(":nth-match(.wodin-right .nav-tabs a, 3)");

--- a/app/static/tests/e2e/stochastic.etest.ts
+++ b/app/static/tests/e2e/stochastic.etest.ts
@@ -46,8 +46,8 @@ test.describe("stochastic app", () => {
         await expectSummaryValues(page, 16, "extinct", 1001, "#cc0044");
     });
 
-    test.only("traces are hidden if replicates are above maxReplicatesDisplay", async ({ page }) => {
-        await page.fill(":nth-match(#run-options input, 2)", "20");
+    test("traces are hidden if replicates are above maxReplicatesDisplay", async ({ page }) => {
+        await page.fill(":nth-match(#run-options input, 2)", "50");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
             "Plot is out of date: number of replicates has changed. Run model to update.", {
                 timeout
@@ -58,9 +58,9 @@ test.describe("stochastic app", () => {
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText("");
 
         const summary = ".wodin-plot-data-summary-series";
-        expect(await page.locator(summary).count()).toBe(44);
+        expect(await page.locator(summary).count()).toBe(104);
 
-        await page.fill(":nth-match(#run-options input, 2)", "21");
+        await page.fill(":nth-match(#run-options input, 2)", "51");
         await expect(await page.locator(".run-tab .action-required-msg")).toHaveText(
             "Plot is out of date: number of replicates has changed. Run model to update.", {
                 timeout

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -154,6 +154,14 @@ describe("NumericInput", () => {
         expect(mockTooltipDirective).toHaveBeenCalledTimes(2);
     });
 
+    it("does min validation when min is 0", async () => {
+        const wrapper = getWrapper(1, Infinity, 0);
+        await wrapper.find("input").setValue("-1");
+        expect(wrapper.emitted("update")![0]).toStrictEqual([0]);
+        const { tooltipProps } = wrapper.vm as any;
+        expect(tooltipProps.content).toBe("Please enter a non-negative number");
+    });
+
     it("does min validation (array)", async () => {
         const wrapper = getWrapper(12, Infinity, [
             { number: 12, message: "middle tooltip" },

--- a/app/static/tests/unit/components/options/numericInput.test.ts
+++ b/app/static/tests/unit/components/options/numericInput.test.ts
@@ -140,7 +140,7 @@ describe("NumericInput", () => {
     it("does max validation (array)", async () => {
         const wrapper = getWrapper(10, {
             error: { number: 12, message: "high tooltip" },
-            warning: {number: 10, message: "middle tooltip"}
+            warning: { number: 10, message: "middle tooltip" }
         });
         await expectValueAndTooltip(wrapper, "10", 0, 10, "");
         await expectValueAndTooltip(wrapper, "11", 1, 11, "middle tooltip");

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -97,17 +97,13 @@ describe("RunOptions", () => {
         const noOfReplicates = wrapper.find("#number-of-replicates").findComponent(NumericInput);
         expect(noOfReplicates.props("value")).toBe(10);
         expect(noOfReplicates.props("minAllowed")).toBe(0);
-        expect(noOfReplicates.props("maxAllowed")).toStrictEqual([
-            {
+        expect(noOfReplicates.props("maxAllowed")).toStrictEqual({
+            error: { number: 1000 },
+            warning: {
                 number: 50,
-                message: "Individual traces will not be shown past this point",
-                variant: "warning"
-            },
-            {
-                number: 1000,
-                message: `Please enter a value less than ${1000}`
+                message: "Individual traces will not be shown for values greater than 50"
             }
-        ]);
+        });
     });
 
     it("can render and update number of replicates", async () => {

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -93,7 +93,13 @@ describe("RunOptions", () => {
     });
 
     it("renders number of replicates correctly", () => {
-        const wrapper = getWrapper(0, { appType: `${AppType.Stochastic}` });
+        const wrapper = getWrapper(0, {
+            appType: `${AppType.Stochastic}`,
+            config: {
+                maxReplicatesDisplay: 50,
+                maxReplicatesRun: 1000
+            }
+        });
         const noOfReplicates = wrapper.find("#number-of-replicates").findComponent(NumericInput);
         expect(noOfReplicates.props("value")).toBe(10);
         expect(noOfReplicates.props("minAllowed")).toBe(0);

--- a/app/static/tests/unit/components/options/runOptions.test.ts
+++ b/app/static/tests/unit/components/options/runOptions.test.ts
@@ -21,7 +21,8 @@ describe("RunOptions", () => {
             run: {
                 namespaced: true,
                 state: {
-                    endTime: 99
+                    endTime: 99,
+                    numberOfReplicates: 10
                 },
                 mutations: {
                     SetEndTime: mockRunSetEndTime,
@@ -89,6 +90,24 @@ describe("RunOptions", () => {
         expect(mockRunSetEndTime.mock.calls[0][1]).toBe(101);
         expect(mockSensitivitySetEndTime).toHaveBeenCalledTimes(1);
         expect(mockSensitivitySetEndTime.mock.calls[0][1]).toBe(101);
+    });
+
+    it("renders number of replicates correctly", () => {
+        const wrapper = getWrapper(0, { appType: `${AppType.Stochastic}` });
+        const noOfReplicates = wrapper.find("#number-of-replicates").findComponent(NumericInput);
+        expect(noOfReplicates.props("value")).toBe(10);
+        expect(noOfReplicates.props("minAllowed")).toBe(0);
+        expect(noOfReplicates.props("maxAllowed")).toStrictEqual([
+            {
+                number: 50,
+                message: "Individual traces will not be shown past this point",
+                variant: "warning"
+            },
+            {
+                number: 1000,
+                message: `Please enter a value less than ${1000}`
+            }
+        ]);
     });
 
     it("can render and update number of replicates", async () => {

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -170,4 +170,43 @@ describe("RunPlot for stochastic", () => {
         const wodinPlot = wrapper.findComponent(WodinPlot);
         expect(wodinPlot.props("fadePlot")).toBe(true);
     });
+
+    it("doesn't show individual traces when replicates > maxReplicatesDisplay", () => {
+        const store = new Vuex.Store<StochasticState>({
+            state: {
+                model: mockModelState({ paletteModel, selectedVariables }),
+                run: {
+                    endTime: 99,
+                    numberOfReplicates: 51,
+                    resultDiscrete: mockResult
+                }
+            } as any
+        });
+        const wrapper = shallowMount(RunStochasticPlot, {
+            props: {
+                fadePlot: false
+            },
+            global: {
+                plugins: [store]
+            }
+        });
+        const wodinPlot = wrapper.findComponent(WodinPlot);
+        const plotData = wodinPlot.props("plotData");
+        const data = plotData();
+        expect(data).toStrictEqual([
+            {
+                mode: "lines",
+                line: {
+                    color: "#00ff00",
+                    width: undefined,
+                    opacity: undefined
+                },
+                name: "I (mean)",
+                x: [0, 1],
+                y: [5, 10],
+                showlegend: true,
+                legendgroup: "I (mean)"
+            }
+        ]);
+    });
 });

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -44,6 +44,10 @@ describe("RunPlot for stochastic", () => {
                     endTime: 99,
                     numberOfReplicates: 20,
                     resultDiscrete: mockResult
+                },
+                config: {
+                    maxReplicatesDisplay: 50,
+                    maxReplicatesRun: 1000
                 }
             } as any
         });

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -42,6 +42,7 @@ describe("RunPlot for stochastic", () => {
                 model: mockModelState({ paletteModel, selectedVariables }),
                 run: {
                     endTime: 99,
+                    numberOfReplicates: 20,
                     resultDiscrete: mockResult
                 }
             } as any

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -427,4 +427,41 @@ describe("WodinPlot", () => {
         expect(mockPlotlyNewPlot).toBeCalledTimes(0);
         expect(mockOn).toBeCalledTimes(0);
     });
+
+    it("re-draws plot if yaxis graph setting toggled", async () => {
+        const wrapper = getWrapper();
+        const mockOn = mockPlotElementOn(wrapper);
+
+        await wrapper.setProps({ redrawWatches: [{} as any] });
+        expect(mockPlotDataFn).toBeCalledTimes(1);
+        expect(mockPlotlyNewPlot).toBeCalledTimes(1);
+        expect(mockOn).toBeCalledTimes(1);
+
+        const store = (wrapper.vm as any).$store;
+        store.state.graphSettings.logScaleYAxis = true;
+        await nextTick();
+
+        expect(mockPlotDataFn).toBeCalledTimes(2);
+        expect(mockPlotlyNewPlot).toBeCalledTimes(2);
+        expect(mockOn).toBeCalledTimes(2);
+    });
+
+    it("does not re-draw plot if plot is faded (yaxis toggle)", async () => {
+        const wrapper = getWrapper();
+        const mockOn = mockPlotElementOn(wrapper);
+
+        await wrapper.setProps({ redrawWatches: [{} as any] });
+        expect(mockPlotDataFn).toBeCalledTimes(1);
+        expect(mockPlotlyNewPlot).toBeCalledTimes(1);
+        expect(mockOn).toBeCalledTimes(1);
+
+        await wrapper.setProps({ fadePlot: true });
+        const store = (wrapper.vm as any).$store;
+        store.state.graphSettings.logScaleYAxis = true;
+        await nextTick();
+
+        expect(mockPlotDataFn).toBeCalledTimes(1);
+        expect(mockPlotlyNewPlot).toBeCalledTimes(1);
+        expect(mockOn).toBeCalledTimes(1);
+    });
 });

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -15,6 +15,7 @@ import Vuex, { Store } from "vuex";
 import WodinPlot from "../../../src/app/components/WodinPlot.vue";
 import WodinPlotDataSummary from "../../../src/app/components/WodinPlotDataSummary.vue";
 import { BasicState } from "../../../src/app/store/basic/state";
+import { fadePlotStyle } from "../../../src/app/plot";
 
 describe("WodinPlot", () => {
     const mockPlotlyNewPlot = jest.spyOn(plotly, "newPlot");
@@ -361,5 +362,17 @@ describe("WodinPlot", () => {
             yaxis: { autorange: true, type: "log" }
         };
         expect(mockPlotlyReact.mock.calls[0][2]).toStrictEqual(expectedLogScaleLayout);
+    });
+
+    it("does not re-draw plot if plot is faded", async () => {
+        const wrapper = getWrapper();
+        const mockOn = mockPlotElementOn(wrapper);
+
+        await wrapper.setProps({ fadePlot: true });
+        await wrapper.setProps({ redrawWatches: [{} as any] });
+
+        expect(mockPlotDataFn).toBeCalledTimes(0);
+        expect(mockPlotlyNewPlot).toBeCalledTimes(0);
+        expect(mockOn).toBeCalledTimes(0);
     });
 });

--- a/app/static/tests/unit/directives/tooltip.test.ts
+++ b/app/static/tests/unit/directives/tooltip.test.ts
@@ -105,6 +105,24 @@ describe("tooltip directive", () => {
         expect(tooltipClick._config.title).toBe("hey");
     });
 
+    it("disposes and creates new tooltip when variant is changed", async () => {
+        const wrapper = mountTemplate("hello",
+            true,
+            { content: "hey", variant: "warning" },
+            { content: "hey", variant: "success" });
+        const div = wrapper.find("div");
+        const tooltipInstance = Tooltip.getInstance(div.element) as any;
+        expect(tooltipInstance._config.title).toBe("hey");
+        expect(tooltipInstance._config.customClass).toBe("tooltip-success");
+        const spyDispose = jest.spyOn(tooltipInstance, "dispose");
+        await div.trigger("click");
+        const divClick = wrapper.find("div");
+        const tooltipClick = Tooltip.getInstance(divClick.element) as any;
+        expect(spyDispose).toBeCalledTimes(1)
+        expect(tooltipClick._config.title).toBe("hey");
+        expect(tooltipClick._config.customClass).toBe("tooltip-warning");
+    });
+
     it("does not have title if no content after update", async () => {
         const wrapper = mountTemplate("hello",
             true,

--- a/app/static/tests/unit/directives/tooltip.test.ts
+++ b/app/static/tests/unit/directives/tooltip.test.ts
@@ -118,7 +118,7 @@ describe("tooltip directive", () => {
         await div.trigger("click");
         const divClick = wrapper.find("div");
         const tooltipClick = Tooltip.getInstance(divClick.element) as any;
-        expect(spyDispose).toBeCalledTimes(1)
+        expect(spyDispose).toBeCalledTimes(1);
         expect(tooltipClick._config.title).toBe("hey");
         expect(tooltipClick._config.customClass).toBe("tooltip-warning");
     });

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -274,6 +274,39 @@ describe("discreteSeriesSetToPlotly", () => {
             }
         ]);
     });
+
+    it("creates expected series if individual traces are off", () => {
+        const seriesSet = {
+            x: [0, 1, 2],
+            values: [
+                { name: "A", description: "Individual", y: [1, 2, 3] },
+                { name: "A", description: "Individual", y: [4, 5, 6] },
+                { name: "A", description: "Mean", y: [7, 8, 9] },
+                { name: "B", description: "Deterministic", y: [10, 11, 12] }
+            ]
+        };
+        const res = discreteSeriesSetToPlotly(seriesSet, palette, false);
+        expect(res).toStrictEqual([
+            {
+                mode: "lines",
+                line: { color: "#ff0000", width: undefined, opacity: undefined },
+                name: "A (mean)",
+                x: [0, 1, 2],
+                y: [7, 8, 9],
+                legendgroup: "A (mean)",
+                showlegend: true
+            },
+            {
+                mode: "lines",
+                line: { color: "#0000ff", width: undefined, opacity: undefined },
+                name: "B",
+                x: [0, 1, 2],
+                y: [10, 11, 12],
+                legendgroup: "B",
+                showlegend: true
+            }
+        ]);
+    });
 });
 
 describe("paramSetLineStyle", () => {

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -234,7 +234,7 @@ describe("discreteSeriesSetToPlotly", () => {
                 { name: "B", description: "Deterministic", y: [10, 11, 12] }
             ]
         };
-        const res = discreteSeriesSetToPlotly(seriesSet, palette);
+        const res = discreteSeriesSetToPlotly(seriesSet, palette, true);
         expect(res).toStrictEqual([
             {
                 mode: "lines",


### PR DESCRIPTION
This is finishing off the putting max number of replicates bounds PR #135. You can now enter an array into max allowed which will trigger specified tooltip messages based on what bounds you enter. For example putting below example into `max-allowed` prop will:
```typescript
[
  {number: 2, content: "number is good!", variant: "success"},
  {number: 4, content: "a little high for me", variant: "warning"},
  {number: 6, content: "too high", variant: "error"}
]
```
for a value, x, spawn a success tooltip with message "number is good!" for 2 < x <= 4, warning tooltip for 4 < x <=6 and error tooltip for x > 6. It does not change the emitted value unless x > 6 in which case it will just emit 6 like before.