### PR TITLE
mrc-4608 Remove current session from Sessions table

### DIFF
--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -30,7 +30,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@playwright/test": "^1.20.0",
+        "@playwright/test": "1.37.0",
         "@types/bootstrap": "^5.2.6",
         "@types/jest": "^27.4.0",
         "@types/markdown-it": "^12.2.3",
@@ -1164,21 +1164,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz",
-      "integrity": "sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
@@ -1683,23 +1668,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
-      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-typescript": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
@@ -1839,23 +1807,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-typescript": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3023,388 +2974,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.0.tgz",
-      "integrity": "sha512-UpI5HTcgNLckR0kqXqwNvbcIXtRaDxk+hnO0OBwPSjfbBjRfRgAJ2ClA/b30C5E3UW5dJa17zhsy2qrk66l5cg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.0",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.20.0",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/@types/istanbul-reports": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/@types/stack-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@playwright/test/node_modules/@types/yargs": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
-      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@playwright/test/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@playwright/test/node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-      "dev": true,
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/expect": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-      "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.2.5",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.5",
-        "jest-message-util": "^27.2.5",
-        "jest-regex-util": "^27.0.6"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-      "dev": true,
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/jest-matcher-utils": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.5.tgz",
-      "integrity": "sha512-qNR/kh6bz0Dyv3m68Ck2g1fLW5KlSOUNcFQh87VXHZwWc/gY6XwnKofx76Qytz3x5LDWT09/2+yXndTkaG4aWg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^27.2.5",
-        "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.5"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/jest-message-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.5.1",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^27.5.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-      "dev": true,
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/@playwright/test/node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "dev": true,
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
-      "integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
-      "dev": true,
-      "dependencies": {
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "jpeg-js": "0.4.3",
-        "mime": "3.0.0",
-        "pixelmatch": "5.2.1",
-        "pngjs": "6.0.0",
-        "progress": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "socks-proxy-agent": "6.1.1",
-        "stack-utils": "2.0.5",
-        "ws": "8.4.2",
-        "yauzl": "2.10.0",
-        "yazl": "2.5.1"
+        "playwright-core": "1.37.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "node": ">=16"
       },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
-    },
-    "node_modules/@playwright/test/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3985,16 +3570,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -7316,41 +6891,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -8941,15 +8481,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -9377,6 +8908,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chokidar/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/chokidar/node_modules/is-number": {
@@ -9998,15 +9548,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -11407,15 +10948,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -13290,49 +12822,6 @@
         "npm": ">=2.0.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -13410,15 +12899,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/feather-icons": {
@@ -14338,6 +13818,20 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -15180,42 +14674,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/i18next": {
@@ -17332,6 +16790,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jest-haste-map/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
     "node_modules/jest-haste-map/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -19245,12 +18722,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "node_modules/jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "dev": true
     },
     "node_modules/js-base64": {
       "version": "2.6.4",
@@ -21838,12 +21309,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -21906,27 +21371,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "dependencies": {
-        "pngjs": "^4.0.1"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-      "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -21961,6 +21405,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/plotly.js-basic-dist-min": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.14.0.tgz",
@@ -21971,15 +21427,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.13.0"
-      }
     },
     "node_modules/pnp-webpack-plugin": {
       "version": "1.7.0",
@@ -23599,17 +23046,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -23628,12 +23064,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -25541,16 +24971,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -25739,57 +25159,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "dev": true,
-      "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/sort-keys": {
       "version": "1.1.2",
@@ -29941,25 +29310,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
     "node_modules/yorkie": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yorkie/-/yorkie-2.0.0.tgz",
@@ -30879,15 +30229,6 @@
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
-    "@babel/plugin-syntax-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz",
-      "integrity": "sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
@@ -31205,17 +30546,6 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
-      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-typescript": "^7.16.7"
-      }
-    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
@@ -31336,17 +30666,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-typescript": "^7.16.7"
       }
     },
     "@babel/runtime": {
@@ -32298,298 +31617,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.20.0.tgz",
-      "integrity": "sha512-UpI5HTcgNLckR0kqXqwNvbcIXtRaDxk+hnO0OBwPSjfbBjRfRgAJ2ClA/b30C5E3UW5dJa17zhsy2qrk66l5cg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.0",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.20.0",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-          "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
-          "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "@types/stack-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-          "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-          "dev": true
-        },
-        "@types/yargs": {
-          "version": "16.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
-          "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
-        "diff-sequences": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-          "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-          "dev": true
-        },
-        "expect": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-          "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^27.2.5",
-            "ansi-styles": "^5.0.0",
-            "jest-get-type": "^27.0.6",
-            "jest-matcher-utils": "^27.2.5",
-            "jest-message-util": "^27.2.5",
-            "jest-regex-util": "^27.0.6"
-          }
-        },
-        "is-wsl": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-          "dev": true,
-          "requires": {
-            "is-docker": "^2.0.0"
-          }
-        },
-        "jest-diff": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-          "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^27.5.1",
-            "jest-get-type": "^27.5.1",
-            "pretty-format": "^27.5.1"
-          }
-        },
-        "jest-get-type": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-          "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.5.tgz",
-          "integrity": "sha512-qNR/kh6bz0Dyv3m68Ck2g1fLW5KlSOUNcFQh87VXHZwWc/gY6XwnKofx76Qytz3x5LDWT09/2+yXndTkaG4aWg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "jest-diff": "^27.2.5",
-            "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.2.5"
-          }
-        },
-        "jest-message-util": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
-          "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^27.5.1",
-            "@types/stack-utils": "^2.0.0",
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.9",
-            "micromatch": "^4.0.4",
-            "pretty-format": "^27.5.1",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3"
-          }
-        },
-        "jest-regex-util": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-          "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-          "dev": true
-        },
-        "mime": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
-        "open": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-          "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-          "dev": true,
-          "requires": {
-            "define-lazy-prop": "^2.0.0",
-            "is-docker": "^2.1.1",
-            "is-wsl": "^2.2.0"
-          }
-        },
-        "pirates": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-          "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-          "dev": true
-        },
-        "playwright-core": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
-          "integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
-          "dev": true,
-          "requires": {
-            "colors": "1.4.0",
-            "commander": "8.3.0",
-            "debug": "4.3.3",
-            "extract-zip": "2.0.1",
-            "https-proxy-agent": "5.0.0",
-            "jpeg-js": "0.4.3",
-            "mime": "3.0.0",
-            "pixelmatch": "5.2.1",
-            "pngjs": "6.0.0",
-            "progress": "2.0.3",
-            "proper-lockfile": "4.1.2",
-            "proxy-from-env": "1.1.0",
-            "rimraf": "3.0.2",
-            "socks-proxy-agent": "6.1.1",
-            "stack-utils": "2.0.5",
-            "ws": "8.4.2",
-            "yauzl": "2.10.0",
-            "yazl": "2.5.1"
-          }
-        },
-        "pretty-format": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-          "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^17.0.1"
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        },
-        "stack-utils": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-          "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^2.0.0"
-          }
-        },
-        "ws": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-          "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-          "dev": true,
-          "requires": {}
-        }
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.37.0"
       }
     },
     "@popperjs/core": {
@@ -33128,16 +32163,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
-    },
-    "@types/yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -35701,32 +34726,6 @@
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
       "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
     },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -37011,12 +36010,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -37358,6 +36351,17 @@
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1",
             "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "is-number": {
@@ -37853,12 +36857,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -39000,12 +37998,6 @@
           "dev": true
         }
       }
-    },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -40503,35 +39495,6 @@
         "css": "^2.1.0"
       }
     },
-    "extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
-    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -40599,15 +39562,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
       }
     },
     "feather-icons": {
@@ -41325,6 +40279,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -42005,33 +40966,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
     },
     "i18next": {
       "version": "22.4.11",
@@ -43876,6 +42810,17 @@
             }
           }
         },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -45218,12 +44163,6 @@
           }
         }
       }
-    },
-    "jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "dev": true
     },
     "js-base64": {
       "version": "2.6.4",
@@ -47345,12 +46284,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -47395,23 +46328,6 @@
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
     },
-    "pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "requires": {
-        "pngjs": "^4.0.1"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-          "dev": true
-        }
-      }
-    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -47439,6 +46355,12 @@
         }
       }
     },
+    "playwright-core": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
+      "dev": true
+    },
     "plotly.js-basic-dist-min": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/plotly.js-basic-dist-min/-/plotly.js-basic-dist-min-2.14.0.tgz",
@@ -47448,12 +46370,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
-    },
-    "pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
       "dev": true
     },
     "pnp-webpack-plugin": {
@@ -48747,17 +47663,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -48773,12 +47678,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -50306,12 +49205,6 @@
         }
       }
     },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -50471,44 +49364,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
-      }
-    },
-    "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "dev": true,
-      "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -53866,25 +52721,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
     },
     "yorkie": {
       "version": "2.0.0",

--- a/app/static/src/app/components/header/AppHeader.vue
+++ b/app/static/src/app/components/header/AppHeader.vue
@@ -14,8 +14,14 @@
           <vue-feather class="grey inline-icon" type="edit-2" size="1.3rem"></vue-feather>
           Edit Label
         </li>
-        <hr/>
-        <li><router-link id="all-sessions-link" class="dropdown-item" to="/sessions">All Sessions</router-link></li>
+        <template v-if="sessionPersisted">
+          <hr/>
+          <li>
+            <router-link id="all-sessions-link" class="dropdown-item" to="/sessions">
+              All Sessions
+            </router-link>
+          </li>
+        </template>
       </ul>
     </span>
     <span v-if="initialised" style="display: flex; align-items: center;">
@@ -69,6 +75,7 @@ export default defineComponent({
 
         const sessionId = computed(() => store.state.sessionId);
         const sessionLabel = computed(() => store.state.sessionLabel);
+        const sessionPersisted = computed(() => store.state.persisted);
 
         const sessionMenuHeader = computed(() => {
             return sessionLabel.value ? `Session: ${sessionLabel.value}` : "Sessions";
@@ -87,6 +94,7 @@ export default defineComponent({
             sessionId,
             sessionLabel,
             sessionMenuHeader,
+            sessionPersisted,
             languagesKeys
         };
     }

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -93,7 +93,7 @@
           </div>
         </div>
     </template>
-    <p v-else>
+    <p v-else id="previous-sessions-placeholder">
       Saved sessions will appear here.
     </p>
     <div id="loading-sessions" v-if="!previousSessions">

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -8,7 +8,10 @@
         <span>
           <router-link to="/" class="brand-link">
             Start a new session
-          </router-link><span v-if="previousSessions && previousSessions.length" id="load-previous-span">or load a previous session.</span>
+          </router-link>
+          <span v-if="previousSessions && previousSessions.length" id="load-previous-span">
+            or load a previous session.
+          </span>
         </span>
     </div>
     <div class="row mb-3" id="current-session" v-else>
@@ -21,12 +24,16 @@
           make a copy of the current session.
         </a>
       </p>
-      <p>
-        <span class="session-copy-link clickable brand" @click="copyLink(currentSession)" @mouseleave="clearLastCopied">
+      <div>
+        <span class="session-copy-link clickable brand"
+              @click="copyLink(currentSession)"
+              @mouseleave="clearLastCopied">
           <vue-feather class="inline-icon" type="copy"></vue-feather>
           Copy link for current session
         </span>
-        <span class="session-copy-code clickable brand ms-2" @click="copyCode(currentSession)" @mouseleave="clearLastCopied">
+        <span class="session-copy-code clickable brand ms-2"
+              @click="copyCode(currentSession)"
+              @mouseleave="clearLastCopied">
           <vue-feather class="inline-icon" type="copy"></vue-feather>
           Copy code for current session
         </span>
@@ -34,7 +41,7 @@
         <div class="session-copy-confirm small text-muted text-nowrap float-start" style="height:0.8rem;">
           {{getCopyMsg(currentSession)}}
         </div>
-      </p>
+      </div>
     </div>
     <template v-if="previousSessions && previousSessions.length">
         <h3>Previous sessions</h3>
@@ -159,8 +166,12 @@ export default defineComponent({
 
         const isCurrentSession = (sessionId: string) => sessionId === currentSessionId.value;
 
-        const previousSessions = computed(() => sessionsMetadata.value?.filter((s: SessionMetadata) => !isCurrentSession(s.id)));
-        const currentSession = computed(() => sessionsMetadata.value?.find((s: SessionMetadata) => isCurrentSession(s.id)));
+        const previousSessions = computed(() => {
+            return sessionsMetadata.value?.filter((s: SessionMetadata) => !isCurrentSession(s.id));
+        });
+        const currentSession = computed(() => {
+            return sessionsMetadata.value?.find((s: SessionMetadata) => isCurrentSession(s.id));
+        });
 
         const toggleEditSessionLabelOpen = (open: boolean) => {
             editSessionLabelOpen.value = open;

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -43,8 +43,8 @@
         </div>
       </div>
     </div>
+    <h3>Previous sessions</h3>
     <template v-if="previousSessions && previousSessions.length">
-        <h3>Previous sessions</h3>
         <div class="row fw-bold py-2" id="previous-sessions-headers">
           <div class="col-2 session-col-header">Saved</div>
           <div class="col-2 session-col-header">Label</div>
@@ -93,6 +93,9 @@
           </div>
         </div>
     </template>
+    <p v-else>
+      Saved sessions will appear here.
+    </p>
     <div id="loading-sessions" v-if="!previousSessions">
       {{ messages.loading }}
     </div>

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -4,43 +4,41 @@
       <errors-alert></errors-alert>
       <h2>Sessions</h2>
     </div>
-    <div class="row mb-3" v-if="!currentSession">
+    <div class="row mb-3" id="no-current-session" v-if="!currentSession">
         <span>
           <router-link to="/" class="brand-link">
             Start a new session
-          </router-link><span v-if="previousSessions && previousSessions.length">or load a previous session.</span>
+          </router-link><span v-if="previousSessions && previousSessions.length" id="load-previous-span">or load a previous session.</span>
         </span>
     </div>
-    <div class="row mb-3" v-else>
+    <div class="row mb-3" id="current-session" v-else>
       <p>
         <router-link to="/" class="brand-link">
           Return to the current session
         </router-link>
         or
-        <a class="brand-link" :href="sessionUrl(currentSessionId)" title="Load as new session">
+        <a class="brand-link" :href="sessionUrl(currentSessionId)">
           make a copy of the current session.
         </a>
       </p>
       <p>
-        <div>
-          <span class="session-copy-link clickable brand" @click="copyLink(currentSession)" @mouseleave="clearLastCopied">
-            <vue-feather class="inline-icon" type="copy"></vue-feather>
-            Copy link for current session
-          </span>
-          <span class="session-copy-code clickable brand ms-2" @click="copyCode(currentSession)" @mouseleave="clearLastCopied">
-            <vue-feather class="inline-icon" type="copy"></vue-feather>
-            Copy code for current session
-          </span>
-          <br/>
-          <div class="session-copy-confirm small text-muted text-nowrap float-start" style="height:0.8rem;">
-            {{getCopyMsg(currentSession)}}
-          </div>
+        <span class="session-copy-link clickable brand" @click="copyLink(currentSession)" @mouseleave="clearLastCopied">
+          <vue-feather class="inline-icon" type="copy"></vue-feather>
+          Copy link for current session
+        </span>
+        <span class="session-copy-code clickable brand ms-2" @click="copyCode(currentSession)" @mouseleave="clearLastCopied">
+          <vue-feather class="inline-icon" type="copy"></vue-feather>
+          Copy code for current session
+        </span>
+        <br/>
+        <div class="session-copy-confirm small text-muted text-nowrap float-start" style="height:0.8rem;">
+          {{getCopyMsg(currentSession)}}
         </div>
       </p>
     </div>
     <template v-if="previousSessions && previousSessions.length">
         <h3>Previous sessions</h3>
-        <div class="row fw-bold py-2">
+        <div class="row fw-bold py-2" id="previous-sessions-headers">
           <div class="col-2 session-col-header">Saved</div>
           <div class="col-2 session-col-header">Label</div>
           <div class="col-2 text-center session-col-header">Edit Label</div>
@@ -48,7 +46,7 @@
           <div class="col-1 text-center session-col-header">Delete</div>
           <div class="col-4 text-center session-col-header">Shareable Link</div>
         </div>
-        <div class="row py-2" v-for="session in previousSessions" :key="session.id">
+        <div class="row py-2 previous-session-row" v-for="session in previousSessions" :key="session.id">
           <div class="col-2 session-col-value session-time">
             {{formatDateTime(session.time)}}
           </div>

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -163,7 +163,8 @@ export const serialiseState = (state: AppState): string => {
 export const deserialiseState = (targetState: AppState, serialised: SerialisedAppState): void => {
     Object.assign(targetState, {
         ...targetState,
-        ...serialised
+        ...serialised,
+        persisted: true
     });
 
     // Initialise selected variables if required

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -25,7 +25,7 @@ async function immediateUploadState(context: ActionContext<AppState, AppState>) 
 
     commit(AppStateMutation.SetStateUploadInProgress, true);
     await api<AppStateMutation, ErrorsMutation>(context)
-        .ignoreSuccess()
+        .withSuccess(AppStateMutation.SetPersisted)
         .withError(ErrorsMutation.AddError)
         .post(`/${appsPath}/${appName}/sessions/${sessionId}`, serialiseState(state));
     commit(AppStateMutation.SetStateUploadInProgress, false);

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -13,7 +13,8 @@ export enum AppStateMutation {
     SetQueuedStateUpload = "SetQueuedStateUpload",
     SetStateUploadInProgress = "SetStateUploadInProgress",
     SetSessionLabel = "SetSessionLabel",
-    SetConfigured = "SetConfigured"
+    SetConfigured = "SetConfigured",
+    SetPersisted = "SetPersisted"
 }
 
 export const StateUploadMutations = [
@@ -59,5 +60,9 @@ export const appStateMutations: MutationTree<AppState> = {
 
     [AppStateMutation.SetConfigured](state: AppState) {
         state.configured = true;
+    },
+
+    [AppStateMutation.SetPersisted](state: AppState) {
+        state.persisted = true;
     }
 };

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -40,5 +40,6 @@ export interface AppState {
     graphSettings: GraphSettingsState,
     versions: VersionsState,
     configured: boolean, // true if configuration has been loaded or rehydrated and defaults set
+    persisted: boolean, // true if we have done an initial save of the session to the back-end
     language: LanguageState
 }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -32,7 +32,8 @@ const defaultState: () => any = () => {
         config: null,
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
-        configured: false
+        configured: false,
+        persisted: false
     };
 };
 

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -34,7 +34,8 @@ const defaultState: () => any = () => {
         config: null,
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
-        configured: false
+        configured: false,
+        persisted: false
     };
 };
 

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -32,7 +32,8 @@ const defaultState: () => any = () => {
         config: null,
         queuedStateUploadIntervalId: -1,
         stateUploadInProgress: false,
-        configured: false
+        configured: false,
+        persisted: false
     };
 };
 

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -28,6 +28,11 @@ $grey: #ccc;
   color: $brand;
 }
 
+.brand-link, .brand-link:hover, .brand-link:visited {
+  @extend .brand;
+  text-decoration: none;
+}
+
 .grey {
   color: $grey;
 }

--- a/app/static/tests/e2e/sessions.etest.ts
+++ b/app/static/tests/e2e/sessions.etest.ts
@@ -86,6 +86,8 @@ test.describe("Sessions tests", () => {
         await page.click("#all-sessions-link");
 
         await expect(await page.innerText(".container h2")).toBe("Sessions");
+        await expect(await page.innerText(":nth-match(#current-session p, 1)"))
+            .toBe("Return to the current session or make a copy of the current session.");
         await expect(await page.innerText(":nth-match(.session-col-header, 1)")).toBe("Saved");
         await expect(await page.innerText(":nth-match(.session-col-header, 2)")).toBe("Label");
         await expect(await page.innerText(":nth-match(.session-col-header, 3)")).toBe("Edit Label");
@@ -108,13 +110,10 @@ test.describe("Sessions tests", () => {
         const copiedLinkText = await page.evaluate("navigator.clipboard.readText()") as string;
         expect(copiedLinkText).toContain("http://localhost:3000/apps/day2/?share=");
 
-        // Set the current session label from the nav menu and check it updates on menu title and in the sessions list
+        // Set the current session label from the nav menu and check it updates on menu title
         await page.click("#sessions-menu");
         await page.click("#edit-current-session-label");
         await enterSessionLabel(page, "header-edit-session-label", "current session label");
-        await expect(await page.locator(":nth-match(.session-label, 1)")).toHaveText(
-            "current session label", { timeout }
-        );
         await expect(await page.innerText("#sessions-menu")).toBe("Session: current session label");
 
         // Set the current session label on a previous session

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -213,6 +213,7 @@ export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
         configured: false,
+        persisted: true,
         language: mockLanguageState(),
         ...state
     };
@@ -264,6 +265,7 @@ export const mockFitState = (state: Partial<FitState> = {}): FitState => {
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
         configured: false,
+        persisted: false,
         language: mockLanguageState(),
         ...state
     };
@@ -294,6 +296,7 @@ export const mockStochasticState = (state: Partial<StochasticState> = {}): Stoch
         versions: mockVersionsState(),
         graphSettings: mockGraphSettingsState(),
         configured: false,
+        persisted: false,
         language: mockLanguageState(),
         ...state
     };

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -149,6 +149,8 @@ describe("SessionsPage", () => {
         expect(current.findComponent(RouterLink).props("to")).toBe("/");
         expect(current.find("a").text()).toBe("make a copy of the current session.");
 
+        expect(wrapper.find("h3").text()).toBe("Previous sessions");
+        expect(wrapper.find("p#previous-sessions-placeholder").text()).toBe("Saved sessions will appear here.");
         expect(wrapper.find("#previous-sessions-headers").exists()).toBe(false);
         expect(wrapper.findAll(".previous-session-row").length).toBe(0);
     });

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -81,7 +81,8 @@ describe("SessionsPage", () => {
         const currentSessionRow = rows.at(1)!;
         expect(currentSessionRow.findComponent(RouterLink).props("to")).toBe("/");
         expect(currentSessionRow.find("a").text()).toBe("make a copy of the current session.");
-        expect(currentSessionRow.find("a").attributes("href")).toBe("http://localhost:3000/apps/testApp/?sessionId=abc");
+        expect(currentSessionRow.find("a").attributes("href"))
+            .toBe("http://localhost:3000/apps/testApp/?sessionId=abc");
         expect(currentSessionRow.find(".session-copy-link").text()).toBe("Copy link for current session");
         expect(currentSessionRow.find(".session-copy-code").text()).toBe("Copy code for current session");
 

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -27,11 +27,13 @@ describe("SessionsPage", () => {
         jest.clearAllMocks();
     });
 
-    const getWrapper = (sessionsMetadata: SessionMetadata[] | null) => {
+    const currentSessionId = "abc";
+
+    const getWrapper = (sessionsMetadata: SessionMetadata[] | null, sessionId: string | undefined) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
                 appName: "testApp",
-                sessionId: "abc",
+                sessionId,
                 baseUrl: "http://localhost:3000",
                 appsPath: "apps"
             }),
@@ -65,14 +67,25 @@ describe("SessionsPage", () => {
         },
         {
             id: "def", time: "2022-01-13T10:26:36.396Z", label: null, friendlyId: null
+        },
+        {
+            id: "ghi", time: "2022-01-14T10:26:36.396Z", label: "another session", friendlyId: "good-dog"
         }
     ];
 
     it("renders as expected", () => {
-        const wrapper = getWrapper(sessionsMetadata);
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         const rows = wrapper.findAll(".container .row");
         expect(rows.at(0)!.find("h2").text()).toBe("Sessions");
-        const columnHeaders = rows.at(1)!.findAll("div.session-col-header");
+
+        const currentSessionRow = rows.at(1)!;
+        expect(currentSessionRow.findComponent(RouterLink).props("to")).toBe("/");
+        expect(currentSessionRow.find("a").text()).toBe("make a copy of the current session.");
+        expect(currentSessionRow.find("a").attributes("href")).toBe("http://localhost:3000/apps/testApp/?sessionId=abc");
+        expect(currentSessionRow.find(".session-copy-link").text()).toBe("Copy link for current session");
+        expect(currentSessionRow.find(".session-copy-code").text()).toBe("Copy code for current session");
+
+        const columnHeaders = rows.at(2)!.findAll("div.session-col-header");
         expect(columnHeaders.length).toBe(6);
         expect(columnHeaders.at(0)!.text()).toBe("Saved");
         expect(columnHeaders.at(1)!.text()).toBe("Label");
@@ -80,25 +93,9 @@ describe("SessionsPage", () => {
         expect(columnHeaders.at(3)!.text()).toBe("Load");
         expect(columnHeaders.at(4)!.text()).toBe("Delete");
         expect(columnHeaders.at(5)!.text()).toBe("Shareable Link");
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        expect(session1Cells.length).toBe(6);
-        expect(session1Cells.at(0)!.text()).toBe("13/01/2022 09:26:36 (current session)");
-        expect(session1Cells.at(1)!.text()).toBe("session1");
-        expect(session1Cells.at(2)!.findComponent(VueFeather).props("type")).toBe("edit-2");
-        const routerLink = session1Cells.at(3)!.findComponent(RouterLink);
-        expect(routerLink.props("to")).toBe("/");
-        // No delete control for current session
-        expect(session1Cells.at(4)!.findComponent(VueFeather).exists()).toBe(false);
-        expect(session1Cells.at(5)!.find("span.session-copy-link").text()).toBe("Copy link");
-        expect(session1Cells.at(5)!.find("span.session-copy-link").findComponent(VueFeather).props("type"))
-            .toBe("copy");
-        expect(session1Cells.at(5)!.find("span.session-copy-code").text()).toBe("Copy code");
-        expect(session1Cells.at(5)!.find("span.session-copy-code").findComponent(VueFeather).props("type"))
-            .toBe("copy");
-        expect(session1Cells.at(5)!.find(".session-copy-confirm").text()).toBe("");
 
         const session2Cells = rows.at(3)!.findAll("div.session-col-value");
-        expect(session1Cells.length).toBe(6);
+        expect(session2Cells.length).toBe(6);
         expect(session2Cells.at(0)!.text()).toBe("13/01/2022 10:26:36");
         expect(session2Cells.at(1)!.text()).toBe("--no label--");
         expect(session2Cells.at(2)!.findComponent(VueFeather).props("type")).toBe("edit-2");
@@ -122,112 +119,154 @@ describe("SessionsPage", () => {
     });
 
     it("shows loading message when session metadata is null in store", () => {
-        const wrapper = getWrapper(null);
+        const wrapper = getWrapper(null, currentSessionId);
         const rows = wrapper.findAll(".container .row");
-        expect(rows.length).toBe(1);
+        expect(rows.length).toBe(2);
         expect(rows.at(0)!.text()).toBe("Sessions");
         expect(wrapper.find("#loading-sessions").text()).toBe("Loading sessions...");
     });
 
-    it("shows no sessions yet message when session metadata is empty in store", () => {
-        const wrapper = getWrapper([]);
-        const rows = wrapper.findAll(".container .row");
-        expect(rows.length).toBe(1);
-        expect(rows.at(0)!.text()).toBe("Sessions");
-        expect(wrapper.find("#empty-sessions").text()).toContain("No saved sessions yet.");
-        expect(wrapper.find("#empty-sessions").findComponent(RouterLink).props("to")).toBe("/");
+    it("renders as expected when no current session", () => {
+        const wrapper = getWrapper(sessionsMetadata, undefined);
+
+        expect(wrapper.find("#current-session").exists()).toBe(false);
+        const noCurrent = wrapper.find("#no-current-session");
+        expect(noCurrent.exists()).toBe(true);
+        expect(noCurrent.findComponent(RouterLink).props("to")).toBe("/");
+        expect(noCurrent.find("#load-previous-span").text()).toBe("or load a previous session.");
+
+        expect(wrapper.find("#previous-sessions-headers").exists()).toBe(true);
+        expect(wrapper.findAll(".previous-session-row").length).toBe(3);
+    });
+
+    it("renders as expected when no previous sessions", () => {
+        // include current session in metadata only
+        const wrapper = getWrapper([sessionsMetadata[0]], currentSessionId);
+        expect(wrapper.find("#no-current-session").exists()).toBe(false);
+        const current = wrapper.find("#current-session");
+        expect(current.exists()).toBe(true);
+        expect(current.findComponent(RouterLink).props("to")).toBe("/");
+        expect(current.find("a").text()).toBe("make a copy of the current session.");
+
+        expect(wrapper.find("#previous-sessions-headers").exists()).toBe(false);
+        expect(wrapper.findAll(".previous-session-row").length).toBe(0);
+    });
+
+    it("renders as expected when no current session and no previous sessions", () => {
+        const wrapper = getWrapper([], undefined);
+        expect(wrapper.find("#current-session").exists()).toBe(false);
+        const noCurrent = wrapper.find("#no-current-session");
+        expect(noCurrent.exists()).toBe(true);
+        expect(noCurrent.findComponent(RouterLink).props("to")).toBe("/");
+        expect(noCurrent.find("#load-previous-span").exists()).toBe(false);
+
+        expect(wrapper.find("#previous-sessions-headers").exists()).toBe(false);
+        expect(wrapper.findAll(".previous-session-row").length).toBe(0);
     });
 
     it("dispatches getSessions action on mount", () => {
-        getWrapper(null);
+        getWrapper(null, currentSessionId);
         expect(mockGetSessions).toHaveBeenCalledTimes(1);
     });
 
     it("shows edit label dialog when click icon", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
+        const rows = wrapper.findAll(".previous-session-row");
+        const session1Cells = rows.at(1)!.findAll("div.session-col-value");
         await session1Cells.at(2)!.findComponent(VueFeather).trigger("click");
         const editDlg = wrapper.findComponent(EditSessionLabel);
         expect(editDlg.props("open")).toBe(true);
-        expect(editDlg.props("sessionId")).toBe("abc");
-        expect(editDlg.props("sessionLabel")).toBe("session1");
+        expect(editDlg.props("sessionId")).toBe("ghi");
+        expect(editDlg.props("sessionLabel")).toBe("another session");
     });
 
     it("copy link dispatches GenerateFriendlyId only if session has no friendly id", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         // session 1 already has a friendly id so action should not be dispatched
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        await session1Cells.at(5)!.find(".session-copy-link").trigger("click");
+        await wrapper.find("#current-session .session-copy-link").trigger("click");
         expect(mockGenerateFriendlyId).not.toHaveBeenCalled();
         // session 2 has no friendly id so action should be dispatched
-        const session2Cells = rows.at(3)!.findAll("div.session-col-value");
+        const session2Cells = wrapper.find(".previous-session-row").findAll("div.session-col-value");
         await session2Cells.at(5)!.find(".session-copy-link").trigger("click");
         expect(mockGenerateFriendlyId).toHaveBeenCalledTimes(1);
         expect(mockGenerateFriendlyId.mock.calls[0][1]).toBe("def");
     });
 
     it("copy code dispatches GenerateFriendlyId only if session has no friendly id", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         // session 1 already has a friendly id so action should not be dispatched
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        await session1Cells.at(5)!.find(".session-copy-code").trigger("click");
+        await wrapper.find("#current-session .session-copy-code").trigger("click");
         expect(mockGenerateFriendlyId).not.toHaveBeenCalled();
         // session 2 has no friendly id so action should be dispatched
-        const session2Cells = rows.at(3)!.findAll("div.session-col-value");
+        const session2Cells = wrapper.find(".previous-session-row").findAll("div.session-col-value");
         await session2Cells.at(5)!.find(".session-copy-code").trigger("click");
         expect(mockGenerateFriendlyId).toHaveBeenCalledTimes(1);
         expect(mockGenerateFriendlyId.mock.calls[0][1]).toBe("def");
     });
 
     it("copy link copies link to clipboard and updates confirmation", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        await session1Cells.at(5)!.find(".session-copy-link").trigger("click");
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
 
-        const expectedLink = "http://localhost:3000/apps/testApp/?share=bad-cat";
-
+        // current session
+        await wrapper.find("#current-session .session-copy-link").trigger("click");
+        let expectedLink = "http://localhost:3000/apps/testApp/?share=bad-cat";
         expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
         expect(mockClipboardWriteText.mock.calls[0][0]).toBe(expectedLink);
+        expect(wrapper.find("#current-session .session-copy-confirm").text()).toBe(`Copied: ${expectedLink}`);
 
-        expect(session1Cells.at(5)!.find(".session-copy-confirm").text())
-            .toBe(`Copied: ${expectedLink}`);
+        // previous session
+        const session3Row = wrapper.findAll(".previous-session-row").at(1)!;
+        await session3Row.find(".session-copy-link").trigger("click");
+        expectedLink = "http://localhost:3000/apps/testApp/?share=good-dog";
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(2);
+        expect(mockClipboardWriteText.mock.calls[1][0]).toBe(expectedLink);
+        expect(session3Row.find(".session-copy-confirm").text()).toBe(`Copied: ${expectedLink}`);
     });
 
     it("copy code copies friendly id to clipboard and updates confirmation", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        await session1Cells.at(5)!.find(".session-copy-code").trigger("click");
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
 
+        // current session
+        await wrapper.find("#current-session .session-copy-code").trigger("click");
         expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
         expect(mockClipboardWriteText.mock.calls[0][0]).toBe("bad-cat");
+        expect(wrapper.find("#current-session .session-copy-confirm").text()).toBe("Copied: bad-cat");
 
-        expect(session1Cells.at(5)!.find(".session-copy-confirm").text())
-            .toBe("Copied: bad-cat");
+        // previous session
+        const session3Row = wrapper.findAll(".previous-session-row").at(1)!;
+        await session3Row.find(".session-copy-code").trigger("click");
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(2);
+        expect(mockClipboardWriteText.mock.calls[1][0]).toBe("good-dog");
+        expect(session3Row.find(".session-copy-confirm").text()).toBe("Copied: good-dog");
     });
 
-    it("mouseleave event from copy control clears confirm text", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
-        const rows = wrapper.findAll(".container .row");
-        const session1Cells = rows.at(2)!.findAll("div.session-col-value");
-        await session1Cells.at(5)!.find(".session-copy-code").trigger("click");
-        expect(session1Cells.at(5)!.find(".session-copy-confirm").text()).toBe("Copied: bad-cat");
+    it("mouseleave event from copy control in previous session row clears confirm text", async () => {
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
+        const rows = wrapper.findAll(".previous-session-row");
+        const session3Cells = rows.at(1)!.findAll("div.session-col-value");
+        await session3Cells.at(5)!.find(".session-copy-code").trigger("click");
+        expect(session3Cells.at(5)!.find(".session-copy-confirm").text()).toBe("Copied: good-dog");
 
-        await session1Cells.at(5)!.find(".session-copy-code").trigger("mouseleave");
-        expect(session1Cells.at(5)!.find(".session-copy-confirm").text()).toBe("");
+        await session3Cells.at(5)!.find(".session-copy-code").trigger("mouseleave");
+        expect(session3Cells.at(5)!.find(".session-copy-confirm").text()).toBe("");
+    });
+
+    it("mouseleave event from copy control for current session clears confirm text", async () => {
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
+        await wrapper.find("#current-session .session-copy-code").trigger("click");
+        expect(wrapper.find("#current-session .session-copy-confirm").text()).toBe("Copied: bad-cat");
+
+        await wrapper.find("#current-session .session-copy-code").trigger("mouseleave");
+        expect(wrapper.find("#current-session .session-copy-confirm").text()).toBe("");
     });
 
     it("copy confirmation indicates if friendly id is being fetched, and could not be generated", (done) => {
         const runAsync = async () => {
             // the mock generate action won't mutate the state, so friendly id will still be null after it's done,
             // and the component will assume the id could not be fetched
-            const wrapper = getWrapper(sessionsMetadata);
-            const rows = wrapper.findAll(".container .row");
-            const session2Cells = rows.at(3)!.findAll("div.session-col-value");
+            const wrapper = getWrapper(sessionsMetadata, currentSessionId);
+            const rows = wrapper.findAll(".previous-session-row");
+            const session2Cells = rows.at(0)!.findAll("div.session-col-value");
             await session2Cells.at(5)!.find(".session-copy-code").trigger("click");
             // message will update to 'Fetching code...' while it calls the action
             const confirm = session2Cells.at(5)!.find(".session-copy-confirm");
@@ -243,7 +282,7 @@ describe("SessionsPage", () => {
     });
 
     it("opens and closes confirm delete dialog", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         const rows = wrapper.findAll(".container .row");
         const session1Cells = rows.at(3)!.findAll("div.session-col-value");
         await session1Cells.at(4)!.findComponent(VueFeather).trigger("click");
@@ -254,7 +293,7 @@ describe("SessionsPage", () => {
     });
 
     it("deletes session on confirm", async () => {
-        const wrapper = getWrapper(sessionsMetadata);
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         const rows = wrapper.findAll(".container .row");
         const session1Cells = rows.at(3)!.findAll("div.session-col-value");
         await session1Cells.at(4)!.findComponent(VueFeather).trigger("click"); // set session to delete

--- a/app/static/tests/unit/components/versions/appHeader.test.ts
+++ b/app/static/tests/unit/components/versions/appHeader.test.ts
@@ -12,10 +12,15 @@ import { LanguageSwitcher } from "../../../../translationPackage";
 
 describe("AppHeader", () => {
     const getWrapper = (appName: string | null = "test", sessionLabel: string | null = null,
-        sessionId = "testSessionId") => {
+        sessionId = "testSessionId", persisted = true) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
-                appName, sessionLabel, sessionId, baseUrl: "http://localhost:3000", appsPath: "apps"
+                appName,
+                sessionLabel,
+                sessionId,
+                baseUrl: "http://localhost:3000",
+                appsPath: "apps",
+                persisted
             })
         });
 
@@ -33,7 +38,7 @@ describe("AppHeader", () => {
         return shallowMount(AppHeader, options);
     };
 
-    it("renders as expected", () => {
+    it("renders as expected when session has been persisted", () => {
         const wrapper = getWrapper();
         expect(wrapper.find("a.navbar-brand").text()).toBe("Test Course Title");
         expect(wrapper.find("a.navbar-brand").attributes("href")).toBe("http://localhost:3000");
@@ -45,6 +50,7 @@ describe("AppHeader", () => {
         expect(editLabelItem.text()).toBe("Edit Label");
         expect(editLabelItem.findComponent(VueFeather).props("type")).toBe("edit-2");
 
+        expect(sessionsDropDown.find("hr").exists()).toBe(true);
         const routerLink = sessionsDropDown.findAll("ul.dropdown-menu li").at(1)!.findComponent(RouterLink);
         expect(routerLink.attributes("to")).toBe("/sessions");
 
@@ -54,6 +60,19 @@ describe("AppHeader", () => {
         expect(editDlg.props("sessionLabel")).toBe(null);
 
         expect(wrapper.findAllComponents(LanguageSwitcher)).toHaveLength(1);
+    });
+
+    it("renders as expected when session has not been persisted", () => {
+        const wrapper = getWrapper("test", null, "testSessionId", false);
+        const sessionsDropDown = wrapper.find(".dropdown");
+        expect(sessionsDropDown.find("a#sessions-menu").text()).toBe("Sessions");
+
+        expect(sessionsDropDown.find("hr").exists()).toBe(false);
+        const routerLink = sessionsDropDown.findComponent(RouterLink);
+        expect(routerLink.exists()).toBe(false);
+
+        const editDlg = wrapper.findComponent(EditSessionLabel);
+        expect(editDlg.exists()).toBe(true);
     });
 
     it("renders version menu as expected", () => {

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -350,6 +350,7 @@ describe("serialise", () => {
             yAxisRange: [1, 2]
         },
         configured: false,
+        persisted: true,
         language: langaugeState
     };
 
@@ -378,6 +379,7 @@ describe("serialise", () => {
             yAxisRange: [1, 2]
         },
         configured: false,
+        persisted: true,
         language: langaugeState
     };
 
@@ -646,6 +648,7 @@ describe("serialise", () => {
 
         deserialiseState(target, serialised);
         expect(target).toStrictEqual({
+            persisted: true,
             sessionId: "123",
             appType: AppType.Fit,
             config: {},

--- a/app/static/tests/unit/store/appState/actions.test.ts
+++ b/app/static/tests/unit/store/appState/actions.test.ts
@@ -292,9 +292,10 @@ describe("AppState actions", () => {
         // use a real timer to wait for the final commit after mock axios returns!
         jest.useRealTimers();
         setTimeout(() => {
-            expect(commit).toHaveBeenCalledTimes(5);
-            expect(commit.mock.calls[4][0]).toBe(AppStateMutation.SetStateUploadInProgress);
-            expect(commit.mock.calls[4][1]).toBe(false);
+            expect(commit).toHaveBeenCalledTimes(6);
+            expect(commit.mock.calls[4][0]).toBe(AppStateMutation.SetPersisted);
+            expect(commit.mock.calls[5][0]).toBe(AppStateMutation.SetStateUploadInProgress);
+            expect(commit.mock.calls[5][1]).toBe(false);
             done();
         });
     });

--- a/app/static/tests/unit/store/appState/mutations.test.ts
+++ b/app/static/tests/unit/store/appState/mutations.test.ts
@@ -70,4 +70,10 @@ describe("AppState mutations", () => {
         appStateMutations.SetConfigured(state);
         expect(state.configured).toBe(true);
     });
+
+    it("sets persisted", () => {
+        const state = mockBasicState();
+        appStateMutations.SetPersisted(state);
+        expect(state.persisted).toBe(true);
+    });
 });


### PR DESCRIPTION
Following user feedback on the short course, this branch removes the current session from the main table on the Sessions page, and adds controls related to the current session above the table. If there is no current session the user is given the option to start a new session. 

The controls for copying code and copying link have also been added above the table, There is no longer an option on this page to edit the label for the current session, but the user can do that from the Sessions menu - does that seem sufficient?

Page when there is a current session:
![image (6)](https://github.com/mrc-ide/wodin/assets/44669576/2eb751ff-b04b-4f44-9fd5-1bb532e963bd)

And when there isn't one...

![image (7)](https://github.com/mrc-ide/wodin/assets/44669576/7b94b8fb-cd10-489d-96e2-c7423bda8759)
