### PR TITLE
mrc-4563 Serialise and rehydrate Multi-sensitivity

### DIFF
--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -11,10 +11,11 @@ import {
     SerialisedAppState, SerialisedModelState,
     SerialisedRunState,
     SerialisedSensitivityState,
-    SerialisedRunResult, SerialisedSensitivityResult
+    SerialisedRunResult, SerialisedSensitivityResult, SerialisedMultiSensitivityState
 } from "./types/serialisationTypes";
 import { GraphSettingsState } from "./store/graphSettings/state";
 import { Dict } from "./types/utilTypes";
+import {MultiSensitivityState} from "./store/multiSensitivity/state";
 
 function serialiseCode(code: CodeState) : CodeState {
     return {
@@ -95,6 +96,19 @@ function serialiseSensitivity(sensitivity: SensitivityState): SerialisedSensitiv
     };
 }
 
+function serialiseMultiSensitivity(multiSensitivity: MultiSensitivityState): SerialisedMultiSensitivityState {
+    return {
+        running: false,
+        paramSettings: multiSensitivity.paramSettings,
+        sensitivityUpdateRequired: multiSensitivity.sensitivityUpdateRequired,
+        result: multiSensitivity.result ? {
+            inputs: multiSensitivity.result.inputs,
+            hasResult: !!multiSensitivity.result.batch,
+            error: multiSensitivity.result.error
+        } : null
+    };
+}
+
 function serialiseFitData(fitData: FitDataState) : FitDataState {
     return {
         data: fitData.data,
@@ -129,6 +143,7 @@ export const serialiseState = (state: AppState) => {
         model: serialiseModel(state.model),
         run: serialiseRun(state.run),
         sensitivity: serialiseSensitivity(state.sensitivity),
+        multiSensitivity: serialiseMultiSensitivity(state.multiSensitivity),
         graphSettings: serialiseGraphSettings(state.graphSettings)
     };
 

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -3,7 +3,7 @@ import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
 import { RunState } from "./store/run/state";
-import {BaseSensitivityState, SensitivityState} from "./store/sensitivity/state";
+import { BaseSensitivityState, SensitivityState } from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
 import { OdinFitResult, OdinRunResultDiscrete, OdinRunResultOde } from "./types/wrapperTypes";
@@ -15,7 +15,7 @@ import {
 } from "./types/serialisationTypes";
 import { GraphSettingsState } from "./store/graphSettings/state";
 import { Dict } from "./types/utilTypes";
-import {MultiSensitivityState} from "./store/multiSensitivity/state";
+import { MultiSensitivityState } from "./store/multiSensitivity/state";
 
 function serialiseCode(code: CodeState) : CodeState {
     return {
@@ -80,7 +80,7 @@ function serialiseBaseSensitivity(sensitivity: BaseSensitivityState) {
             hasResult: !!sensitivity.result.batch,
             error: sensitivity.result.error
         } : null
-    }
+    };
 }
 
 function serialiseSensitivity(sensitivity: SensitivityState): SerialisedSensitivityState {

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -3,7 +3,7 @@ import { FitState } from "./store/fit/state";
 import { CodeState } from "./store/code/state";
 import { ModelState } from "./store/model/state";
 import { RunState } from "./store/run/state";
-import { SensitivityState } from "./store/sensitivity/state";
+import {BaseSensitivityState, SensitivityState} from "./store/sensitivity/state";
 import { FitDataState } from "./store/fitData/state";
 import { ModelFitState } from "./store/modelFit/state";
 import { OdinFitResult, OdinRunResultDiscrete, OdinRunResultOde } from "./types/wrapperTypes";
@@ -71,6 +71,18 @@ function serialiseRun(run: RunState): SerialisedRunState {
     };
 }
 
+function serialiseBaseSensitivity(sensitivity: BaseSensitivityState) {
+    return {
+        running: false,
+        sensitivityUpdateRequired: sensitivity.sensitivityUpdateRequired,
+        result: sensitivity.result ? {
+            inputs: sensitivity.result.inputs,
+            hasResult: !!sensitivity.result.batch,
+            error: sensitivity.result.error
+        } : null
+    }
+}
+
 function serialiseSensitivity(sensitivity: SensitivityState): SerialisedSensitivityState {
     const serialisedParameterSetResults = {} as Dict<SerialisedSensitivityResult>;
     Object.keys(sensitivity.parameterSetResults).forEach((name) => {
@@ -83,29 +95,17 @@ function serialiseSensitivity(sensitivity: SensitivityState): SerialisedSensitiv
     });
 
     return {
-        running: false,
+        ...serialiseBaseSensitivity(sensitivity),
         paramSettings: sensitivity.paramSettings,
-        sensitivityUpdateRequired: sensitivity.sensitivityUpdateRequired,
         plotSettings: sensitivity.plotSettings,
-        result: sensitivity.result ? {
-            inputs: sensitivity.result.inputs,
-            hasResult: !!sensitivity.result.batch,
-            error: sensitivity.result.error
-        } : null,
         parameterSetResults: serialisedParameterSetResults
     };
 }
 
 function serialiseMultiSensitivity(multiSensitivity: MultiSensitivityState): SerialisedMultiSensitivityState {
     return {
-        running: false,
-        paramSettings: multiSensitivity.paramSettings,
-        sensitivityUpdateRequired: multiSensitivity.sensitivityUpdateRequired,
-        result: multiSensitivity.result ? {
-            inputs: multiSensitivity.result.inputs,
-            hasResult: !!multiSensitivity.result.batch,
-            error: multiSensitivity.result.error
-        } : null
+        ...serialiseBaseSensitivity(multiSensitivity),
+        paramSettings: multiSensitivity.paramSettings
     };
 }
 

--- a/app/static/src/app/store/multiSensitivity/actions.ts
+++ b/app/static/src/app/store/multiSensitivity/actions.ts
@@ -1,11 +1,16 @@
 import { ActionTree } from "vuex";
 import { AppState } from "../appState/state";
-import { baseSensitivityActions, runSensitivity } from "../sensitivity/actions";
+import {
+    baseSensitivityActions,
+    runSensitivity,
+    runSensitivityOnRehydrate
+} from "../sensitivity/actions";
 import { MultiSensitivityState } from "./state";
 import { BaseSensitivityGetter } from "../sensitivity/getters";
 
 export enum MultiSensitivityAction {
     RunMultiSensitivity = "RunMultiSensitivity",
+    RunMultiSensitivityOnRehydrate = "RunMultiSensitivityOnRehydrate"
 }
 
 export const actions: ActionTree<MultiSensitivityState, AppState> = {
@@ -16,5 +21,9 @@ export const actions: ActionTree<MultiSensitivityState, AppState> = {
         const batchPars = getters[BaseSensitivityGetter.batchPars];
 
         runSensitivity(batchPars, endTime, context, true);
+    },
+
+    [MultiSensitivityAction.RunMultiSensitivityOnRehydrate](context) {
+        runSensitivityOnRehydrate(context);
     }
 };

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -143,6 +143,14 @@ export const runSensitivity = (
     }
 };
 
+export const runSensitivityOnRehydrate = (context: ActionContext<BaseSensitivityState, AppState>) => {
+    const { state, rootState } = context;
+    const { endTime } = rootState.run;
+    const { pars } = state.result!.inputs;
+
+    runSensitivity(pars, endTime, context);
+}
+
 export const baseSensitivityActions: ActionTree<BaseSensitivityState, AppState> = {
     [BaseSensitivityAction.ComputeNext](context, batch: Batch) {
         const {
@@ -181,10 +189,6 @@ export const actions: ActionTree<SensitivityState, AppState> = {
     },
 
     [SensitivityAction.RunSensitivityOnRehydrate](context) {
-        const { state, rootState } = context;
-        const { endTime } = rootState.run;
-        const { pars } = state.result!.inputs;
-
-        runSensitivity(pars, endTime, context);
+        runSensitivityOnRehydrate(context);
     }
 };

--- a/app/static/src/app/store/sensitivity/actions.ts
+++ b/app/static/src/app/store/sensitivity/actions.ts
@@ -149,7 +149,7 @@ export const runSensitivityOnRehydrate = (context: ActionContext<BaseSensitivity
     const { pars } = state.result!.inputs;
 
     runSensitivity(pars, endTime, context);
-}
+};
 
 export const baseSensitivityActions: ActionTree<BaseSensitivityState, AppState> = {
     [BaseSensitivityAction.ComputeNext](context, batch: Batch) {

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -12,7 +12,7 @@ import { SerialisedAppState } from "../../types/serialisationTypes";
 import { deserialiseState } from "../../serialise";
 import { SensitivityAction } from "../sensitivity/actions";
 import { AppStateGetter } from "../appState/getters";
-import {MultiSensitivityAction} from "../multiSensitivity/actions";
+import { MultiSensitivityAction } from "../multiSensitivity/actions";
 
 export enum SessionsAction {
     GetSessions = "GetSessions",
@@ -69,7 +69,8 @@ export const actions: ActionTree<SessionsState, AppState> = {
                     dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
                 }
                 if (sessionData.multiSensitivity.result?.hasResult) {
-                    dispatch(`multiSensitivity/${MultiSensitivityAction.RunMultiSensitivityOnRehydrate}`, null, rootOption);
+                    dispatch(`multiSensitivity/${MultiSensitivityAction.RunMultiSensitivityOnRehydrate}`, null,
+                        rootOption);
                 }
             }
         }

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -12,6 +12,7 @@ import { SerialisedAppState } from "../../types/serialisationTypes";
 import { deserialiseState } from "../../serialise";
 import { SensitivityAction } from "../sensitivity/actions";
 import { AppStateGetter } from "../appState/getters";
+import {MultiSensitivityAction} from "../multiSensitivity/actions";
 
 export enum SessionsAction {
     GetSessions = "GetSessions",
@@ -66,6 +67,9 @@ export const actions: ActionTree<SessionsState, AppState> = {
                 }
                 if (sessionData.sensitivity.result?.hasResult) {
                     dispatch(`sensitivity/${SensitivityAction.RunSensitivityOnRehydrate}`, null, rootOption);
+                }
+                if (sessionData.multiSensitivity.result?.hasResult) {
+                    dispatch(`multiSensitivity/${MultiSensitivityAction.RunMultiSensitivityOnRehydrate}`, null, rootOption);
                 }
             }
         }

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -65,6 +65,13 @@ export interface SerialisedSensitivityState {
     parameterSetResults: Dict<SerialisedSensitivityResult>
 }
 
+export interface SerialisedMultiSensitivityState {
+    running: boolean,
+    paramSettings: SensitivityParameterSettings[]
+    sensitivityUpdateRequired: SensitivityUpdateRequiredReasons,
+    result: null | SerialisedSensitivityResult
+}
+
 export interface SerialisedModelFitState {
     fitUpdateRequired: FitUpdateRequiredReasons,
     iterations: number | null,
@@ -80,6 +87,7 @@ export interface SerialisedAppState {
     model: SerialisedModelState,
     run: SerialisedRunState,
     sensitivity: SerialisedSensitivityState,
+    multiSensitivity: SerialisedMultiSensitivityState,
     graphSettings: GraphSettingsState,
     fitData?: FitDataState,
     modelFit?: SerialisedModelFitState,

--- a/app/static/tests/e2e/download.etest.ts
+++ b/app/static/tests/e2e/download.etest.ts
@@ -21,6 +21,7 @@ test.describe("Download tests", () => {
     };
 
     test("can download from Run tab", async ({ page }) => {
+        console.log("start download");
         await page.click("#download-btn");
         await expect(await page.inputValue("#download-file-name input")).toContain("day2-run");
         await testCanInputFileNameAndDownload(page);

--- a/app/static/tests/e2e/download.etest.ts
+++ b/app/static/tests/e2e/download.etest.ts
@@ -21,7 +21,6 @@ test.describe("Download tests", () => {
     };
 
     test("can download from Run tab", async ({ page }) => {
-        console.log("start download");
         await page.click("#download-btn");
         await expect(await page.inputValue("#download-file-name input")).toContain("day2-run");
         await testCanInputFileNameAndDownload(page);

--- a/app/static/tests/e2e/multiSensitivity.etest.ts
+++ b/app/static/tests/e2e/multiSensitivity.etest.ts
@@ -1,11 +1,11 @@
 import { expect, Page, test } from "@playwright/test";
 import { SensitivityScaleType, SensitivityVariationType } from "../../src/app/store/sensitivity/state";
 import PlaywrightConfig from "../../playwright.config";
-import { writeCode } from "./utils";
+import { expectCanRunMultiSensitivity, writeCode } from "./utils";
+
+const { timeout } = PlaywrightConfig;
 
 test.describe("Multi-sensitivity tests", () => {
-    const { timeout } = PlaywrightConfig;
-
     test.beforeEach(async ({ page }) => {
         await page.goto("/apps/day1");
         // Open Options tab
@@ -122,22 +122,8 @@ test.describe("Multi-sensitivity tests", () => {
             SensitivityVariationType.Percentage, 5, null, null, 10, "1.900, 1.922, 1.944, ..., 2.100");
     });
 
-    const expectCanRunMultiSensitivity = async (page: Page) => {
-        // add a second varying parameter with default 10 values - should get 100 solutions from the 2 varying
-        await page.click("#add-param-settings");
-        await expect(await page.locator("#edit-param-to-vary select")).toBeVisible();
-        await page.click("#ok-settings");
-        await expect(await page.locator(".sensitivity-options-settings").count()).toBe(2);
-
-        await expect(await page.innerText(".multi-sensitivity-status")).toBe("Multi-sensitivity has not been run.");
-        await page.click("#run-multi-sens-btn");
-        await expect(await page.locator("#run-multi-sens-btn")).toBeEnabled();
-        await expect(await page.locator(".multi-sensitivity-status"))
-            .toHaveText("Multi-sensitivity run produced 100 solutions.", { timeout });
-    };
-
     test("can run multi-sensitivity", async ({ page }) => {
-        await expectCanRunMultiSensitivity(page);
+        await expectCanRunMultiSensitivity(page, timeout);
 
         // shows update required message when update code
         await page.click(":nth-match(.wodin-left .nav-tabs a, 1)");
@@ -152,7 +138,7 @@ test.describe("Multi-sensitivity tests", () => {
         await page.click(":nth-match(.wodin-left .nav-tabs a, 2)");
         await page.click(":nth-match(.wodin-right .nav-tabs a, 4)");
 
-        await expectCanRunMultiSensitivity(page);
+        await expectCanRunMultiSensitivity(page, timeout);
     });
 
     test("can show error in multi-sensitivity run", async ({ page }) => {

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -148,3 +148,18 @@ export const expectSummaryValues = async (page: Page, idx: number, name: string,
         expect(await page.getAttribute(locator, "y-max")).toBe(yMax);
     }
 };
+
+export const expectCanRunMultiSensitivity = async (page: Page, timeout = 10000) => {
+    // add a second varying parameter with default 10 values - should get 100 solutions from the 2 varying
+    await page.click("#add-param-settings");
+    await expect(await page.locator("#edit-param-to-vary select")).toBeVisible();
+    await page.click("#ok-settings");
+    await expect(await page.locator(".sensitivity-options-settings").count()).toBe(2);
+
+    await expect(await page.innerText(".multi-sensitivity-status")).toBe("Multi-sensitivity has not been run.");
+    await page.click("#run-multi-sens-btn");
+    await expect(await page.locator("#run-multi-sens-btn")).toBeEnabled();
+    await expect(await page.locator(".multi-sensitivity-status"))
+        .toHaveText("Multi-sensitivity run produced 100 solutions.", { timeout });
+    await expect(await page.locator("#download-summary-btn")).toBeEnabled();
+};

--- a/app/static/tests/unit/store/multiSensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/multiSensitivity/actions.test.ts
@@ -6,10 +6,11 @@ import {
     mockRunState,
     mockRunnerOde,
     rootGetters,
-    testCommonRunSensitivity
+    testCommonRunSensitivity, expectRunOnRehydrateToUseParametersFromResult
 } from "../sensitivity/actions.test";
 import { AppType } from "../../../../src/app/store/appState/state";
 import { BaseSensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
+import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
 
 jest.mock("../../../../src/app/excel/wodinSensitivitySummaryDownload");
 
@@ -65,5 +66,10 @@ describe("multiSensitivity actions", () => {
             defaultAdvanced
         );
         expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("run multiSensitivity on rehydrate uses parameters from result", () => {
+        expectRunOnRehydrateToUseParametersFromResult(
+            actions[MultiSensitivityAction.RunMultiSensitivityOnRehydrate] as any);
     });
 });

--- a/app/static/tests/unit/store/multiSensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/multiSensitivity/actions.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../sensitivity/actions.test";
 import { AppType } from "../../../../src/app/store/appState/state";
 import { BaseSensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
-import {SensitivityAction} from "../../../../src/app/store/sensitivity/actions";
+import { SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 
 jest.mock("../../../../src/app/excel/wodinSensitivitySummaryDownload");
 
@@ -70,6 +70,7 @@ describe("multiSensitivity actions", () => {
 
     it("run multiSensitivity on rehydrate uses parameters from result", () => {
         expectRunOnRehydrateToUseParametersFromResult(
-            actions[MultiSensitivityAction.RunMultiSensitivityOnRehydrate] as any);
+            actions[MultiSensitivityAction.RunMultiSensitivityOnRehydrate] as any
+        );
     });
 });

--- a/app/static/tests/unit/store/sensitivity/actions.test.ts
+++ b/app/static/tests/unit/store/sensitivity/actions.test.ts
@@ -1,4 +1,4 @@
-import {Action, ActionTree} from "vuex";
+import { Action, ActionTree } from "vuex";
 import { actions, BaseSensitivityAction, SensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import { BaseSensitivityMutation, SensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import { ModelGetter } from "../../../../src/app/store/model/getters";
@@ -8,7 +8,7 @@ import { AdvancedOptions } from "../../../../src/app/types/responseTypes";
 import { AdvancedComponentType } from "../../../../src/app/store/run/state";
 import { WodinSensitivitySummaryDownload } from "../../../../src/app/excel/wodinSensitivitySummaryDownload";
 import Mock = jest.Mock;
-import {BaseSensitivityState} from "../../../../src/app/store/sensitivity/state";
+import { BaseSensitivityState } from "../../../../src/app/store/sensitivity/state";
 
 jest.mock("../../../../src/app/excel/wodinSensitivitySummaryDownload");
 


### PR DESCRIPTION
This branch serialises multiSensitivity state on session save, and runs multiSensitivity on rehydrate if appropriate. 

To test, you should be able to reload a session where multisensitivity options had been modified, and multiSensitivity had been run, and should see the options changes have been preserved. You should also see that the 'produced X solutions' message is visible on the Multi-sensitivity tab, with download button enabled. 