### PR TITLE
mrc-4602 Do not show Graph Settings when Multi-sensitivity tab is open

### DIFF
--- a/app/static/package.json
+++ b/app/static/package.json
@@ -45,7 +45,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@playwright/test": "^1.20.0",
+    "@playwright/test": "1.37.0",
     "@types/bootstrap": "^5.2.6",
     "@types/jest": "^27.4.0",
     "@types/markdown-it": "^12.2.3",

--- a/app/static/src/app/components/options/OptionsTab.vue
+++ b/app/static/src/app/components/options/OptionsTab.vue
@@ -14,7 +14,7 @@
     <vertical-collapse v-if="fitTabIsOpen" title="Optimisation" collapse-id="optimisation">
       <optimisation-options></optimisation-options>
     </vertical-collapse>
-    <vertical-collapse title="Graph Settings" collapse-id="graph-settings">
+    <vertical-collapse v-if="!multiSensitivityOpen" title="Graph Settings" collapse-id="graph-settings">
       <graph-settings></graph-settings>
     </vertical-collapse>
     <vertical-collapse v-if="!isStochastic"

--- a/app/static/tests/unit/components/options/optionsTab.test.ts
+++ b/app/static/tests/unit/components/options/optionsTab.test.ts
@@ -15,7 +15,6 @@ import { RunMutation } from "../../../../src/app/store/run/mutations";
 import GraphSettings from "../../../../src/app/components/options/GraphSettings.vue";
 import ParameterSets from "../../../../src/app/components/options/ParameterSets.vue";
 import { getters as runGetters } from "../../../../src/app/store/run/getters";
-import fitApp from "../../../../src/app/components/fit/FitApp.vue";
 import AdvancedSettings from "../../../../src/app/components/options/AdvancedSettings.vue";
 
 describe("OptionsTab", () => {
@@ -299,5 +298,6 @@ describe("OptionsTab", () => {
             }
         });
         expect(wrapper.findComponent(SensitivityOptions).exists()).toBe(true);
+        expect(wrapper.findComponent(GraphSettings).exists()).toBe(false);
     });
 });


### PR DESCRIPTION
Hide graph settings when Multi-sensitivity tab is open, since there is no plotting for Multi-sensitivity