### PR TITLE
mrc-4519 Download multi-sensitivity summary

### DIFF
--- a/app/static/src/app/components/mixins/baseSensitivity.ts
+++ b/app/static/src/app/components/mixins/baseSensitivity.ts
@@ -1,5 +1,5 @@
-import { Store } from "vuex";
-import { computed } from "vue";
+import {Store} from "vuex";
+import {computed, ComputedRef, WritableComputedRef} from "vue";
 import { AppState } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import userMessages from "../../userMessages";
@@ -7,9 +7,18 @@ import { anyTrue } from "../../utils";
 import {sensitivityUpdateRequiredExplanation, verifyValidPlotSettingsTime} from "../sensitivity/support";
 import { Dict } from "../../types/utilTypes";
 import {BaseSensitivityMutation} from "../../store/sensitivity/mutations";
-import {BaseSensitivityAction, SensitivityAction} from "../../store/sensitivity/actions";
+import {BaseSensitivityAction} from "../../store/sensitivity/actions";
 
-export default (store: Store<AppState>, multiSensitivity: boolean) => {
+export interface BaseSensitivityMixin {
+    sensitivityPrerequisitesReady: ComputedRef<boolean>,
+    updateMsg: ComputedRef<string>,
+    downloading: ComputedRef<boolean>,
+    canDownloadSummary: ComputedRef<boolean>,
+    downloadSummaryUserFileName: WritableComputedRef<string>,
+    downloadSummary: (payload: { fileName: string }) => void
+}
+
+export default (store: Store<AppState>, multiSensitivity: boolean): BaseSensitivityMixin => {
     const namespace = multiSensitivity ? "multiSensitivity" : "sensitivity";
 
     const hasRunner = computed(() => store.getters[`model/${ModelGetter.hasRunner}`]);
@@ -42,7 +51,7 @@ export default (store: Store<AppState>, multiSensitivity: boolean) => {
     const downloading = computed(() => sensModule.downloading);
 
     // only allow download if update not required, and if we have run sensitivity
-    const canDownloadSummary = computed(() => !updateMsg.value && sensModule.result?.batch);
+    const canDownloadSummary = computed(() => !updateMsg.value && !!sensModule.result?.batch);
 
     const downloadSummaryUserFileName = computed({
         get: () => sensModule.userSummaryDownloadFileName,

--- a/app/static/src/app/components/mixins/baseSensitivity.ts
+++ b/app/static/src/app/components/mixins/baseSensitivity.ts
@@ -1,13 +1,13 @@
-import {Store} from "vuex";
-import {computed, ComputedRef, WritableComputedRef} from "vue";
+import { Store } from "vuex";
+import { computed, ComputedRef, WritableComputedRef } from "vue";
 import { AppState } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import userMessages from "../../userMessages";
 import { anyTrue } from "../../utils";
-import {sensitivityUpdateRequiredExplanation, verifyValidPlotSettingsTime} from "../sensitivity/support";
+import { sensitivityUpdateRequiredExplanation, verifyValidPlotSettingsTime } from "../sensitivity/support";
 import { Dict } from "../../types/utilTypes";
-import {BaseSensitivityMutation} from "../../store/sensitivity/mutations";
-import {BaseSensitivityAction} from "../../store/sensitivity/actions";
+import { BaseSensitivityMutation } from "../../store/sensitivity/mutations";
+import { BaseSensitivityAction } from "../../store/sensitivity/actions";
 
 export interface BaseSensitivityMixin {
     sensitivityPrerequisitesReady: ComputedRef<boolean>,

--- a/app/static/src/app/components/multiSensitivity/MultiSensitivityTab.vue
+++ b/app/static/src/app/components/multiSensitivity/MultiSensitivityTab.vue
@@ -12,7 +12,8 @@
       {{ multiSensitivityRunStatusMsg }}
     </div>
     <error-info :error="error"></error-info>
-    <sensitivity-summary-download :multi-sensitivity="true" :download-type="'Multi-sensitivity Summary'"></sensitivity-summary-download>
+    <sensitivity-summary-download :multi-sensitivity="true" :download-type="'Multi-sensitivity Summary'">
+    </sensitivity-summary-download>
   </div>
 </template>
 <script lang="ts">
@@ -21,12 +22,12 @@ import { useStore } from "vuex";
 import ActionRequiredMessage from "@/app/components/ActionRequiredMessage.vue";
 import ErrorInfo from "@/app/components/ErrorInfo.vue";
 import { update } from "plotly.js-basic-dist-min";
+import SensitivitySummaryDownload from "@/app/components/sensitivity/SensitivitySummaryDownload.vue";
 import baseSensitivity from "../mixins/baseSensitivity";
 import { MultiSensitivityAction } from "../../store/multiSensitivity/actions";
 import LoadingButton from "../LoadingButton.vue";
 import userMessages from "../../userMessages";
 import { BaseSensitivityGetter } from "../../store/sensitivity/getters";
-import SensitivitySummaryDownload from "@/app/components/sensitivity/SensitivitySummaryDownload.vue";
 
 export default defineComponent({
     name: "MultiSensitivityTab",

--- a/app/static/src/app/components/multiSensitivity/MultiSensitivityTab.vue
+++ b/app/static/src/app/components/multiSensitivity/MultiSensitivityTab.vue
@@ -12,6 +12,7 @@
       {{ multiSensitivityRunStatusMsg }}
     </div>
     <error-info :error="error"></error-info>
+    <sensitivity-summary-download :multi-sensitivity="true" :download-type="'Multi-sensitivity Summary'"></sensitivity-summary-download>
   </div>
 </template>
 <script lang="ts">
@@ -25,11 +26,13 @@ import { MultiSensitivityAction } from "../../store/multiSensitivity/actions";
 import LoadingButton from "../LoadingButton.vue";
 import userMessages from "../../userMessages";
 import { BaseSensitivityGetter } from "../../store/sensitivity/getters";
+import SensitivitySummaryDownload from "@/app/components/sensitivity/SensitivitySummaryDownload.vue";
 
 export default defineComponent({
     name: "MultiSensitivityTab",
     methods: { update },
     components: {
+        SensitivitySummaryDownload,
         ErrorInfo,
         ActionRequiredMessage,
         LoadingButton

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryDownload.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryDownload.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <button class="btn btn-primary" id="download-summary-btn"
+            :disabled="downloading || !canDownloadSummary"
+            @click="toggleShowDownloadSummary(true)">
+      <vue-feather size="20" class="inline-icon" type="download"></vue-feather>
+      Download summary
+    </button>
+    <div v-if="downloading" id="downloading">
+      <LoadingSpinner size="xs"></LoadingSpinner>
+      Downloading...
+    </div>
+  </div>
+  <DownloadOutput :open="showDownloadSummary"
+                  :download-type="downloadType"
+                  :include-points="false"
+                  v-model:user-file-name="downloadSummaryUserFileName"
+                  @download="downloadSummary"
+                  @close="toggleShowDownloadSummary(false)"></DownloadOutput>
+</template>
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import LoadingSpinner from "@/app/components/LoadingSpinner.vue";
+import DownloadOutput from "@/app/components/DownloadOutput.vue";
+import VueFeather from "vue-feather";
+import { useStore } from "vuex";
+import baseSensitivity from "../mixins/baseSensitivity";
+
+export default defineComponent({
+    name: "SensitivitySummaryDownload",
+    components: { VueFeather, DownloadOutput, LoadingSpinner },
+    props: {
+        multiSensitivity: {
+            type: Boolean,
+            required: false
+        },
+        downloadType: {
+            type: String,
+            required: true
+        }
+    },
+    setup(props) {
+        const store = useStore();
+        const {
+            canDownloadSummary,
+            downloading,
+            downloadSummaryUserFileName,
+            downloadSummary
+        } = baseSensitivity(store, props.multiSensitivity);
+        const showDownloadSummary = ref(false);
+        const toggleShowDownloadSummary = (show: boolean) => { showDownloadSummary.value = show; };
+
+        return {
+            canDownloadSummary,
+            downloading,
+            showDownloadSummary,
+            downloadSummaryUserFileName,
+            toggleShowDownloadSummary,
+            downloadSummary
+        };
+    }
+});
+</script>

--- a/app/static/src/app/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTab.vue
@@ -15,15 +15,15 @@
       <span class="ms-2">{{ sensitivityProgressMsg }}</span>
     </div>
     <error-info :error="error"></error-info>
-    <sensitivity-summary-download :multi-sensitivity="false" :download-type="'Sensitivity Summary'"></sensitivity-summary-download>
+    <sensitivity-summary-download :multi-sensitivity="false" :download-type="'Sensitivity Summary'">
+    </sensitivity-summary-download>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent } from "vue";
 import { useStore } from "vuex";
-import VueFeather from "vue-feather";
-import DownloadOutput from "@/app/components/DownloadOutput.vue";
+import SensitivitySummaryDownload from "@/app/components/sensitivity/SensitivitySummaryDownload.vue";
 import SensitivityTracesPlot from "./SensitivityTracesPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
 import { BaseSensitivityGetter } from "../../store/sensitivity/getters";
@@ -35,13 +35,10 @@ import LoadingSpinner from "../LoadingSpinner.vue";
 import LoadingButton from "../LoadingButton.vue";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
 import baseSensitivity from "../mixins/baseSensitivity";
-import SensitivitySummaryDownload from "@/app/components/sensitivity/SensitivitySummaryDownload.vue";
 
 export default defineComponent({
     name: "SensitivityTab",
     components: {
-        DownloadOutput,
-        VueFeather,
         ErrorInfo,
         LoadingSpinner,
         SensitivitySummaryPlot,

--- a/app/static/src/app/excel/wodinExcelDownload.ts
+++ b/app/static/src/app/excel/wodinExcelDownload.ts
@@ -45,6 +45,4 @@ export abstract class WodinExcelDownload {
                 { detail: `Error downloading to ${this._fileName}: ${e}` }, { root: true });
         }
     }
-
-    abstract download(): void;
 }

--- a/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
+++ b/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
@@ -1,7 +1,8 @@
 import * as XLSX from "xlsx";
 import { WodinExcelDownload } from "./wodinExcelDownload";
-import { SensitivityPlotExtreme, SensitivityPlotExtremePrefix } from "../store/sensitivity/state";
+import {BaseSensitivityState, SensitivityPlotExtreme, SensitivityPlotExtremePrefix} from "../store/sensitivity/state";
 import { OdinUserType, OdinUserTypeSeriesSet } from "../types/responseTypes";
+import {OdinSensitivityResult} from "../types/wrapperTypes";
 
 interface ExtremeSummarySheetSettings {
     name: string,
@@ -16,36 +17,37 @@ const extremeSummarySheets: ExtremeSummarySheetSettings[] = [
     { name: "TimeAtMax", extremePrefix: SensitivityPlotExtremePrefix.time, extreme: SensitivityPlotExtreme.Max }
 ];
 export class WodinSensitivitySummaryDownload extends WodinExcelDownload {
-    private _addSummarySheetFromOdinSeriesSet = (data: OdinUserTypeSeriesSet, varyingParameter: string,
-        sheetName: string) => {
+    private _addSummarySheetFromOdinSeriesSet = (data: OdinUserTypeSeriesSet, sheetName: string) => {
         const sheetData = data.x.map((x: OdinUserType, index: number) => {
-            const xValue = x[varyingParameter];
-            return Object.fromEntries([
-                [varyingParameter, xValue],
-                ...data.values.map((v) => [v.name, v.y[index]])
-            ]);
+            return {
+                ...x,
+                ...Object.fromEntries([
+                    ...data.values.map((v) => [v.name, v.y[index]])
+                ])
+            };
         });
         const worksheet = XLSX.utils.json_to_sheet(sheetData);
         XLSX.utils.book_append_sheet(this._workbook, worksheet, sheetName);
     };
 
-    download = () => {
+    download = (result: OdinSensitivityResult) => {
         this._writeFile(() => {
-            const { sensitivity } = this._state;
-            const { batch } = sensitivity.result!;
-            const varyingParameter = sensitivity.paramSettings.parameterToVary!;
-            const time = sensitivity.plotSettings.time!;
+            const { batch } = result;
+            if (batch?.successfulVaryingParams?.length) {
+                const varyingParams = Object.keys(batch.successfulVaryingParams[0]);
+                const time = this._state.sensitivity.plotSettings.time!;
 
-            // Value at time summary
-            const valueAtTimeData = batch!.valueAtTime(time);
-            this._addSummarySheetFromOdinSeriesSet(valueAtTimeData, varyingParameter, `ValueAtTime${time}`);
+                // Value at time summary
+                const valueAtTimeData = batch!.valueAtTime(time);
+                this._addSummarySheetFromOdinSeriesSet(valueAtTimeData, `ValueAtTime${time}`);
 
-            // Extreme summaries
-            extremeSummarySheets.forEach((sheet) => {
-                const data = batch!.extreme(`${sheet.extremePrefix}${sheet.extreme}`);
-                this._addSummarySheetFromOdinSeriesSet(data, varyingParameter, sheet.name);
-            });
-            this._addParameters([varyingParameter]);
+                // Extreme summaries
+                extremeSummarySheets.forEach((sheet) => {
+                    const data = batch!.extreme(`${sheet.extremePrefix}${sheet.extreme}`);
+                    this._addSummarySheetFromOdinSeriesSet(data, sheet.name);
+                });
+                this._addParameters(varyingParams);
+            }
         });
     };
 }

--- a/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
+++ b/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
@@ -1,8 +1,8 @@
 import * as XLSX from "xlsx";
 import { WodinExcelDownload } from "./wodinExcelDownload";
-import { SensitivityPlotExtreme, SensitivityPlotExtremePrefix} from "../store/sensitivity/state";
+import { SensitivityPlotExtreme, SensitivityPlotExtremePrefix } from "../store/sensitivity/state";
 import { OdinUserType, OdinUserTypeSeriesSet } from "../types/responseTypes";
-import {OdinSensitivityResult} from "../types/wrapperTypes";
+import { OdinSensitivityResult } from "../types/wrapperTypes";
 
 interface ExtremeSummarySheetSettings {
     name: string,

--- a/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
+++ b/app/static/src/app/excel/wodinSensitivitySummaryDownload.ts
@@ -1,6 +1,6 @@
 import * as XLSX from "xlsx";
 import { WodinExcelDownload } from "./wodinExcelDownload";
-import {BaseSensitivityState, SensitivityPlotExtreme, SensitivityPlotExtremePrefix} from "../store/sensitivity/state";
+import { SensitivityPlotExtreme, SensitivityPlotExtremePrefix} from "../store/sensitivity/state";
 import { OdinUserType, OdinUserTypeSeriesSet } from "../types/responseTypes";
 import {OdinSensitivityResult} from "../types/wrapperTypes";
 

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -18,13 +18,13 @@ import { convertAdvancedSettingsToOdin } from "../../utils";
 import { WodinSensitivitySummaryDownload } from "../../excel/wodinSensitivitySummaryDownload";
 
 export enum BaseSensitivityAction {
-    ComputeNext = "ComputeNext"
+    ComputeNext = "ComputeNext",
+    DownloadSummary = "DownloadSummary"
 }
 
 export enum SensitivityAction {
     RunSensitivity = "RunSensitivity",
-    RunSensitivityOnRehydrate = "RunSensitivityOnRehydrate",
-    DownloadSummary = "DownloadSummary"
+    RunSensitivityOnRehydrate = "RunSensitivityOnRehydrate"
 }
 
 const runModelIfRequired = (rootState: AppState, dispatch: Dispatch) => {
@@ -142,6 +142,8 @@ export const runSensitivity = (
     }
 };
 
+
+
 export const baseSensitivityActions: ActionTree<BaseSensitivityState, AppState> = {
     [BaseSensitivityAction.ComputeNext](context, batch: Batch) {
         const {
@@ -156,6 +158,16 @@ export const baseSensitivityActions: ActionTree<BaseSensitivityState, AppState> 
                 dispatch(BaseSensitivityAction.ComputeNext, batch);
             }, 0);
         }
+    },
+
+    [BaseSensitivityAction.DownloadSummary](context, filename: string) {
+        const { commit, state } = context;
+        commit(BaseSensitivityMutation.SetDownloading, true);
+        setTimeout(() => {
+            new WodinSensitivitySummaryDownload(context, filename)
+                .download(state.result!);
+            commit(BaseSensitivityMutation.SetDownloading, false);
+        }, 5);
     }
 };
 
@@ -175,15 +187,5 @@ export const actions: ActionTree<SensitivityState, AppState> = {
         const { pars } = state.result!.inputs;
 
         runSensitivity(pars, endTime, context);
-    },
-
-    [SensitivityAction.DownloadSummary](context, filename: string) {
-        const { commit } = context;
-        commit(SensitivityMutation.SetDownloading, true);
-        setTimeout(() => {
-            new WodinSensitivitySummaryDownload(context, filename)
-                .download();
-            commit(SensitivityMutation.SetDownloading, false);
-        }, 5);
     }
 };

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -143,8 +143,6 @@ export const runSensitivity = (
     }
 };
 
-
-
 export const baseSensitivityActions: ActionTree<BaseSensitivityState, AppState> = {
     [BaseSensitivityAction.ComputeNext](context, batch: Batch) {
         const {

--- a/app/static/src/app/store/sensitivity/mutations.ts
+++ b/app/static/src/app/store/sensitivity/mutations.ts
@@ -14,6 +14,8 @@ export enum BaseSensitivityMutation {
     SetRunning = "SetRunning",
     SetResult = "SetResult",
     SetUpdateRequired = "SetUpdateRequired",
+    SetUserSummaryDownloadFileName = "SetUserSummaryDownloadFileName",
+    SetDownloading = "SetDownloading",
 }
 
 export enum SensitivityMutation {
@@ -23,9 +25,7 @@ export enum SensitivityMutation {
     SetPlotType = "SetPlotType",
     SetPlotExtreme = "SetPlotExtreme",
     SetPlotTime = "SetPlotTime",
-    SetDownloading = "SetDownloading",
     SetLoading = "SetLoading",
-    SetUserSummaryDownloadFileName = "SetUserSummaryDownloadFileName",
     ParameterSetAdded = "ParameterSetAdded",
     SetParameterSetResults = "SetParameterSetResults",
     ParameterSetDeleted = "ParameterSetDeleted",
@@ -47,6 +47,14 @@ export const baseSensitivityMutations: MutationTree<BaseSensitivityState> = {
 
     [BaseSensitivityMutation.SetRunning](state: BaseSensitivityState, payload: boolean) {
         state.running = payload;
+    },
+
+    [BaseSensitivityMutation.SetUserSummaryDownloadFileName](state: BaseSensitivityState, payload: string) {
+        state.userSummaryDownloadFileName = payload;
+    },
+
+    [BaseSensitivityMutation.SetDownloading](state: BaseSensitivityState, payload: boolean) {
+        state.downloading = payload;
     }
 };
 
@@ -90,14 +98,6 @@ export const mutations: MutationTree<SensitivityState> = {
 
     [SensitivityMutation.SetLoading](state: BaseSensitivityState, payload: boolean) {
         state.loading = payload;
-    },
-
-    [SensitivityMutation.SetDownloading](state: SensitivityState, payload: boolean) {
-        state.downloading = payload;
-    },
-
-    [SensitivityMutation.SetUserSummaryDownloadFileName](state: SensitivityState, payload: string) {
-        state.userSummaryDownloadFileName = payload;
     },
 
     [SensitivityMutation.ParameterSetAdded](state: SensitivityState, payload: string) {

--- a/app/static/tests/e2e/download.etest.ts
+++ b/app/static/tests/e2e/download.etest.ts
@@ -5,9 +5,7 @@ test.describe("Download tests", () => {
         await page.goto("/apps/day2");
     });
 
-    test("can download from Run tab", async ({ page }) => {
-        await page.click("#download-btn");
-        await expect(await page.inputValue("#download-file-name input")).toContain("day2-run");
+    const testCanInputFileNameAndDownload = async (page: Page) => {
         await page.fill("#download-file-name input", "test-download");
 
         const [download] = await Promise.all([
@@ -20,6 +18,12 @@ test.describe("Download tests", () => {
         await download.path();
 
         expect(download.suggestedFilename()).toBe("test-download.xlsx");
+    };
+
+    test("can download from Run tab", async ({ page }) => {
+        await page.click("#download-btn");
+        await expect(await page.inputValue("#download-file-name input")).toContain("day2-run");
+        await testCanInputFileNameAndDownload(page);
     });
 
     test("can download Sensitivity Summary", async ({ page }) => {
@@ -28,17 +32,23 @@ test.describe("Download tests", () => {
         await page.click("#run-sens-btn");
         await page.click("#download-summary-btn");
         await expect(await page.inputValue("#download-file-name input")).toContain("day2-sensitivity-summary");
-        await page.fill("#download-file-name input", "test-download");
+        await testCanInputFileNameAndDownload(page);
+    });
 
-        const [download] = await Promise.all([
-            // Start waiting for the download
-            page.waitForEvent("download"),
-            // Perform the action that initiates download
-            page.click("#ok-download")
-        ]);
-        // Wait for the download process to complete
-        await download.path();
+    test("can download Multi-sensitivity Summary", async ({ page }) => {
+        // Go to Multi-sensitivity tab
+        await page.click(":nth-match(.wodin-right .nav-tabs a, 4)");
 
-        expect(download.suggestedFilename()).toBe("test-download.xlsx");
+        // Specify a second varying parameter
+        await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
+        await page.click("#add-param-settings");
+        await page.click("#ok-settings");
+        await expect(await page.locator(".sensitivity-options-settings:has-text('Parameter: L')")).toBeVisible();
+
+        // Run multi-sensitivity
+        await page.click("#run-multi-sens-btn");
+        await page.click("#download-summary-btn");
+        await expect(await page.inputValue("#download-file-name input")).toContain("day2-multi-sensitivity-summary");
+        await testCanInputFileNameAndDownload(page);
     });
 });

--- a/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
+++ b/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
@@ -1,11 +1,21 @@
 import Vuex from "vuex";
 import { ModelState } from "../../../../src/app/store/model/state";
-import baseSensitivity from "../../../../src/app/components/mixins/baseSensitivity";
+import baseSensitivity, {BaseSensitivityMixin} from "../../../../src/app/components/mixins/baseSensitivity";
 import { BaseSensitivityState } from "../../../../src/app/store/sensitivity/state";
 import { noSensitivityUpdateRequired } from "../../../../src/app/store/sensitivity/sensitivity";
 import { AppState } from "../../../../src/app/store/appState/state";
+import {BaseSensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import {nextTick} from "vue";
+import {BaseSensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import mock = jest.mock;
 
 describe("baseSensitivity mixin", () => {
+    const mockSensSetUserSummaryDownloadFileName = jest.fn();
+    const mockMultiSensSetUserSummaryDownloadFileName = jest.fn();
+
+    const mockSensDownloadSummary = jest.fn();
+    const mockMultiSensDownloadSummary = jest.fn();
+
     const getStore = (hasRunner = true, modelState: Partial<ModelState> = {},
         sensitivityState: Partial<BaseSensitivityState> = {},
         multiSensitivityState: Partial<BaseSensitivityState> = {}) => {
@@ -34,6 +44,13 @@ describe("baseSensitivity mixin", () => {
                             }
                         },
                         ...multiSensitivityState
+                    },
+                    mutations: {
+                        [BaseSensitivityMutation.SetUserSummaryDownloadFileName]:
+                            mockMultiSensSetUserSummaryDownloadFileName
+                    },
+                    actions: {
+                        [BaseSensitivityAction.DownloadSummary]: mockSensDownloadSummary
                     }
                 },
                 sensitivity: {
@@ -46,11 +63,23 @@ describe("baseSensitivity mixin", () => {
                             }
                         },
                         ...sensitivityState
+                    },
+                    mutations: {
+                        [BaseSensitivityMutation.SetUserSummaryDownloadFileName]:
+                            mockSensSetUserSummaryDownloadFileName
+                    },
+                    actions: {
+                        [BaseSensitivityAction.DownloadSummary]: mockSensDownloadSummary
                     }
                 }
             } as any
         });
     };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
 
     it("sensitivityPrerequisitesReady returns true when all prerequisites have been met", () => {
         const store = getStore();
@@ -117,5 +146,75 @@ describe("baseSensitivity mixin", () => {
         expectUpdateMsgForSensAndMultiSens(true, {}, { sensitivityUpdateRequired },
             "Plot is out of date: model code has been recompiled. Run Sensitivity to update.",
             "Status is out of date: model code has been recompiled. Run Multi-sensitivity to update.");
+    });
+
+    const testForSensAndMultiSens = (state: Partial<BaseSensitivityState>, test: (mixin: BaseSensitivityMixin) => void) => {
+        let store = getStore(true, {}, state, {});
+        test(baseSensitivity(store, false));
+        store = getStore(true, {}, {}, state);
+        test(baseSensitivity(store, true));
+    };
+
+    it("returns downloading", () => {
+        testForSensAndMultiSens({downloading: true}, (mixin) => {
+            expect(mixin.downloading.value).toBe(true);
+        });
+        testForSensAndMultiSens({}, (mixin) => {
+            expect(mixin.downloading.value).toBe(false);
+        });
+    });
+
+    it("can download summary when no update required and batch exists", () => {
+        testForSensAndMultiSens({}, (mixin) => {
+            expect(mixin.canDownloadSummary.value).toBe(true);
+        });
+    });
+
+    it("cannot download summary when update required", () => {
+        const state = {
+            sensitivityUpdateRequired: {
+                ...noSensitivityUpdateRequired(),
+                modelChanged: true
+            }
+        };
+        testForSensAndMultiSens(state, (mixin) => {
+            expect(mixin.canDownloadSummary.value).toBe(false);
+        });
+    });
+
+    it("cannot download summary when no batch exists", () => {
+        const state = {
+            result: {}
+        } as any;
+        testForSensAndMultiSens(state, (mixin) => {
+            expect(mixin.canDownloadSummary.value).toBe(false);
+        });
+    });
+
+    it("returns download summary user file name", () => {
+        const state = { userSummaryDownloadFileName: "test.xlsx" };
+        testForSensAndMultiSens(state, (mixin) => {
+            expect(mixin.downloadSummaryUserFileName.value).toBe("test.xlsx");
+        });
+    });
+
+    it("writes download summary user file name", () => {
+        const sensSut = baseSensitivity(getStore(), false);
+        sensSut.downloadSummaryUserFileName.value = "new.xlsx";
+        expect(mockSensSetUserSummaryDownloadFileName.mock.calls[0][1]).toBe("new.xlsx");
+
+        const multiSensSut = baseSensitivity(getStore(), true);
+        multiSensSut.downloadSummaryUserFileName.value = "newMulti.xlsx";
+        expect(mockMultiSensSetUserSummaryDownloadFileName.mock.calls[0][1]).toBe("newMulti.xlsx");
+    });
+
+    it("downloadSummary dispatches action", () => {
+        const sensSut = baseSensitivity(getStore(), false);
+        sensSut.downloadSummary({ fileName: "test.xlsx" });
+        expect(mockSensDownloadSummary.mock.calls[0][1]).toBe("test.xlsx");
+
+        const multiSensSut = baseSensitivity(getStore(), true);
+        multiSensSut.downloadSummary({ fileName: "testMulti.xlsx" });
+        expect(mockMultiSensDownloadSummary.mock.calls[0][1]).toBe("testMulti.xlsx");
     });
 });

--- a/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
+++ b/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
@@ -1,12 +1,12 @@
 import Vuex from "vuex";
+import { nextTick } from "vue";
 import { ModelState } from "../../../../src/app/store/model/state";
-import baseSensitivity, {BaseSensitivityMixin} from "../../../../src/app/components/mixins/baseSensitivity";
+import baseSensitivity, { BaseSensitivityMixin } from "../../../../src/app/components/mixins/baseSensitivity";
 import { BaseSensitivityState } from "../../../../src/app/store/sensitivity/state";
 import { noSensitivityUpdateRequired } from "../../../../src/app/store/sensitivity/sensitivity";
 import { AppState } from "../../../../src/app/store/appState/state";
-import {BaseSensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
-import {nextTick} from "vue";
-import {BaseSensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import { BaseSensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import { BaseSensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import mock = jest.mock;
 
 describe("baseSensitivity mixin", () => {
@@ -34,9 +34,16 @@ describe("baseSensitivity mixin", () => {
                         hasRunner: () => hasRunner
                     }
                 },
+                run: {
+                    namespace: true,
+                    state: {
+                        endTime: 100
+                    }
+                },
                 multiSensitivity: {
                     namespaced: true,
                     state: {
+                        downloading: false,
                         sensitivityUpdateRequired: noSensitivityUpdateRequired(),
                         result: {
                             batch: {
@@ -50,13 +57,17 @@ describe("baseSensitivity mixin", () => {
                             mockMultiSensSetUserSummaryDownloadFileName
                     },
                     actions: {
-                        [BaseSensitivityAction.DownloadSummary]: mockSensDownloadSummary
+                        [BaseSensitivityAction.DownloadSummary]: mockMultiSensDownloadSummary
                     }
                 },
                 sensitivity: {
                     namespaced: true,
                     state: {
+                        downloading: false,
                         sensitivityUpdateRequired: noSensitivityUpdateRequired(),
+                        plotSettings: {
+                            time: 50
+                        },
                         result: {
                             batch: {
                                 solutions: [{}]
@@ -79,7 +90,6 @@ describe("baseSensitivity mixin", () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
-
 
     it("sensitivityPrerequisitesReady returns true when all prerequisites have been met", () => {
         const store = getStore();
@@ -148,7 +158,8 @@ describe("baseSensitivity mixin", () => {
             "Status is out of date: model code has been recompiled. Run Multi-sensitivity to update.");
     });
 
-    const testForSensAndMultiSens = (state: Partial<BaseSensitivityState>, test: (mixin: BaseSensitivityMixin) => void) => {
+    const testForSensAndMultiSens = (state: Partial<BaseSensitivityState>,
+        test: (mixin: BaseSensitivityMixin) => void) => {
         let store = getStore(true, {}, state, {});
         test(baseSensitivity(store, false));
         store = getStore(true, {}, {}, state);
@@ -156,7 +167,7 @@ describe("baseSensitivity mixin", () => {
     };
 
     it("returns downloading", () => {
-        testForSensAndMultiSens({downloading: true}, (mixin) => {
+        testForSensAndMultiSens({ downloading: true }, (mixin) => {
             expect(mixin.downloading.value).toBe(true);
         });
         testForSensAndMultiSens({}, (mixin) => {

--- a/app/static/tests/unit/components/multiSensitivity/multiSensitivityTab.test.ts
+++ b/app/static/tests/unit/components/multiSensitivity/multiSensitivityTab.test.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import MultiSensitivityTab from "../../../../src/app/components/multiSensitivity/MultiSensitivityTab.vue";
-import {AppState, AppType} from "../../../../src/app/store/appState/state";
+import { AppState, AppType } from "../../../../src/app/store/appState/state";
 import LoadingButton from "../../../../src/app/components/LoadingButton.vue";
 import { ModelState } from "../../../../src/app/store/model/state";
 import { MultiSensitivityAction } from "../../../../src/app/store/multiSensitivity/actions";

--- a/app/static/tests/unit/components/multiSensitivity/multiSensitivityTab.test.ts
+++ b/app/static/tests/unit/components/multiSensitivity/multiSensitivityTab.test.ts
@@ -1,13 +1,14 @@
 import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import MultiSensitivityTab from "../../../../src/app/components/multiSensitivity/MultiSensitivityTab.vue";
-import { AppState } from "../../../../src/app/store/appState/state";
+import {AppState, AppType} from "../../../../src/app/store/appState/state";
 import LoadingButton from "../../../../src/app/components/LoadingButton.vue";
 import { ModelState } from "../../../../src/app/store/model/state";
 import { MultiSensitivityAction } from "../../../../src/app/store/multiSensitivity/actions";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
 import { MultiSensitivityState } from "../../../../src/app/store/multiSensitivity/state";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
+import SensitivitySummaryDownload from "../../../../src/app/components/sensitivity/SensitivitySummaryDownload.vue";
 
 describe("MultiSensitivityTab", () => {
     const mockRunMultiSensitivity = jest.fn();
@@ -140,5 +141,12 @@ describe("MultiSensitivityTab", () => {
             } as any
         });
         expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(error);
+    });
+
+    it("renders SensitivitySummaryDownload", () => {
+        const wrapper = getWrapper();
+        const download = wrapper.findComponent(SensitivitySummaryDownload);
+        expect(download.props("multiSensitivity")).toBe(true);
+        expect(download.props("downloadType")).toBe("Multi-sensitivity Summary");
     });
 });

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
@@ -1,0 +1,173 @@
+import DownloadOutput from "../../../../src/app/components/DownloadOutput.vue";
+import {AppState, AppType} from "../../../../src/app/store/appState/state";
+import {ModelState} from "../../../../src/app/store/model/state";
+import {BaseSensitivityState, SensitivityState} from "../../../../src/app/store/sensitivity/state";
+import Vuex from "vuex";
+import {shallowMount} from "@vue/test-utils";
+import SensitivityTab from "../../../../src/app/components/sensitivity/SensitivityTab.vue";
+import SensitivitySummaryDownload from "../../../../src/app/components/sensitivity/SensitivitySummaryDownload.vue";
+import {BaseSensitivityAction, SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import {BaseSensitivityMutation, SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
+import {nextTick} from "vue";
+import {ModelGetter} from "../../../../src/app/store/model/getters";
+describe("SensitivitySummaryDownload", () => {
+    const mockSetUserSummaryDownloadFileName = jest.fn();
+    const mockDownloadSummary = jest.fn();
+
+    const getWrapper = (multiSens = false, state: Partial<BaseSensitivityState> = {}) => {
+
+        const sensMod = {
+            namespaced: true,
+            state: {
+                userSummaryDownloadFileName: "",
+                result: {
+                    inputs: {},
+                    batch: {
+                        solutions: [],
+                        errors: []
+                    },
+                    error: null
+                },
+                ...state
+            },
+            actions: {
+                [BaseSensitivityAction.DownloadSummary]: mockDownloadSummary
+            },
+            mutations: {
+                [BaseSensitivityMutation.SetUserSummaryDownloadFileName]: mockSetUserSummaryDownloadFileName,
+            }
+        };
+        const store = new Vuex.Store<AppState>({
+            modules: {
+                model: {
+                    namespaced: true,
+                    state: {
+                        odinRunnerOde: {},
+                        odin: {},
+                        selectedVariables: ["S"]
+                    },
+                    getters: {
+                        [ModelGetter.hasRunner]: () => true
+                    }
+                },
+                multiSensitivity: multiSens ? sensMod : {},
+                sensitivity: multiSens ? {} : sensMod
+            }
+        });
+
+        return shallowMount(SensitivitySummaryDownload, {
+            props: {
+                multiSensitivity: multiSens,
+                downloadType: "Test Download Type"
+            },
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
+    it("enables download button when expected", () => {
+        const expectDownloadButtonEnabled = (state: Partial<SensitivityState>, expectButtonEnabled: boolean) => {
+            const wrapper = getWrapper(false, state);
+            const button = wrapper.find("button#download-summary-btn");
+            expect((button.element as HTMLButtonElement).disabled).toBe(!expectButtonEnabled);
+        };
+
+        // enabled if not downloading, and no update required, and batch result exists
+        const noUpdateRequiredReasons = {
+            modelChanged: false,
+            parameterValueChanged: false,
+            endTimeChanged: false,
+            sensitivityOptionsChanged: false,
+            numberOfReplicatesChanged: false
+        };
+        const enabledResult = {
+            inputs: {},
+            batch: {
+                solutions: ["test solution"] as any,
+                errors: []
+            },
+            error: null
+        };
+        const enabledState = {
+            downloading: false,
+            sensitivityUpdateRequired: noUpdateRequiredReasons,
+            result: enabledResult
+        } as any;
+        expectDownloadButtonEnabled(enabledState, true);
+
+        // disabled if downloading
+        expectDownloadButtonEnabled({ ...enabledState, downloading: true }, false);
+
+        // disabled if update required
+        expectDownloadButtonEnabled({
+            ...enabledState,
+            sensitivityUpdateRequired: { modelChanged: true }
+        }, false);
+
+        // disabled if no batch result
+        expectDownloadButtonEnabled({
+            ...enabledState,
+            result: { ...enabledResult, batch: null }
+        }, false);
+    });
+
+    it("renders DownloadOutput as expected", () => {
+        const wrapper = getWrapper(false,{ userSummaryDownloadFileName: "test.xlsx" });
+        const downloadOutput = wrapper.findComponent(DownloadOutput);
+        expect(downloadOutput.props().open).toBe(false);
+        expect(downloadOutput.props().downloadType).toBe("Test Download Type");
+        expect(downloadOutput.props().includePoints).toBe(false);
+        expect(downloadOutput.props().userFileName).toBe("test.xlsx");
+    });
+
+    it("renders downloading as expected", () => {
+        // does not render if not downloading
+        let wrapper = getWrapper();
+        expect(wrapper.find("div#downloading").exists()).toBe(false);
+
+        // does render if downloading
+        wrapper = getWrapper(false, { downloading: true });
+        const downloading = wrapper.find("div#downloading");
+        expect(downloading.text()).toBe("Downloading...");
+        expect(wrapper.findComponent(LoadingSpinner).props("size")).toBe("xs");
+    });
+
+    it("opens dialog on click download button", async () => {
+        const wrapper = getWrapper();
+        const button = wrapper.find("button#download-summary-btn");
+        expect((button.element as HTMLButtonElement).disabled).toBe(false)
+        await button.trigger("click");
+        expect(wrapper.findComponent(DownloadOutput).props().open).toBe(true);
+    });
+
+    it("commits user download filename change", () => {
+        const wrapper = getWrapper();
+        const downloadOutput = wrapper.findComponent(DownloadOutput);
+        downloadOutput.vm.$emit("update:userFileName", "newFile.xlsx");
+        expect(mockSetUserSummaryDownloadFileName).toHaveBeenCalledTimes(1);
+        expect(mockSetUserSummaryDownloadFileName.mock.calls[0][1]).toBe("newFile.xlsx");
+    });
+
+    /*
+    it("verifies end time and dispatches action on download output emit", () => {
+        const wrapper = getWrapper();
+        const downloadOutput = wrapper.findComponent(DownloadOutput);
+        downloadOutput.vm.$emit("download", { fileName: "test.xlsx" });
+        // should have updated plot settings time to run end time
+        expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
+        expect(mockDownloadSummary.mock.calls[0][1]).toBe("test.xlsx");
+    });
+
+    it("closes output dialog on close emit", async () => {
+        const wrapper = getWrapper();
+        await wrapper.find("#download-summary-btn").trigger("click");
+        const downloadOutput = wrapper.findComponent(DownloadOutput);
+        expect(downloadOutput.props().open).toBe(true);
+        downloadOutput.vm.$emit("close");
+        await nextTick();
+        expect(downloadOutput.props().open).toBe(false);
+    });
+    */
+});

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
@@ -1,14 +1,18 @@
-import DownloadOutput from "../../../../src/app/components/DownloadOutput.vue";
-import {AppState, AppType} from "../../../../src/app/store/appState/state";
-import {BaseSensitivityState, SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
 import Vuex from "vuex";
-import {shallowMount, VueWrapper} from "@vue/test-utils";
+import { shallowMount, VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import DownloadOutput from "../../../../src/app/components/DownloadOutput.vue";
+import { AppState } from "../../../../src/app/store/appState/state";
+import {
+    BaseSensitivityState,
+    SensitivityPlotType,
+    SensitivityState
+} from "../../../../src/app/store/sensitivity/state";
 import SensitivitySummaryDownload from "../../../../src/app/components/sensitivity/SensitivitySummaryDownload.vue";
-import {BaseSensitivityAction, SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
-import {BaseSensitivityMutation, SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import { BaseSensitivityAction, SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
+import { BaseSensitivityMutation, SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
-import {nextTick} from "vue";
-import {ModelGetter} from "../../../../src/app/store/model/getters";
+import { ModelGetter } from "../../../../src/app/store/model/getters";
 
 describe("SensitivitySummaryDownload", () => {
     const mockSetUserSummaryDownloadFileName = jest.fn();
@@ -16,7 +20,6 @@ describe("SensitivitySummaryDownload", () => {
     const mockSetPlotTime = jest.fn();
 
     const getWrapper = (multiSens = false, state: Partial<BaseSensitivityState> = {}) => {
-
         const plotSettings = {
             plotType: SensitivityPlotType.TraceOverTime,
             time: null
@@ -90,7 +93,8 @@ describe("SensitivitySummaryDownload", () => {
         });
     };
 
-    const testForSensAndMultiSens = (test: (wrapper: VueWrapper<any>, multiSens: boolean) => void, state: Partial<SensitivityState> = {}) => {
+    const testForSensAndMultiSens = (test: (wrapper: VueWrapper<any>, multiSens: boolean) => void,
+        state: Partial<SensitivityState> = {}) => {
         let wrapper = getWrapper(false, state);
         test(wrapper, false);
         jest.clearAllMocks();
@@ -98,7 +102,8 @@ describe("SensitivitySummaryDownload", () => {
         test(wrapper, true);
     };
 
-    const asyncTestForSensAndMultiSens = async (test: (wrapper: VueWrapper<any>, multiSens: boolean) => Promise<void>, state: Partial<SensitivityState> = {}) => {
+    const asyncTestForSensAndMultiSens = async (test: (wrapper: VueWrapper<any>, multiSens: boolean) => Promise<void>,
+        state: Partial<SensitivityState> = {}) => {
         let wrapper = getWrapper(false, state);
         await test(wrapper, false);
         jest.clearAllMocks();
@@ -158,7 +163,7 @@ describe("SensitivitySummaryDownload", () => {
     });
 
     it("renders DownloadOutput as expected", () => {
-        const state = {userSummaryDownloadFileName: "test.xlsx"};
+        const state = { userSummaryDownloadFileName: "test.xlsx" };
         testForSensAndMultiSens((wrapper) => {
             const downloadOutput = wrapper.findComponent(DownloadOutput);
             expect(downloadOutput.props().open).toBe(false);
@@ -186,7 +191,7 @@ describe("SensitivitySummaryDownload", () => {
     it("opens dialog on click download button", async () => {
         const wrapper = getWrapper();
         const button = wrapper.find("button#download-summary-btn");
-        expect((button.element as HTMLButtonElement).disabled).toBe(false)
+        expect((button.element as HTMLButtonElement).disabled).toBe(false);
         await button.trigger("click");
         expect(wrapper.findComponent(DownloadOutput).props().open).toBe(true);
     });
@@ -203,7 +208,7 @@ describe("SensitivitySummaryDownload", () => {
     it("verifies end time and dispatches action on download output emit", () => {
         testForSensAndMultiSens((wrapper) => {
             const downloadOutput = wrapper.findComponent(DownloadOutput);
-            downloadOutput.vm.$emit("download", {fileName: "test.xlsx"});
+            downloadOutput.vm.$emit("download", { fileName: "test.xlsx" });
             // should have updated plot settings time to run end time
             expect(mockSetPlotTime).toHaveBeenCalledTimes(1);
             expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -1,19 +1,19 @@
-import {mount, shallowMount} from "@vue/test-utils";
+import {shallowMount} from "@vue/test-utils";
 import Vuex from "vuex";
-import { nextTick } from "vue";
-import { ModelState } from "../../../../src/app/store/model/state";
+import {ModelState} from "../../../../src/app/store/model/state";
 import SensitivityTab from "../../../../src/app/components/sensitivity/SensitivityTab.vue";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
-import { BaseSensitivityGetter, SensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
+import {BaseSensitivityGetter} from "../../../../src/app/store/sensitivity/getters";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
-import { SensitivityPlotType, SensitivityState } from "../../../../src/app/store/sensitivity/state";
-import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
+import {SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
+import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
-import { AppState, AppType } from "../../../../src/app/store/appState/state";
-import { ModelGetter } from "../../../../src/app/store/model/getters";
+import {AppState, AppType} from "../../../../src/app/store/appState/state";
+import {ModelGetter} from "../../../../src/app/store/model/getters";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
-import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import SensitivitySummaryDownload from "../../../../src/app/components/sensitivity/SensitivitySummaryDownload.vue";
 
 jest.mock("plotly.js-basic-dist-min", () => {});
 
@@ -143,6 +143,13 @@ describe("SensitivityTab", () => {
         const wrapper = getWrapper(AppType.Basic, {}, sensitivityState);
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(false);
         expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
+    });
+
+    it("renders SensitivitySummaryDownload", () => {
+        const wrapper = getWrapper(AppType.Basic);
+        const download = wrapper.findComponent(SensitivitySummaryDownload);
+        expect(download.props("multiSensitivity")).toBe(false);
+        expect(download.props("downloadType")).toBe("Sensitivity Summary");
     });
 
     it("renders error", () => {

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import Vuex from "vuex";
 import { nextTick } from "vue";
 import { ModelState } from "../../../../src/app/store/model/state";
@@ -14,15 +14,12 @@ import { AppState, AppType } from "../../../../src/app/store/appState/state";
 import { ModelGetter } from "../../../../src/app/store/model/getters";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
 import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
-import DownloadOutput from "../../../../src/app/components/DownloadOutput.vue";
 
 jest.mock("plotly.js-basic-dist-min", () => {});
 
 describe("SensitivityTab", () => {
     const mockRunSensitivity = jest.fn();
     const mockSetLoading = jest.fn();
-    const mockSetUserSummaryDownloadFileName = jest.fn();
-    const mockDownloadSummary = jest.fn();
     const mockSetPlotTime = jest.fn();
 
     const getWrapper = (appType = AppType.Basic, modelState: Partial<ModelState> = {},
@@ -74,25 +71,22 @@ describe("SensitivityTab", () => {
                         paramSettings: {
                             numberOfRuns: 5
                         },
-                        userSummaryDownloadFileName: "",
                         ...sensitivityState
                     },
                     getters: {
                         [BaseSensitivityGetter.batchPars]: () => batchPars
                     },
                     actions: {
-                        [SensitivityAction.RunSensitivity]: mockRunSensitivity,
-                        [SensitivityAction.DownloadSummary]: mockDownloadSummary
+                        [SensitivityAction.RunSensitivity]: mockRunSensitivity
                     },
                     mutations: {
                         [SensitivityMutation.SetLoading]: mockSetLoading,
-                        [SensitivityMutation.SetUserSummaryDownloadFileName]: mockSetUserSummaryDownloadFileName,
                         [SensitivityMutation.SetPlotTime]: mockSetPlotTime
                     }
                 }
             }
         });
-        return mount(SensitivityTab, {
+        return shallowMount(SensitivityTab, {
             global: {
                 plugins: [store],
                 stubs: [
@@ -149,73 +143,6 @@ describe("SensitivityTab", () => {
         const wrapper = getWrapper(AppType.Basic, {}, sensitivityState);
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(false);
         expect(wrapper.findComponent(SensitivityTracesPlot).exists()).toBe(false);
-    });
-
-    it("enables download button when expected", () => {
-        const expectDownloadButtonEnabled = (state: Partial<SensitivityState>, expectButtonEnabled: boolean) => {
-            const wrapper = getWrapper(AppType.Basic, {}, state);
-            const button = wrapper.find("button#download-summary-btn");
-            expect((button.element as HTMLButtonElement).disabled).toBe(!expectButtonEnabled);
-        };
-
-        // enabled if not downloading, and no update required, and batch result exists
-        const noUpdateRequiredReasons = {
-            modelChanged: false,
-            parameterValueChanged: false,
-            endTimeChanged: false,
-            sensitivityOptionsChanged: false,
-            numberOfReplicatesChanged: false
-        };
-        const enabledResult = {
-            inputs: {},
-            batch: {
-                solutions: ["test solution"] as any,
-                errors: []
-            },
-            error: null
-        };
-        const enabledState = {
-            downloading: false,
-            sensitivityUpdateRequired: noUpdateRequiredReasons,
-            result: enabledResult
-        } as any;
-        expectDownloadButtonEnabled(enabledState, true);
-
-        // disabled if downloading
-        expectDownloadButtonEnabled({ ...enabledState, downloading: true }, false);
-
-        // disabled if update required
-        expectDownloadButtonEnabled({
-            ...enabledState,
-            sensitivityUpdateRequired: { modelChanged: true }
-        }, false);
-
-        // disabled if no batch result
-        expectDownloadButtonEnabled({
-            ...enabledState,
-            result: { ...enabledResult, batch: null }
-        }, false);
-    });
-
-    it("renders DownloadOutput as expected", () => {
-        const wrapper = getWrapper(AppType.Basic, {}, { userSummaryDownloadFileName: "test.xlsx" });
-        const downloadOutput = wrapper.findComponent(DownloadOutput);
-        expect(downloadOutput.props().open).toBe(false);
-        expect(downloadOutput.props().downloadType).toBe("Sensitivity Summary");
-        expect(downloadOutput.props().includePoints).toBe(false);
-        expect(downloadOutput.props().userFileName).toBe("test.xlsx");
-    });
-
-    it("renders downloading as expected", () => {
-        // does not render if not downloading
-        let wrapper = getWrapper();
-        expect(wrapper.find("div#downloading").exists()).toBe(false);
-
-        // does render if downloading
-        wrapper = getWrapper(AppType.Basic, {}, { downloading: true });
-        const downloading = wrapper.find("div#downloading");
-        expect(downloading.text()).toBe("Downloading...");
-        expect(wrapper.findComponent(LoadingSpinner).props("size")).toBe("xs");
     });
 
     it("renders error", () => {
@@ -351,38 +278,5 @@ describe("SensitivityTab", () => {
         await new Promise((r) => setTimeout(r, 101));
         expect(mockRunSensitivity).toHaveBeenCalledTimes(1);
         expect(mockSetLoading).toHaveBeenCalledTimes(1);
-    });
-
-    it("opens dialog on click download button", async () => {
-        const wrapper = getWrapper();
-        await wrapper.find("button#download-summary-btn").trigger("click");
-        expect(wrapper.findComponent(DownloadOutput).props().open).toBe(true);
-    });
-
-    it("commits user download filename change", () => {
-        const wrapper = getWrapper();
-        const downloadOutput = wrapper.findComponent(DownloadOutput);
-        downloadOutput.vm.$emit("update:userFileName", "newFile.xlsx");
-        expect(mockSetUserSummaryDownloadFileName).toHaveBeenCalledTimes(1);
-        expect(mockSetUserSummaryDownloadFileName.mock.calls[0][1]).toBe("newFile.xlsx");
-    });
-
-    it("verifies end time and dispatches action on download output emit", () => {
-        const wrapper = getWrapper();
-        const downloadOutput = wrapper.findComponent(DownloadOutput);
-        downloadOutput.vm.$emit("download", { fileName: "test.xlsx" });
-        // should have updated plot settings time to run end time
-        expect(mockSetPlotTime.mock.calls[0][1]).toBe(100);
-        expect(mockDownloadSummary.mock.calls[0][1]).toBe("test.xlsx");
-    });
-
-    it("closes output dialog on close emit", async () => {
-        const wrapper = getWrapper();
-        await wrapper.find("#download-summary-btn").trigger("click");
-        const downloadOutput = wrapper.findComponent(DownloadOutput);
-        expect(downloadOutput.props().open).toBe(true);
-        downloadOutput.vm.$emit("close");
-        await nextTick();
-        expect(downloadOutput.props().open).toBe(false);
     });
 });

--- a/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivityTab.test.ts
@@ -1,19 +1,20 @@
-import {shallowMount} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
-import {ModelState} from "../../../../src/app/store/model/state";
+import { ModelState } from "../../../../src/app/store/model/state";
 import SensitivityTab from "../../../../src/app/components/sensitivity/SensitivityTab.vue";
 import ActionRequiredMessage from "../../../../src/app/components/ActionRequiredMessage.vue";
-import {BaseSensitivityGetter} from "../../../../src/app/store/sensitivity/getters";
+import { BaseSensitivityGetter } from "../../../../src/app/store/sensitivity/getters";
 import SensitivityTracesPlot from "../../../../src/app/components/sensitivity/SensitivityTracesPlot.vue";
-import {SensitivityPlotType, SensitivityState} from "../../../../src/app/store/sensitivity/state";
-import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import { SensitivityPlotType, SensitivityState } from "../../../../src/app/store/sensitivity/state";
+import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import SensitivitySummaryPlot from "../../../../src/app/components/sensitivity/SensitivitySummaryPlot.vue";
 import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
-import {AppState, AppType} from "../../../../src/app/store/appState/state";
-import {ModelGetter} from "../../../../src/app/store/model/getters";
+import { AppState, AppType } from "../../../../src/app/store/appState/state";
+import { ModelGetter } from "../../../../src/app/store/model/getters";
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
-import {SensitivityMutation} from "../../../../src/app/store/sensitivity/mutations";
+import { SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import SensitivitySummaryDownload from "../../../../src/app/components/sensitivity/SensitivitySummaryDownload.vue";
+import LoadingButton from "../../../../src/app/components/LoadingButton.vue";
 
 jest.mock("plotly.js-basic-dist-min", () => {});
 
@@ -106,8 +107,7 @@ describe("SensitivityTab", () => {
 
     it("renders as expected when Trace over Time", () => {
         const wrapper = getWrapper();
-        expect(wrapper.find("button").text()).toBe("Run sensitivity");
-        expect(wrapper.find("button").element.disabled).toBe(false);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(SensitivityTracesPlot).props("fadePlot")).toBe(false);
         expect(wrapper.findComponent(ErrorInfo).props("error")).toBe(null);
@@ -117,14 +117,13 @@ describe("SensitivityTab", () => {
 
     it("enables sensitivity when app is stochastic and runner is available", () => {
         const wrapper = getWrapper(AppType.Stochastic);
-        expect(wrapper.find("button").element.disabled).toBe(false);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(false);
     });
 
     it("renders as expected when Value at Time", () => {
         const sensitivityState = { plotSettings: { plotType: SensitivityPlotType.ValueAtTime } as any };
         const wrapper = getWrapper(AppType.Fit, {}, sensitivityState);
-        expect(wrapper.find("button").text()).toBe("Run sensitivity");
-        expect(wrapper.find("button").element.disabled).toBe(false);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(false);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(SensitivitySummaryPlot).props("fadePlot")).toBe(false);
 
@@ -167,34 +166,34 @@ describe("SensitivityTab", () => {
 
     it("disables run button when hasRunner is false", () => {
         const wrapper = getWrapper(AppType.Basic, { odinRunnerOde: null }, {}, {}, false);
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(true);
     });
 
     it("disables run button when no odin model", () => {
         const wrapper = getWrapper(AppType.Fit, { odin: null });
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(true);
     });
 
     it("disables run button when required action is Compile", () => {
         const wrapper = getWrapper(AppType.Basic, {
             compileRequired: true
         });
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(true);
     });
 
     it("disables run button when no batchPars", () => {
         const wrapper = getWrapper(AppType.Basic, {}, {}, null);
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("isDisabled")).toBe(true);
     });
 
-    it("disables run button when loading is true", () => {
+    it("sets loading prop on LoadingBUtton when loading is true", () => {
         const wrapper = getWrapper(AppType.Fit, {}, { loading: true });
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("loading")).toBe(true);
     });
 
-    it("disables run button when running is true", () => {
+    it("sets loading prop on LoadingButton when running is true", () => {
         const wrapper = getWrapper(AppType.Fit, {}, { running: true });
-        expect(wrapper.find("button").element.disabled).toBe(true);
+        expect(wrapper.findComponent(LoadingButton).props("loading")).toBe(true);
     });
 
     it("renders expected update message when required action is Compile", () => {
@@ -281,7 +280,7 @@ describe("SensitivityTab", () => {
         const wrapper = getWrapper();
         expect(mockRunSensitivity).not.toHaveBeenCalled();
         expect(mockSetLoading).not.toHaveBeenCalled();
-        wrapper.find("button").trigger("click");
+        wrapper.findComponent(LoadingButton).vm.$emit("click");
         await new Promise((r) => setTimeout(r, 101));
         expect(mockRunSensitivity).toHaveBeenCalledTimes(1);
         expect(mockSetLoading).toHaveBeenCalledTimes(1);

--- a/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
@@ -56,6 +56,16 @@ const mockBatchMulti = {
     })
 };
 
+const plotSettings = {
+    time: 50
+};
+
+const parameterValues = {
+    beta: 1.1,
+    N: 1000,
+    D: 3
+};
+
 describe("WodinSensitivitySummaryDownload", () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -67,17 +77,11 @@ describe("WodinSensitivitySummaryDownload", () => {
         } as any;
         const rootState = mockBasicState({
             sensitivity: mockSensitivityState({
-                plotSettings: {
-                    time: 50
-                },
+                plotSettings,
                 result
             } as any),
             run: mockRunState({
-                parameterValues: {
-                    beta: 1.1,
-                    N: 1000,
-                    D: 3
-                }
+                parameterValues
             })
         });
         const commit = jest.fn();
@@ -156,19 +160,13 @@ describe("WodinSensitivitySummaryDownload", () => {
         } as any;
         const rootState = mockBasicState({
             sensitivity: mockSensitivityState({
-                plotSettings: {
-                    time: 50
-                }
+                plotSettings
             } as any),
             multiSensitivity: {
                 result
             } as any,
             run: mockRunState({
-                parameterValues: {
-                    beta: 1.1,
-                    N: 1000,
-                    D: 3
-                }
+                parameterValues
             })
         });
         const commit = jest.fn();

--- a/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
@@ -179,10 +179,18 @@ describe("WodinSensitivitySummaryDownload", () => {
 
         expect(mockBookAppendSheet.mock.calls[0][1]).toStrictEqual({
             data: [
-                { beta: 1, N: 100, S: 10, I: 50 },
-                { beta: 1, N: 1000, S: 20, I: 60 },
-                { beta: 2, N: 100, S: 30, I: 70 },
-                { beta: 2, N: 1000, S: 40, I: 80 }
+                {
+                    beta: 1, N: 100, S: 10, I: 50
+                },
+                {
+                    beta: 1, N: 1000, S: 20, I: 60
+                },
+                {
+                    beta: 2, N: 100, S: 30, I: 70
+                },
+                {
+                    beta: 2, N: 1000, S: 40, I: 80
+                }
             ],
             type: "json"
         });

--- a/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/excel/wodinSensitivitySummaryDownload.test.ts
@@ -8,6 +8,7 @@ const xValues = [
     { beta: 1.2 }
 ];
 const mockBatch = {
+    successfulVaryingParams: xValues,
     valueAtTime: jest.fn().mockImplementation(() => {
         return {
             x: xValues,
@@ -27,23 +28,49 @@ const mockBatch = {
     })
 };
 
+const xValuesMulti = [
+    { beta: 1, N: 100 },
+    { beta: 1, N: 1000 },
+    { beta: 2, N: 100 },
+    { beta: 2, N: 1000 }
+];
+
+const mockBatchMulti = {
+    successfulVaryingParams: xValuesMulti,
+    valueAtTime: jest.fn().mockImplementation(() => {
+        return {
+            x: xValuesMulti,
+            values: [
+                { name: "S", y: [10, 20, 30, 40] },
+                { name: "I", y: [50, 60, 70, 80] }
+            ]
+        };
+    }),
+    extreme: jest.fn().mockImplementation((extremeType: string) => {
+        return {
+            x: xValuesMulti,
+            values: [
+                { name: extremeType, y: [11, 22, 33, 44] }
+            ]
+        };
+    })
+};
+
 describe("WodinSensitivitySummaryDownload", () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it("downloads expected workbook", () => {
+    it("downloads expected workbook for single varying parameter", () => {
+        const result = {
+            batch: mockBatch
+        } as any;
         const rootState = mockBasicState({
             sensitivity: mockSensitivityState({
-                paramSettings: {
-                    parameterToVary: "beta"
-                },
                 plotSettings: {
                     time: 50
                 },
-                result: {
-                    batch: mockBatch
-                }
+                result
             } as any),
             run: mockRunState({
                 parameterValues: {
@@ -56,7 +83,7 @@ describe("WodinSensitivitySummaryDownload", () => {
         const commit = jest.fn();
         const context = { rootState, commit } as any;
         const sut = new WodinSensitivitySummaryDownload(context, "test.xlsx");
-        sut.download();
+        sut.download(result);
 
         expect(mockBookNew).toHaveBeenCalledTimes(1);
         expect(mockBatch.valueAtTime).toHaveBeenCalledWith(50);
@@ -114,6 +141,101 @@ describe("WodinSensitivitySummaryDownload", () => {
         expect(mockBookAppendSheet.mock.calls[5][1]).toStrictEqual({
             data: [
                 { name: "N", value: 1000 },
+                { name: "D", value: 3 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[5][2]).toStrictEqual("Parameters");
+
+        expect(mockWriteFile.mock.calls[0][1]).toBe("test.xlsx");
+    });
+
+    it("downloads expected workbook for multiple varying parameter", () => {
+        const result = {
+            batch: mockBatchMulti
+        } as any;
+        const rootState = mockBasicState({
+            sensitivity: mockSensitivityState({
+                plotSettings: {
+                    time: 50
+                }
+            } as any),
+            multiSensitivity: {
+                result
+            } as any,
+            run: mockRunState({
+                parameterValues: {
+                    beta: 1.1,
+                    N: 1000,
+                    D: 3
+                }
+            })
+        });
+        const commit = jest.fn();
+        const context = { rootState, commit } as any;
+        const sut = new WodinSensitivitySummaryDownload(context, "test.xlsx");
+        sut.download(result);
+
+        expect(mockBookNew).toHaveBeenCalledTimes(1);
+        expect(mockBatchMulti.valueAtTime).toHaveBeenCalledWith(50);
+
+        expect(mockBookAppendSheet.mock.calls[0][1]).toStrictEqual({
+            data: [
+                { beta: 1, N: 100, S: 10, I: 50 },
+                { beta: 1, N: 1000, S: 20, I: 60 },
+                { beta: 2, N: 100, S: 30, I: 70 },
+                { beta: 2, N: 1000, S: 40, I: 80 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[0][2]).toStrictEqual("ValueAtTime50");
+
+        expect(mockBookAppendSheet.mock.calls[1][1]).toStrictEqual({
+            data: [
+                { beta: 1, N: 100, yMin: 11 },
+                { beta: 1, N: 1000, yMin: 22 },
+                { beta: 2, N: 100, yMin: 33 },
+                { beta: 2, N: 1000, yMin: 44 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[1][2]).toStrictEqual("ValueAtMin");
+
+        expect(mockBookAppendSheet.mock.calls[2][1]).toStrictEqual({
+            data: [
+                { beta: 1, N: 100, yMax: 11 },
+                { beta: 1, N: 1000, yMax: 22 },
+                { beta: 2, N: 100, yMax: 33 },
+                { beta: 2, N: 1000, yMax: 44 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[2][2]).toStrictEqual("ValueAtMax");
+
+        expect(mockBookAppendSheet.mock.calls[3][1]).toStrictEqual({
+            data: [
+                { beta: 1, N: 100, tMin: 11 },
+                { beta: 1, N: 1000, tMin: 22 },
+                { beta: 2, N: 100, tMin: 33 },
+                { beta: 2, N: 1000, tMin: 44 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[3][2]).toStrictEqual("TimeAtMin");
+
+        expect(mockBookAppendSheet.mock.calls[4][1]).toStrictEqual({
+            data: [
+                { beta: 1, N: 100, tMax: 11 },
+                { beta: 1, N: 1000, tMax: 22 },
+                { beta: 2, N: 100, tMax: 33 },
+                { beta: 2, N: 1000, tMax: 44 }
+            ],
+            type: "json"
+        });
+        expect(mockBookAppendSheet.mock.calls[4][2]).toStrictEqual("TimeAtMax");
+
+        expect(mockBookAppendSheet.mock.calls[5][1]).toStrictEqual({
+            data: [
                 { name: "D", value: 3 }
             ],
             type: "json"

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -136,7 +136,10 @@ describe("BaseSensitivity actions", () => {
         mockWodinSensitivitySummaryDownload.mockImplementation(() => ({ download: mockDownload }));
 
         const commit = jest.fn();
-        const context = { commit };
+        const state = {
+            result: {}
+        };
+        const context = { commit, state };
         const payload = "myFile.xlsx";
         (actions[BaseSensitivityAction.DownloadSummary] as any)(context, payload);
         expect(commit).toHaveBeenCalledTimes(1);
@@ -147,6 +150,7 @@ describe("BaseSensitivity actions", () => {
             expect(mockWodinSensitivitySummaryDownload.mock.calls[0][0]).toBe(context);
             expect(mockWodinSensitivitySummaryDownload.mock.calls[0][1]).toBe("myFile.xlsx");
             expect(mockDownload).toHaveBeenCalledTimes(1);
+            expect(mockDownload.mock.calls[0][0]).toBe(state.result);
 
             expect(commit).toHaveBeenCalledTimes(2);
             expect(commit.mock.calls[1][0]).toBe(BaseSensitivityMutation.SetDownloading);

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -129,6 +129,32 @@ describe("BaseSensitivity actions", () => {
             done();
         });
     });
+
+    it("downloads sensitivity summary", (done) => {
+        const mockDownload = jest.fn();
+        const mockWodinSensitivitySummaryDownload = WodinSensitivitySummaryDownload as any as Mock;
+        mockWodinSensitivitySummaryDownload.mockImplementation(() => ({ download: mockDownload }));
+
+        const commit = jest.fn();
+        const context = { commit };
+        const payload = "myFile.xlsx";
+        (actions[BaseSensitivityAction.DownloadSummary] as any)(context, payload);
+        expect(commit).toHaveBeenCalledTimes(1);
+        expect(commit.mock.calls[0][0]).toBe(BaseSensitivityMutation.SetDownloading);
+        expect(commit.mock.calls[0][1]).toBe(true);
+        setTimeout(() => {
+            expect(mockWodinSensitivitySummaryDownload).toHaveBeenCalledTimes(1); // expect download constructor
+            expect(mockWodinSensitivitySummaryDownload.mock.calls[0][0]).toBe(context);
+            expect(mockWodinSensitivitySummaryDownload.mock.calls[0][1]).toBe("myFile.xlsx");
+            expect(mockDownload).toHaveBeenCalledTimes(1);
+
+            expect(commit).toHaveBeenCalledTimes(2);
+            expect(commit.mock.calls[1][0]).toBe(BaseSensitivityMutation.SetDownloading);
+            expect(commit.mock.calls[1][1]).toBe(false);
+
+            done();
+        }, 20);
+    });
 });
 
 export const testCommonRunSensitivity = (runSensitivityAction: Action<any, AppState>) => {
@@ -526,31 +552,5 @@ describe("Sensitivity actions", () => {
         );
 
         expect(dispatch).not.toHaveBeenCalled();
-    });
-
-    it("downloads sensitivity summary", (done) => {
-        const mockDownload = jest.fn();
-        const mockWodinSensitivitySummaryDownload = WodinSensitivitySummaryDownload as any as Mock;
-        mockWodinSensitivitySummaryDownload.mockImplementation(() => ({ download: mockDownload }));
-
-        const commit = jest.fn();
-        const context = { commit };
-        const payload = "myFile.xlsx";
-        (actions[SensitivityAction.DownloadSummary] as any)(context, payload);
-        expect(commit).toHaveBeenCalledTimes(1);
-        expect(commit.mock.calls[0][0]).toBe(SensitivityMutation.SetDownloading);
-        expect(commit.mock.calls[0][1]).toBe(true);
-        setTimeout(() => {
-            expect(mockWodinSensitivitySummaryDownload).toHaveBeenCalledTimes(1); // expect download constructor
-            expect(mockWodinSensitivitySummaryDownload.mock.calls[0][0]).toBe(context);
-            expect(mockWodinSensitivitySummaryDownload.mock.calls[0][1]).toBe("myFile.xlsx");
-            expect(mockDownload).toHaveBeenCalledTimes(1);
-
-            expect(commit).toHaveBeenCalledTimes(2);
-            expect(commit.mock.calls[1][0]).toBe(SensitivityMutation.SetDownloading);
-            expect(commit.mock.calls[1][1]).toBe(false);
-
-            done();
-        }, 20);
     });
 });


### PR DESCRIPTION
This branch adds download button to the Multi-sensitivity tab, so summary Excel file can be downloaded after run. 

Key changes:
- The changes to the WodinExcelDownload class were actually pretty minimal. The download method now takes an odin result in order to distinguish between single and multi sensitivity to download, and all varying parameter values are determined from the batch itself.
- more tedious refactoring for code sharing in the components - I've pulled out a `SensitivitySummaryDownload` component which is used by both the Sensitivity and Multi-sensitivity tabs, and it uses the `baseSensitivityMixin` to manage the download for both, 
- I may have gone overboard in the unit testing for these units - some functionality tested in both the mixin and component..
- The Sensitivity tab unit tests were doing a `mount` rather than a `shallowMount` and testing HTML elements rendered by child components, particularly the button rendered by the `LoadingButton`. This doesn't really fit out usual component unit testing pattern, so I refactored that to do a `shallowMount` instead and just test the component props. 