### PR TITLE
mrc-4562 Filter multi-sensitivity parameter settings options to those which are available 

### DIFF
--- a/app/static/.eslintrc.js
+++ b/app/static/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
         "arrow-body-style": "off",
         "import/prefer-default-export": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
+        "no-plusplus": "off",
         "no-shadow": "off",
         "@typescript-eslint/no-shadow": ["error"],
         "no-underscore-dangle": "off",

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -13,9 +13,10 @@
                  <label class="col-form-label">Parameter to vary</label>
                </div>
                <div class="col-6">
-                 <select class="form-select" v-model="settingsInternal.parameterToVary">
+                 <select v-if="paramNames.length > 1" class="form-select" v-model="settingsInternal.parameterToVary">
                    <option v-for="param in paramNames" :key="param">{{param}}</option>
                  </select>
+                 <span v-else>{{ settingsInternal.parameterToVary }}</span>
                </div>
              </div>
             <div class="row mt-2" id="edit-variation-type">
@@ -144,7 +145,7 @@ export default defineComponent({
             type: Boolean,
             required: true
         },
-        paramNames: {s
+        paramNames: {
             type: Array as PropType<string[]>,
             required: true
         },
@@ -208,7 +209,6 @@ export default defineComponent({
         };
 
         return {
-            paramNames,
             scaleValues,
             variationTypeValues,
             settingsInternal,

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -16,7 +16,7 @@
                  <select v-if="paramNames.length > 1" class="form-select" v-model="settingsInternal.parameterToVary">
                    <option v-for="param in paramNames" :key="param">{{param}}</option>
                  </select>
-                 <span v-else>{{ settingsInternal.parameterToVary }}</span>
+                 <div v-else class="col-form-label">{{ settingsInternal.parameterToVary }}</div>
                </div>
              </div>
             <div class="row mt-2" id="edit-variation-type">

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -144,6 +144,10 @@ export default defineComponent({
             type: Boolean,
             required: true
         },
+        paramNames: {s
+            type: Array as PropType<string[]>,
+            required: true
+        },
         paramSettings: {
             type: Object as PropType<SensitivityParameterSettings>,
             required: false
@@ -158,10 +162,6 @@ export default defineComponent({
     setup(props, { emit }) {
         const store = useStore();
         const settingsInternal = reactive({} as SensitivityParameterSettings);
-
-        const paramNames = computed(() => {
-            return store.state.run.parameterValues ? Object.keys(store.state.run.parameterValues) : [];
-        });
 
         const scaleValues = Object.keys(SensitivityScaleType);
         const variationTypeValues = Object.keys(SensitivityVariationType);

--- a/app/static/src/app/components/options/EditParamSettings.vue
+++ b/app/static/src/app/components/options/EditParamSettings.vue
@@ -13,10 +13,12 @@
                  <label class="col-form-label">Parameter to vary</label>
                </div>
                <div class="col-6">
-                 <select v-if="paramNames.length > 1" class="form-select" v-model="settingsInternal.parameterToVary">
+                 <select v-if="paramNames.length > 1"
+                         class="form-select edit-param-select"
+                         v-model="settingsInternal.parameterToVary">
                    <option v-for="param in paramNames" :key="param">{{param}}</option>
                  </select>
-                 <div v-else class="col-form-label">{{ settingsInternal.parameterToVary }}</div>
+                 <div v-else class="col-form-label param-name-label">{{ settingsInternal.parameterToVary }}</div>
                </div>
              </div>
             <div class="row mt-2" id="edit-variation-type">

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -130,7 +130,7 @@ export default defineComponent({
             if (props.multiSensitivity) {
                 // return all params which are either unused or are the param for the settings to edit
                 return allParamNames.filter((p) => paramsWithoutSettings.value.includes(p)
-                    || (!addingParamSettings.value && !!editSettingsIdx.value
+                    || (!addingParamSettings.value && editSettingsIdx.value !== null
                         && p === allSettings.value[editSettingsIdx.value]?.parameterToVary));
             }
             return allParamNames;

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -131,8 +131,9 @@ export default defineComponent({
                 // return all params which are either unused or are the param for the settings to edit
                 const editIdx = editSettingsIdx.value;
                 const editParam = editIdx !== null && (allSettings.value[editIdx]?.parameterToVary || null);
-                return allParamNames.filter((p) => paramsWithoutSettings.value.includes(p)
-                    || (!addingParamSettings.value && editParam !== null && p === editParam));
+                // check if a given param is that for the settings being edited
+                const isEditParam = (p: string) => !addingParamSettings.value && editParam !== null && p === editParam;
+                return allParamNames.filter((p) => paramsWithoutSettings.value.includes(p) || isEditParam(p));
             }
             return allParamNames;
         });

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -129,9 +129,10 @@ export default defineComponent({
             const allParamNames = store.state.run.parameterValues ? Object.keys(store.state.run.parameterValues) : [];
             if (props.multiSensitivity) {
                 // return all params which are either unused or are the param for the settings to edit
+                const editIdx = editSettingsIdx.value;
+                const editParam = editIdx !== null && (allSettings.value[editIdx]?.parameterToVary || null);
                 return allParamNames.filter((p) => paramsWithoutSettings.value.includes(p)
-                    || (!addingParamSettings.value && editSettingsIdx.value !== null
-                        && p === allSettings.value[editSettingsIdx.value]?.parameterToVary));
+                    || (!addingParamSettings.value && editParam !== null && p === editParam));
             }
             return allParamNames;
         });

--- a/app/static/src/app/components/options/SensitivityOptions.vue
+++ b/app/static/src/app/components/options/SensitivityOptions.vue
@@ -56,6 +56,7 @@
   </vertical-collapse>
   <edit-param-settings :open="editOpen"
                        :param-settings="settingsToEdit"
+                       :param-names="paramNamesForSettingsEdit"
                        @close="closeEdit"
                        @update="editSettings"></edit-param-settings>
 </template>
@@ -124,6 +125,17 @@ export default defineComponent({
             return editSettingsIdx.value === null ? null : allSettings.value[editSettingsIdx.value];
         });
 
+        const paramNamesForSettingsEdit = computed(() => {
+            const allParamNames = store.state.run.parameterValues ? Object.keys(store.state.run.parameterValues) : [];
+            if (props.multiSensitivity) {
+                // return all params which are either unused or are the param for the settings to edit
+                return allParamNames.filter((p) => paramsWithoutSettings.value.includes(p)
+                    || (!addingParamSettings.value && !!editSettingsIdx.value
+                        && p === allSettings.value[editSettingsIdx.value]?.parameterToVary));
+            }
+            return allParamNames;
+        });
+
         const openEdit = (settingsIdx: number) => {
             editSettingsIdx.value = settingsIdx;
             editOpen.value = true;
@@ -174,6 +186,7 @@ export default defineComponent({
             allSettings,
             settingsToEdit,
             paramsWithoutSettings,
+            paramNamesForSettingsEdit,
             canDeleteSettings,
             showOptions,
             compileModelMessage,

--- a/app/static/tests/unit/components/options/sensitivityOptions.test.ts
+++ b/app/static/tests/unit/components/options/sensitivityOptions.test.ts
@@ -70,7 +70,7 @@ describe("SensitivityOptions", () => {
                 run: {
                     namespaced: true,
                     state: {
-                        parameterValues: {}
+                        parameterValues: { A: 1, B: 2 }
                     }
                 }
             } as any
@@ -280,6 +280,7 @@ describe("SensitivityOptions", () => {
         const editParamSettings = wrapper.findComponent(EditParamSettings);
         expect(editParamSettings.props("open")).toBe(true);
         expect(editParamSettings.props("paramSettings")).toStrictEqual(percentSettings);
+        expect(editParamSettings.props("paramNames")).toStrictEqual(["A", "B"]);
 
         await editParamSettings.vm.$emit("close");
         expect(editParamSettings.props("open")).toBe(false);
@@ -292,6 +293,7 @@ describe("SensitivityOptions", () => {
         const editParamSettings = wrapper.findComponent(EditParamSettings);
         expect(editParamSettings.props("open")).toBe(true);
         expect(editParamSettings.props("paramSettings")).toStrictEqual(percentSettings);
+        expect(editParamSettings.props("paramNames")).toStrictEqual(["A", "C", "D"]);
 
         await editParamSettings.vm.$emit("close");
         expect(editParamSettings.props("open")).toBe(false);
@@ -401,5 +403,25 @@ describe("SensitivityOptions", () => {
             { ...rangeSettings, parameterToVary: "D" }
         ]);
         expect(wrapper.find("#add-param-settings").exists()).toBe(false);
+    });
+
+    it("removes parameter names from editor which already have multi-sensitivity, when Adding", async () => {
+        const wrapper = getWrapperForMultiSensitivity([
+            percentSettings, // param A
+            rangeSettings, // param B
+            customSettings // param C
+        ]);
+        await wrapper.find("#add-param-settings").trigger("click");
+        expect(wrapper.findComponent(EditParamSettings).props("paramNames")).toStrictEqual(["D"]);
+    });
+
+    it("removes non-current parameter names from editor which already have settings, when Editing", async () => {
+        const wrapper = getWrapperForMultiSensitivity([
+            percentSettings, // param A
+            rangeSettings, // param B
+            customSettings // param C
+        ]);
+        await wrapper.findAll(".edit-param-settings")[0].trigger("click");
+        expect(wrapper.findComponent(EditParamSettings).props("paramNames")).toStrictEqual(["A", "D"]);
     });
 });


### PR DESCRIPTION
This branch should ensure that users cannot add parameter settings for the same parameter twice - the Edit Parameter Settings dialog now only provide parameter names in the drop-down for params which are not used in any other current settings in multiSensitivity. 
If only one param is available, that will be shown as text rather than a select.

This does mean that it would not be possible to swap sensitivity settings for two parameter names as you'd need to go through a stage where you had two settings with the same name - but I think it's unlikely anyone would want to do that!