### PR TITLE
mrc-4628 Filter out duplicate sessions from Sessions page

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^4.17.2",
         "hbs": "^4.2.0",
         "ioredis": "^5.2.2",
+        "md5": "^2.3.0",
         "morgan": "^1.10.0",
         "uid": "^2.0.0",
         "zoo-ids": "^2.0.0"
@@ -27,6 +28,7 @@
         "@types/axios": "^0.14.0",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.0",
+        "@types/md5": "^2.3.4",
         "@types/node": "^17.0.12",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
@@ -1294,6 +1296,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/md5": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
+      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -2293,6 +2301,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
@@ -2502,6 +2518,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssom": {
@@ -5476,6 +5500,21 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/md5/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -8331,6 +8370,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/md5": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
+      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -9050,6 +9095,11 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "ci-info": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
@@ -9227,6 +9277,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -11456,6 +11511,23 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
       }
     },
     "media-typer": {

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -22,6 +22,7 @@
     "express": "^4.17.2",
     "hbs": "^4.2.0",
     "ioredis": "^5.2.2",
+    "md5": "^2.3.0",
     "morgan": "^1.10.0",
     "uid": "^2.0.0",
     "zoo-ids": "^2.0.0"
@@ -30,6 +31,7 @@
     "@types/axios": "^0.14.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.0",
+    "@types/md5": "^2.3.4",
     "@types/node": "^17.0.12",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",

--- a/app/server/src/controllers/sessionsController.ts
+++ b/app/server/src/controllers/sessionsController.ts
@@ -32,9 +32,10 @@ export class SessionsController {
             const sessionIdsString = req.query.sessionIds as string;
             let metadata: SessionMetadata[] = [];
             if (sessionIdsString) {
+                const removeDups = req.query.removeDuplicates === "true";
                 const sessionIds = sessionIdsString.split(",");
                 const store = getSessionStore(req);
-                metadata = await store.getSessionsMetadata(sessionIds);
+                metadata = await store.getSessionsMetadata(sessionIds, removeDups);
             }
             jsonResponseSuccess(metadata, res);
         });

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -92,7 +92,7 @@ export class SessionStore {
                         // For backward compatibility, save hash for data if not present
                         if (hash === null) {
                             const data = await this.getSession(id);
-                            hash = this.hashForData(data!);
+                            hash = SessionStore.hashForData(data!);
                             saveMissingHashes.push(this.saveMissingSessionHash(id, hash));
                         }
 

--- a/app/server/src/db/sessionStore.ts
+++ b/app/server/src/db/sessionStore.ts
@@ -3,6 +3,7 @@ import * as md5 from "md5";
 import { generateId } from "zoo-ids";
 import { Request } from "express";
 import { AppLocals, SessionMetadata } from "../types";
+import {Session} from "inspector";
 
 export const cleanFriendlyId = (id: string): string => {
     let ret = id.toLowerCase();
@@ -104,7 +105,7 @@ export class SessionStore {
                 allResults = ids.map((id: string, idx: number) => buildSessionMetadata(id, idx))
                     .filter((session) => session.time !== null);
             }
-            return allResults.sort((a, b) => a.time!! < b.time!! ? 1 : -1);
+            return allResults.sort((a, b) => a.time!! < b.time!! ? 1 : -1) as SessionMetadata[];
         });
     }
 

--- a/app/server/tests/controllers/sessionsController.test.ts
+++ b/app/server/tests/controllers/sessionsController.test.ts
@@ -55,7 +55,8 @@ describe("SessionsController", () => {
         const metadataReq = {
             ...req,
             query: {
-                sessionIds: "1234,5678"
+                sessionIds: "1234,5678",
+                removeDuplicates: "true"
             }
         };
         await SessionsController.getSessionsMetadata(metadataReq, res, jest.fn());
@@ -63,9 +64,26 @@ describe("SessionsController", () => {
         expect(mockGetSessionStore.mock.calls[0][0]).toBe(metadataReq);
         expect(mockSessionStore.getSessionsMetadata).toHaveBeenCalledTimes(1);
         expect(mockSessionStore.getSessionsMetadata.mock.calls[0][0]).toStrictEqual(["1234", "5678"]);
+        expect(mockSessionStore.getSessionsMetadata.mock.calls[0][1]).toStrictEqual(true);
 
         expect(res.header).toHaveBeenCalledWith("Content-Type", "application/json");
         expect(res.end).toHaveBeenCalledTimes(1);
+    });
+
+    it("getSessionMetadata can pass false remove duplicates parameter to session store", async () => {
+        const metadataReq = {
+            ...req,
+            query: {
+                sessionIds: "1234",
+                removeDuplicates: "false"
+            }
+        };
+        await SessionsController.getSessionsMetadata(metadataReq, res, jest.fn());
+        expect(mockGetSessionStore).toHaveBeenCalledTimes(1);
+        expect(mockGetSessionStore.mock.calls[0][0]).toBe(metadataReq);
+        expect(mockSessionStore.getSessionsMetadata).toHaveBeenCalledTimes(1);
+        expect(mockSessionStore.getSessionsMetadata.mock.calls[0][0]).toStrictEqual(["1234"]);
+        expect(mockSessionStore.getSessionsMetadata.mock.calls[0][1]).toStrictEqual(false);
     });
 
     it("getSessionMetadata handles error", async () => {

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -202,7 +202,10 @@ describe("generate friendly id", () => {
 });
 
 describe("SessionStore handles duplicate sessions", () => {
-    const mockRedis = (savedHmGetValues: Record<string, (string | null)[]>, savedHGetValues: Record<string, string> = {}) => {
+    const mockRedis = (
+        savedHmGetValues: Record<string, (string | null)[]>,
+        savedHGetValues: Record<string, string> = {}
+    ) => {
         return {
             hmget: jest.fn().mockImplementation(async (sessionKey: string) => {
                 const key = sessionKey.split(":").slice(-1)[0];
@@ -217,7 +220,13 @@ describe("SessionStore handles duplicate sessions", () => {
 
     it("Filters out earlier duplicate sessions if removeDuplicates is true", async () => {
         const savedValues = {
-            time: ["2023-10-25 11:10:01", "2023-10-25 11:10:02", "2023-10-25 11:10:03", "2023-10-25 11:10:04", "2023-10-25 11:10:05"],
+            time: [
+                "2023-10-25 11:10:01",
+                "2023-10-25 11:10:02",
+                "2023-10-25 11:10:03",
+                "2023-10-25 11:10:04",
+                "2023-10-25 11:10:05"
+            ],
             label: [null, null, null, null, null],
             friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
             hash: ["123", "234", "567", "234", "123"]
@@ -235,15 +244,27 @@ describe("SessionStore handles duplicate sessions", () => {
 
         // results should be ordered chrono desc
         expect(result).toStrictEqual([
-            {id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"},
-            {id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"},
-            {id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"}
+            {
+                id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"
+            },
+            {
+                id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"
+            },
+            {
+                id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"
+            }
         ]);
     });
 
     it("Does not filter out earlier duplicate sessions if removeDuplicates is false", async () => {
         const savedValues = {
-            time: ["2023-10-25 11:10:01", "2023-10-25 11:10:02", "2023-10-25 11:10:03", "2023-10-25 11:10:04", "2023-10-25 11:10:05"],
+            time: [
+                "2023-10-25 11:10:01",
+                "2023-10-25 11:10:02",
+                "2023-10-25 11:10:03",
+                "2023-10-25 11:10:04",
+                "2023-10-25 11:10:05"
+            ],
             label: [null, null, null, null, null],
             friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
             hash: ["123", "234", "567", "234", "123"]
@@ -260,17 +281,33 @@ describe("SessionStore handles duplicate sessions", () => {
         expect(redis.hmget).toHaveBeenNthCalledWith(4, `${sessionKeyPrefix}hash`, ...ids);
 
         expect(result).toStrictEqual([
-            {id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"},
-            {id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"},
-            {id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"},
-            {id: "def", time: "2023-10-25 11:10:02", label: null, friendlyId: "bad cat"},
-            {id: "abc", time: "2023-10-25 11:10:01", label: null, friendlyId: "good dog"}
+            {
+                id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"
+            },
+            {
+                id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"
+            },
+            {
+                id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"
+            },
+            {
+                id: "def", time: "2023-10-25 11:10:02", label: null, friendlyId: "bad cat"
+            },
+            {
+                id: "abc", time: "2023-10-25 11:10:01", label: null, friendlyId: "good dog"
+            }
         ]);
     });
 
     it("returns duplicates if they have labels", async () => {
         const savedValues = {
-            time: ["2023-10-25 11:10:01", "2023-10-25 11:10:02", "2023-10-25 11:10:03", "2023-10-25 11:10:04", "2023-10-25 11:10:05"],
+            time: [
+                "2023-10-25 11:10:01",
+                "2023-10-25 11:10:02",
+                "2023-10-25 11:10:03",
+                "2023-10-25 11:10:04",
+                "2023-10-25 11:10:05"
+            ],
             label: ["oldest session", null, null, "newer session", null],
             friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
             hash: ["123", "234", "567", "234", "123"]
@@ -281,10 +318,18 @@ describe("SessionStore handles duplicate sessions", () => {
         const result = await sut.getSessionsMetadata(ids, true);
 
         expect(result).toStrictEqual([
-            {id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"},
-            {id: "jkl", time: "2023-10-25 11:10:04", label: "newer session", friendlyId: "happy bat"},
-            {id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"},
-            {id: "abc", time: "2023-10-25 11:10:01", label: "oldest session", friendlyId: "good dog"}
+            {
+                id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"
+            },
+            {
+                id: "jkl", time: "2023-10-25 11:10:04", label: "newer session", friendlyId: "happy bat"
+            },
+            {
+                id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"
+            },
+            {
+                id: "abc", time: "2023-10-25 11:10:01", label: "oldest session", friendlyId: "good dog"
+            }
         ]);
     });
 
@@ -297,13 +342,19 @@ describe("SessionStore handles duplicate sessions", () => {
         const sessionContent2Hash = md5(sessionContent2);
 
         const savedValues = {
-            time: ["2023-10-25 11:10:01", "2023-10-25 11:10:02", "2023-10-25 11:10:03", "2023-10-25 11:10:04", "2023-10-25 11:10:05"],
+            time: [
+                "2023-10-25 11:10:01",
+                "2023-10-25 11:10:02",
+                "2023-10-25 11:10:03",
+                "2023-10-25 11:10:04",
+                "2023-10-25 11:10:05"
+            ],
             label: [null, null, null, null, null],
             friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
             hash: [sessionContent1Hash, null, "567", sessionContent2Hash, null]
         };
 
-        const redis = mockRedis(savedValues, {def: sessionContent2, mno: sessionContent1});
+        const redis = mockRedis(savedValues, { def: sessionContent2, mno: sessionContent1 });
         const sut = new SessionStore(redis, "Test Course", "testApp");
         const ids = ["abc", "def", "ghi", "jkl", "mno"];
         const result = await sut.getSessionsMetadata(ids, true);
@@ -316,9 +367,15 @@ describe("SessionStore handles duplicate sessions", () => {
 
         // results should be ordered chrono desc
         expect(result).toStrictEqual([
-            {id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"},
-            {id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"},
-            {id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"}
+            {
+                id: "mno", time: "2023-10-25 11:10:05", label: null, friendlyId: "sad owl"
+            },
+            {
+                id: "jkl", time: "2023-10-25 11:10:04", label: null, friendlyId: "happy bat"
+            },
+            {
+                id: "ghi", time: "2023-10-25 11:10:03", label: null, friendlyId: "devious chaffinch"
+            }
         ]);
     });
 });

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -1,3 +1,4 @@
+import * as md5 from "md5";
 import {
     friendlyAdjectiveAnimal, cleanFriendlyId, SessionStore, getSessionStore
 } from "../../src/db/sessionStore";
@@ -31,13 +32,16 @@ describe("SessionStore", () => {
         await sut.saveSession("1234", data);
 
         expect(mockRedis.pipeline).toHaveBeenCalledTimes(1);
-        expect(mockPipeline.hset).toHaveBeenCalledTimes(2);
+        expect(mockPipeline.hset).toHaveBeenCalledTimes(3);
         expect(mockPipeline.hset.mock.calls[0][0]).toBe("Test Course:testApp:sessions:time");
         expect(mockPipeline.hset.mock.calls[0][1]).toBe("1234");
         expect(mockPipeline.hset.mock.calls[0][2]).toBe("2022-01-24T17:00:00.000Z");
         expect(mockPipeline.hset.mock.calls[1][0]).toBe("Test Course:testApp:sessions:data");
         expect(mockPipeline.hset.mock.calls[1][1]).toBe("1234");
         expect(mockPipeline.hset.mock.calls[1][2]).toBe("testSession");
+        expect(mockPipeline.hset.mock.calls[2][0]).toBe("Test Course:testApp:sessions:hash");
+        expect(mockPipeline.hset.mock.calls[2][1]).toBe("1234");
+        expect(mockPipeline.hset.mock.calls[2][2]).toBe(md5("testSession"));
         expect(mockPipeline.exec).toHaveBeenCalledTimes(1);
     });
 

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -50,16 +50,16 @@ describe("SessionStore", () => {
         const result = await sut.getSessionsMetadata(["1234", "5678"]);
         expect(result).toStrictEqual([
             {
-                id: "1234",
-                time: "1234 value for Test Course:testApp:sessions:time",
-                label: "1234 value for Test Course:testApp:sessions:label",
-                friendlyId: "1234 value for Test Course:testApp:sessions:friendly"
-            },
-            {
                 id: "5678",
                 time: "5678 value for Test Course:testApp:sessions:time",
                 label: "5678 value for Test Course:testApp:sessions:label",
                 friendlyId: "5678 value for Test Course:testApp:sessions:friendly"
+            },
+            {
+                id: "1234",
+                time: "1234 value for Test Course:testApp:sessions:time",
+                label: "1234 value for Test Course:testApp:sessions:label",
+                friendlyId: "1234 value for Test Course:testApp:sessions:friendly"
             }
         ]);
     });

--- a/app/server/tests/db/sessionStore.test.ts
+++ b/app/server/tests/db/sessionStore.test.ts
@@ -218,20 +218,21 @@ describe("SessionStore handles duplicate sessions", () => {
         } as any;
     };
 
+    const sessionSavedValues = {
+        time: [
+            "2023-10-25 11:10:01",
+            "2023-10-25 11:10:02",
+            "2023-10-25 11:10:03",
+            "2023-10-25 11:10:04",
+            "2023-10-25 11:10:05"
+        ],
+        label: [null, null, null, null, null],
+        friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
+        hash: ["123", "234", "567", "234", "123"]
+    };
+
     it("Filters out earlier duplicate sessions if removeDuplicates is true", async () => {
-        const savedValues = {
-            time: [
-                "2023-10-25 11:10:01",
-                "2023-10-25 11:10:02",
-                "2023-10-25 11:10:03",
-                "2023-10-25 11:10:04",
-                "2023-10-25 11:10:05"
-            ],
-            label: [null, null, null, null, null],
-            friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
-            hash: ["123", "234", "567", "234", "123"]
-        };
-        const redis = mockRedis(savedValues);
+        const redis = mockRedis(sessionSavedValues);
         const sut = new SessionStore(redis, "Test Course", "testApp");
         const ids = ["abc", "def", "ghi", "jkl", "mno"];
         const result = await sut.getSessionsMetadata(ids, true);
@@ -257,19 +258,7 @@ describe("SessionStore handles duplicate sessions", () => {
     });
 
     it("Does not filter out earlier duplicate sessions if removeDuplicates is false", async () => {
-        const savedValues = {
-            time: [
-                "2023-10-25 11:10:01",
-                "2023-10-25 11:10:02",
-                "2023-10-25 11:10:03",
-                "2023-10-25 11:10:04",
-                "2023-10-25 11:10:05"
-            ],
-            label: [null, null, null, null, null],
-            friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
-            hash: ["123", "234", "567", "234", "123"]
-        };
-        const redis = mockRedis(savedValues);
+        const redis = mockRedis(sessionSavedValues);
         const sut = new SessionStore(redis, "Test Course", "testApp");
         const ids = ["abc", "def", "ghi", "jkl", "mno"];
         const result = await sut.getSessionsMetadata(ids, false);
@@ -301,16 +290,8 @@ describe("SessionStore handles duplicate sessions", () => {
 
     it("returns duplicates if they have labels", async () => {
         const savedValues = {
-            time: [
-                "2023-10-25 11:10:01",
-                "2023-10-25 11:10:02",
-                "2023-10-25 11:10:03",
-                "2023-10-25 11:10:04",
-                "2023-10-25 11:10:05"
-            ],
-            label: ["oldest session", null, null, "newer session", null],
-            friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
-            hash: ["123", "234", "567", "234", "123"]
+            ...sessionSavedValues,
+            label: ["oldest session", null, null, "newer session", null]
         };
         const redis = mockRedis(savedValues);
         const sut = new SessionStore(redis, "Test Course", "testApp");
@@ -342,15 +323,7 @@ describe("SessionStore handles duplicate sessions", () => {
         const sessionContent2Hash = md5(sessionContent2);
 
         const savedValues = {
-            time: [
-                "2023-10-25 11:10:01",
-                "2023-10-25 11:10:02",
-                "2023-10-25 11:10:03",
-                "2023-10-25 11:10:04",
-                "2023-10-25 11:10:05"
-            ],
-            label: [null, null, null, null, null],
-            friendly: ["good dog", "bad cat", "devious chaffinch", "happy bat", "sad owl"],
+            ...sessionSavedValues,
             hash: [sessionContent1Hash, null, "567", sessionContent2Hash, null]
         };
 

--- a/app/server/tests/integration/session.test.ts
+++ b/app/server/tests/integration/session.test.ts
@@ -76,13 +76,13 @@ describe("Session id integration", () => {
         expect(Array.isArray(sessions)).toBe(true);
         expect(sessions.length).toBe(2);
 
-        expect(sessions[0].id).toBe(sessionId);
+        expect(sessions[0].id).toBe(anotherSessionId);
         expectRecentTime(sessions[0].time);
-        expect(sessions[0].label).toBe("label1");
+        expect(sessions[0].label).toBe(null);
 
-        expect(sessions[1].id).toBe(anotherSessionId);
+        expect(sessions[1].id).toBe(sessionId);
         expectRecentTime(sessions[1].time);
-        expect(sessions[1].label).toBe(null);
+        expect(sessions[1].label).toBe("label1");
     });
 
     it("gets empty sessionMetadata if sessionIds parameter omitted", async () => {

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -34,6 +34,7 @@
         "@types/bootstrap": "^5.2.6",
         "@types/jest": "^27.4.0",
         "@types/markdown-it": "^12.2.3",
+        "@types/md5": "^2.3.4",
         "@types/plotly.js-basic-dist-min": "^2.12.1",
         "@types/xlsx": "^0.0.36",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
@@ -3351,6 +3352,12 @@
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
       }
+    },
+    "node_modules/@types/md5": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
+      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
+      "dev": true
     },
     "node_modules/@types/mdurl": {
       "version": "1.0.2",
@@ -31947,6 +31954,12 @@
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
       }
+    },
+    "@types/md5": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
+      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
+      "dev": true
     },
     "@types/mdurl": {
       "version": "1.0.2",

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -34,7 +34,6 @@
         "@types/bootstrap": "^5.2.6",
         "@types/jest": "^27.4.0",
         "@types/markdown-it": "^12.2.3",
-        "@types/md5": "^2.3.4",
         "@types/plotly.js-basic-dist-min": "^2.12.1",
         "@types/xlsx": "^0.0.36",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
@@ -3352,12 +3351,6 @@
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
       }
-    },
-    "node_modules/@types/md5": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
-      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
-      "dev": true
     },
     "node_modules/@types/mdurl": {
       "version": "1.0.2",
@@ -31954,12 +31947,6 @@
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
       }
-    },
-    "@types/md5": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.4.tgz",
-      "integrity": "sha512-e/L4hvpCK8GavKXmP02QlNilZOj8lpmZGGA9QGMMPZjCUoKgi1B4BvhXcbruIi6r+PqzpcjLfda/tocpHFKqDA==",
-      "dev": true
     },
     "@types/mdurl": {
       "version": "1.0.2",

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -294,9 +294,9 @@ export default defineComponent({
             window.location.assign(link);
         };
 
-        onMounted(() => {
+        onMounted(async () => {
+            await store.dispatch(AppStateAction.LoadUserPreferences);
             store.dispatch(`${namespace}/${SessionsAction.GetSessions}`);
-            store.dispatch(AppStateAction.LoadUserPreferences);
         });
 
         const messages = userMessages.sessions;

--- a/app/static/src/app/components/sessions/SessionsPage.vue
+++ b/app/static/src/app/components/sessions/SessionsPage.vue
@@ -60,6 +60,8 @@
     <p>
       <input id="show-unlabelled-check" type="checkbox" class="form-check-input" v-model="showUnlabelledSessions" />
       <label for="show-unlabelled-check" class="form-check-label ms-2">Show unlabelled sessions</label>
+      <input id="show-duplicates-check" type="checkbox" class="form-check-input ms-4" v-model="showDuplicateSessions" />
+      <label for="show-duplicates-check" class="form-check-label ms-2">Show duplicate sessions</label>
     </p>
     <template v-if="previousSessions && previousSessions.length">
         <div class="row fw-bold py-2" id="previous-sessions-headers">
@@ -195,6 +197,15 @@ export default defineComponent({
             }
         });
 
+        const showDuplicateSessions = computed({
+            get() {
+                return store.state.userPreferences?.showDuplicateSessions;
+            },
+            set(newValue: boolean) {
+                store.dispatch(AppStateAction.SaveUserPreferences, { showDuplicateSessions: newValue });
+            }
+        });
+
         const isCurrentSession = (sessionId: string) => sessionId === currentSessionId.value;
 
         const previousSessions = computed(() => {
@@ -312,6 +323,7 @@ export default defineComponent({
             toggleConfirmDeleteSessionOpen,
             deleteSession,
             showUnlabelledSessions,
+            showDuplicateSessions,
             sessionCode,
             loadSessionFromCode,
             messages

--- a/app/static/src/app/localStorageManager.ts
+++ b/app/static/src/app/localStorageManager.ts
@@ -9,7 +9,8 @@ class LocalStorageManager {
     static _preferencesKey = "preferences";
 
     static _initialUserPreferences = (): UserPreferences => ({
-        showUnlabelledSessions: true
+        showUnlabelledSessions: true,
+        showDuplicateSessions: false
     });
 
     getSessionIds = (appName: string, basePath: string): string[] => {

--- a/app/static/src/app/store/appState/actions.ts
+++ b/app/static/src/app/store/appState/actions.ts
@@ -115,9 +115,13 @@ export const appStateActions: ActionTree<AppState, AppState> = {
     },
 
     async [AppStateAction.SaveUserPreferences](context, payload: Partial<UserPreferences>) {
-        const { commit, state } = context;
+        const { commit, state, dispatch } = context;
         const newPrefs = { ...state.userPreferences, ...payload };
+        const duplicatesPrefChanged = newPrefs.showDuplicateSessions !== state.userPreferences.showDuplicateSessions;
         localStorageManager.setUserPreferences(newPrefs);
         commit(AppStateMutation.SetUserPreferences, newPrefs);
+        if (duplicatesPrefChanged) {
+            await dispatch(`sessions/${SessionsAction.GetSessions}`);
+        }
     }
 };

--- a/app/static/src/app/store/appState/state.ts
+++ b/app/static/src/app/store/appState/state.ts
@@ -22,7 +22,8 @@ export enum VisualisationTab {
 }
 
 export interface UserPreferences {
-    showUnlabelledSessions: boolean
+    showUnlabelledSessions: boolean,
+    showDuplicateSessions: boolean
 }
 
 export interface AppState {

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -34,7 +34,8 @@ export const actions: ActionTree<SessionsState, AppState> = {
 
         const sessionIds = localStorageManager.getSessionIds(appName!, rootGetters[AppStateGetter.baseUrlPath]);
         const sessionIdsQs = sessionIds.join(",");
-        const url = `/${appsPath}/${appName}/sessions/metadata?sessionIds=${sessionIdsQs}`;
+        const removeDuplicates = !rootState.userPreferences.showDuplicateSessions;
+        const url = `/${appsPath}/${appName}/sessions/metadata?sessionIds=${sessionIdsQs}&removeDuplicates=${removeDuplicates}`;
         await api(context)
             .withSuccess(SessionsMutation.SetSessionsMetadata)
             .withError(`errors/${ErrorsMutation.AddError}`, true)

--- a/app/static/src/app/store/sessions/actions.ts
+++ b/app/static/src/app/store/sessions/actions.ts
@@ -35,7 +35,8 @@ export const actions: ActionTree<SessionsState, AppState> = {
         const sessionIds = localStorageManager.getSessionIds(appName!, rootGetters[AppStateGetter.baseUrlPath]);
         const sessionIdsQs = sessionIds.join(",");
         const removeDuplicates = !rootState.userPreferences.showDuplicateSessions;
-        const url = `/${appsPath}/${appName}/sessions/metadata?sessionIds=${sessionIdsQs}&removeDuplicates=${removeDuplicates}`;
+        const qs = `?sessionIds=${sessionIdsQs}&removeDuplicates=${removeDuplicates}`;
+        const url = `/${appsPath}/${appName}/sessions/metadata${qs}`;
         await api(context)
             .withSuccess(SessionsMutation.SetSessionsMetadata)
             .withError(`errors/${ErrorsMutation.AddError}`, true)

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -189,7 +189,7 @@ export const mockMultiSensitivityState = (state: Partial<MultiSensitivityState> 
     };
 };
 
-const mockUserPreferences = () => ({ showUnlabelledSessions: true });
+export const mockUserPreferences = () => ({ showUnlabelledSessions: true, showDuplicateSessions: false });
 
 export const mockBasicState = (state: Partial<BasicState> = {}): BasicState => {
     return {

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -2,16 +2,16 @@ import { shallowMount } from "@vue/test-utils";
 import Vuex from "vuex";
 import VueFeather from "vue-feather";
 import { RouterLink } from "vue-router";
+import { nextTick } from "vue";
 import SessionsPage from "../../../../src/app/components/sessions/SessionsPage.vue";
 import ErrorsAlert from "../../../../src/app/components/ErrorsAlert.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import {mockBasicState, mockUserPreferences} from "../../../mocks";
+import { mockBasicState, mockUserPreferences } from "../../../mocks";
 import { SessionsAction } from "../../../../src/app/store/sessions/actions";
 import { SessionMetadata } from "../../../../src/app/types/responseTypes";
 import EditSessionLabel from "../../../../src/app/components/sessions/EditSessionLabel.vue";
 import ConfirmModal from "../../../../src/app/components/ConfirmModal.vue";
 import { AppStateAction } from "../../../../src/app/store/appState/actions";
-import {nextTick} from "vue";
 
 describe("SessionsPage", () => {
     const mockGetSessions = jest.fn();

--- a/app/static/tests/unit/components/sessions/sessionsPage.test.ts
+++ b/app/static/tests/unit/components/sessions/sessionsPage.test.ts
@@ -5,12 +5,13 @@ import { RouterLink } from "vue-router";
 import SessionsPage from "../../../../src/app/components/sessions/SessionsPage.vue";
 import ErrorsAlert from "../../../../src/app/components/ErrorsAlert.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState } from "../../../mocks";
+import {mockBasicState, mockUserPreferences} from "../../../mocks";
 import { SessionsAction } from "../../../../src/app/store/sessions/actions";
 import { SessionMetadata } from "../../../../src/app/types/responseTypes";
 import EditSessionLabel from "../../../../src/app/components/sessions/EditSessionLabel.vue";
 import ConfirmModal from "../../../../src/app/components/ConfirmModal.vue";
 import { AppStateAction } from "../../../../src/app/store/appState/actions";
+import {nextTick} from "vue";
 
 describe("SessionsPage", () => {
     const mockGetSessions = jest.fn();
@@ -33,16 +34,14 @@ describe("SessionsPage", () => {
     const currentSessionId = "abc";
 
     const getWrapper = (sessionsMetadata: SessionMetadata[] | null, sessionId: string | undefined,
-        showUnlabelledSessions = true) => {
+        userPreferences = mockUserPreferences()) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState({
                 appName: "testApp",
                 sessionId,
                 baseUrl: "http://localhost:3000",
                 appsPath: "apps",
-                userPreferences: {
-                    showUnlabelledSessions
-                }
+                userPreferences
             }),
             actions: {
                 [AppStateAction.SaveUserPreferences]: mockSaveUserPreferences,
@@ -148,6 +147,7 @@ describe("SessionsPage", () => {
         expect((wrapper.find("button#load-session-from-code").element as HTMLInputElement).disabled).toBe(true);
 
         expect((wrapper.find("input#show-unlabelled-check").element as HTMLInputElement).checked).toBe(true);
+        expect((wrapper.find("input#show-duplicates-check").element as HTMLInputElement).checked).toBe(false);
     });
 
     it("shows loading message when session metadata is null in store", () => {
@@ -198,8 +198,10 @@ describe("SessionsPage", () => {
         expect(wrapper.findAll(".previous-session-row").length).toBe(0);
     });
 
-    it("dispatches getSessions action on mount", () => {
+    it("dispatches getSessions action on mount", async () => {
         getWrapper(null, currentSessionId);
+        await nextTick();
+        await nextTick();
         expect(mockGetSessions).toHaveBeenCalledTimes(1);
     });
 
@@ -356,15 +358,23 @@ describe("SessionsPage", () => {
         expect(mockLoadUserPreferences).toHaveBeenCalledTimes(1);
     });
 
-    it("clicking checkbox saves show unlabelled sessions preference", async () => {
+    it("can save show unlabelled sessions preference", async () => {
         const wrapper = getWrapper(sessionsMetadata, currentSessionId);
         await wrapper.find("input#show-unlabelled-check").trigger("click");
         expect(mockSaveUserPreferences).toHaveBeenCalledTimes(1);
         expect(mockSaveUserPreferences.mock.calls[0][1]).toStrictEqual({ showUnlabelledSessions: false });
     });
 
+    it("can save show duplicate sessions preference", async () => {
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId);
+        await wrapper.find("input#show-duplicates-check").trigger("click");
+        expect(mockSaveUserPreferences).toHaveBeenCalledTimes(1);
+        expect(mockSaveUserPreferences.mock.calls[0][1]).toStrictEqual({ showDuplicateSessions: true });
+    });
+
     it("when showUnlabelledSessions is false, filters out unlabelled sessions from view", () => {
-        const wrapper = getWrapper(sessionsMetadata, currentSessionId, false);
+        const wrapper = getWrapper(sessionsMetadata, currentSessionId,
+            { showUnlabelledSessions: false, showDuplicateSessions: true });
         const rows = wrapper.findAll(".container .row");
 
         const currentSessionRow = rows.at(1)!;
@@ -388,5 +398,6 @@ describe("SessionsPage", () => {
         expect(session3Cells.at(5)!.find(".session-copy-confirm").text()).toBe("");
 
         expect((wrapper.find("input#show-unlabelled-check").element as HTMLInputElement).checked).toBe(false);
+        expect((wrapper.find("input#show-duplicates-check").element as HTMLInputElement).checked).toBe(true);
     });
 });

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -1,4 +1,5 @@
 import { localStorageManager } from "../../src/app/localStorageManager";
+import {mockUserPreferences} from "../mocks";
 
 describe("localStorageManager for sessions", () => {
     let spyOnGetItem: any;
@@ -68,12 +69,12 @@ describe("localStorageManager gets and saves user preferences", () => {
 
     it("can get user preferences", () => {
         const result = localStorageManager.getUserPreferences();
-        expect(result).toStrictEqual({ showUnlabelledSessions: false });
+        expect(result).toStrictEqual(mockUserPreferences());
         expect(spyOnGetItem).toHaveBeenCalledWith("preferences");
     });
 
     it("can set user preferences", () => {
-        const prefs = { showUnlabelledSessions: false };
+        const prefs = mockUserPreferences();
         localStorageManager.setUserPreferences(prefs);
         expect(spyOnSetItem).toHaveBeenCalledWith("preferences", JSON.stringify(prefs));
     });

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -1,5 +1,5 @@
 import { localStorageManager } from "../../src/app/localStorageManager";
-import {mockUserPreferences} from "../mocks";
+import { mockUserPreferences } from "../mocks";
 
 describe("localStorageManager for sessions", () => {
     let spyOnGetItem: any;

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -37,7 +37,7 @@ describe("localStorageManager for sessions", () => {
     });
 
     it("can add session id when basePath is not empty", () => {
-        localStorageManager.addSessionId("day1", "testInstance","session3");
+        localStorageManager.addSessionId("day1", "testInstance", "session3");
         expect(spyOnGetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem.mock.calls[0][0]).toBe("testInstance_day1_sessionIds");
@@ -69,7 +69,7 @@ describe("localStorageManager gets and saves user preferences", () => {
 
     it("can get user preferences", () => {
         const result = localStorageManager.getUserPreferences();
-        expect(result).toStrictEqual({showUnlabelledSessions: false, showDuplicateSessions: true});
+        expect(result).toStrictEqual({ showUnlabelledSessions: false, showDuplicateSessions: true });
         expect(spyOnGetItem).toHaveBeenCalledWith("preferences");
     });
 

--- a/app/static/tests/unit/localStorageManager.test.ts
+++ b/app/static/tests/unit/localStorageManager.test.ts
@@ -37,7 +37,7 @@ describe("localStorageManager for sessions", () => {
     });
 
     it("can add session id when basePath is not empty", () => {
-        localStorageManager.addSessionId("day1", "testInstance", "session3");
+        localStorageManager.addSessionId("day1", "testInstance","session3");
         expect(spyOnGetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem).toHaveBeenCalledTimes(1);
         expect(spyOnSetItem.mock.calls[0][0]).toBe("testInstance_day1_sessionIds");
@@ -59,7 +59,7 @@ describe("localStorageManager gets and saves user preferences", () => {
 
     beforeAll(() => {
         spyOnGetItem = jest.spyOn(Storage.prototype, "getItem")
-            .mockReturnValue("{\"showUnlabelledSessions\": false}");
+            .mockReturnValue("{\"showUnlabelledSessions\": false, \"showDuplicateSessions\": true}");
         spyOnSetItem = jest.spyOn(Storage.prototype, "setItem");
     });
 
@@ -69,7 +69,7 @@ describe("localStorageManager gets and saves user preferences", () => {
 
     it("can get user preferences", () => {
         const result = localStorageManager.getUserPreferences();
-        expect(result).toStrictEqual(mockUserPreferences());
+        expect(result).toStrictEqual({showUnlabelledSessions: false, showDuplicateSessions: true});
         expect(spyOnGetItem).toHaveBeenCalledWith("preferences");
     });
 
@@ -94,7 +94,7 @@ describe("localStorageManager gets default user preferences", () => {
 
     it("can get default user preferences", () => {
         const result = localStorageManager.getUserPreferences();
-        expect(result).toStrictEqual({ showUnlabelledSessions: true });
+        expect(result).toStrictEqual({ showUnlabelledSessions: true, showDuplicateSessions: false });
         expect(spyOnGetItem).toHaveBeenCalledWith("preferences");
     });
 });

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -328,7 +328,8 @@ describe("serialise", () => {
     };
 
     const userPreferences = {
-        showUnlabelledSessions: true
+        showUnlabelledSessions: true,
+        showDuplicateSessions: false
     };
 
     const basicState: BasicState = {

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -251,10 +251,11 @@ describe("SessionsActions", () => {
     });
 
     it("GetSessions commits error", async () => {
-        mockAxios.onGet("/apps/test-app/sessions/metadata?sessionIds=123,456")
+        mockAxios.onGet("/apps/test-app/sessions/metadata?sessionIds=123,456&removeDuplicates=true")
             .reply(500, mockFailure("TEST ERROR"));
 
-        const rootState = mockBasicState({ appName: "test-app", appsPath: "apps" });
+        const userPreferences = mockUserPreferences();
+        const rootState = mockBasicState({ appName: "test-app", appsPath: "apps", userPreferences });
         const commit = jest.fn();
         await (actions[SessionsAction.GetSessions] as any)({ commit, rootState, rootGetters });
 

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -222,7 +222,7 @@ describe("SessionsActions", () => {
         const url = "/apps/test-app/sessions/metadata?sessionIds=123,456&removeDuplicates=true";
         mockAxios.onGet(url).reply(200, mockSuccess(metadata));
 
-        const userPreferences = {...mockUserPreferences(), showDuplicateSessions: false};
+        const userPreferences = { ...mockUserPreferences(), showDuplicateSessions: false };
         const rootState = mockBasicState({ appName: "test-app", appsPath: "apps", userPreferences });
         const commit = jest.fn();
         await (actions[SessionsAction.GetSessions] as any)({ commit, rootState, rootGetters });
@@ -242,7 +242,7 @@ describe("SessionsActions", () => {
         const url = "/apps/test-app/sessions/metadata?sessionIds=123,456&removeDuplicates=false";
         mockAxios.onGet(url).reply(200, mockSuccess([]));
 
-        const userPreferences = {...mockUserPreferences(), showDuplicateSessions: true};
+        const userPreferences = { ...mockUserPreferences(), showDuplicateSessions: true };
         const rootState = mockBasicState({ appName: "test-app", appsPath: "apps", userPreferences });
         const commit = jest.fn();
         await (actions[SessionsAction.GetSessions] as any)({ commit, rootState, rootGetters });

--- a/app/static/tests/unit/store/sessions/actions.test.ts
+++ b/app/static/tests/unit/store/sessions/actions.test.ts
@@ -1,6 +1,6 @@
 import { actions, SessionsAction } from "../../../../src/app/store/sessions/actions";
 import {
-    mockAxios, mockBasicState, mockFailure, mockSuccess
+    mockAxios, mockBasicState, mockFailure, mockSuccess, mockUserPreferences
 } from "../../../mocks";
 import { SessionsMutation } from "../../../../src/app/store/sessions/mutations";
 import { localStorageManager } from "../../../../src/app/localStorageManager";
@@ -218,12 +218,16 @@ describe("SessionsActions", () => {
             { id: "123", time: "10:20", label: "session1" },
             { id: "456", time: "10:21", label: "session2" }
         ];
-        mockAxios.onGet("/apps/test-app/sessions/metadata?sessionIds=123,456")
-            .reply(200, mockSuccess(metadata));
 
-        const rootState = mockBasicState({ appName: "test-app", appsPath: "apps" });
+        const url = "/apps/test-app/sessions/metadata?sessionIds=123,456&removeDuplicates=true";
+        mockAxios.onGet(url).reply(200, mockSuccess(metadata));
+
+        const userPreferences = {...mockUserPreferences(), showDuplicateSessions: false};
+        const rootState = mockBasicState({ appName: "test-app", appsPath: "apps", userPreferences });
         const commit = jest.fn();
         await (actions[SessionsAction.GetSessions] as any)({ commit, rootState, rootGetters });
+
+        expect(mockAxios.history.get[0].url).toBe(url);
 
         expect(commit).toHaveBeenCalledTimes(1);
         expect(commit.mock.calls[0][0]).toBe(SessionsMutation.SetSessionsMetadata);
@@ -232,6 +236,18 @@ describe("SessionsActions", () => {
         expect(getSessionIdsSpy).toHaveBeenCalledTimes(1);
         expect(getSessionIdsSpy.mock.calls[0][0]).toBe("test-app");
         expect(getSessionIdsSpy.mock.calls[0][1]).toBe("testInstance");
+    });
+
+    it("GetSessions sends removeDuplicates=false if showDuplicates user preference is true", async () => {
+        const url = "/apps/test-app/sessions/metadata?sessionIds=123,456&removeDuplicates=false";
+        mockAxios.onGet(url).reply(200, mockSuccess([]));
+
+        const userPreferences = {...mockUserPreferences(), showDuplicateSessions: true};
+        const rootState = mockBasicState({ appName: "test-app", appsPath: "apps", userPreferences });
+        const commit = jest.fn();
+        await (actions[SessionsAction.GetSessions] as any)({ commit, rootState, rootGetters });
+
+        expect(mockAxios.history.get[0].url).toBe(url);
     });
 
     it("GetSessions commits error", async () => {


### PR DESCRIPTION
This branch gives the user a checkbox to filter out duplicate sessions from the Sessions page (checked by default). Unlabelled sessions which are duplicates of a later session will not be shown. Labelled sessions are always shown (I think users would be confused if their labelled session vanished because a later session happened to be identical). 

Now that we're saving hashes for sessions in order to identify duplicates, we could potentially make a further change to only save the data for a hash  once, rather than for every session separately. One for another ticket: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4677