### PR TITLE
mrc-4621 Pin Playwright version

### DIFF
--- a/app/static/package.json
+++ b/app/static/package.json
@@ -45,7 +45,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@playwright/test": "^1.20.0",
+    "@playwright/test": "1.37.0",
     "@types/bootstrap": "^5.2.6",
     "@types/jest": "^27.4.0",
     "@types/markdown-it": "^12.2.3",

--- a/app/static/playwright.config.ts
+++ b/app/static/playwright.config.ts
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
         }
     },
     retries: 1,
-    timeout: 60000
+    timeout: 120000
 };
 
 export default config;

--- a/app/static/playwright.config.ts
+++ b/app/static/playwright.config.ts
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
         }
     },
     retries: 1,
-    timeout: 120000
+    timeout: 60000
 };
 
 export default config;


### PR DESCRIPTION
The Playwright tests have become flaky around selecting options from drop-downs (it seemed to time out when trying to do the select). I tried various diagnostics, checking that the option was really there before attempting to select it etc, and nothing seemed to make a difference except for pinning Playwright back to the previous version (1.37). There's no indication in the docs that the API around selecting options should no longer support the way we ae using it, though it look like they did add some additional options fairly recently (v1.29), so I guess this may be a related bug. 
https://playwright.dev/docs/release-notes

I've added a ticket to unpin later: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4623