### PR TITLE
mrc-4588 Display model fit error details

### DIFF
--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -21,6 +21,7 @@
           <div v-if="cancelled" id="fit-cancelled-msg" class="small text-danger">{{cancelledMsg}}</div>
         </div>
       </fit-plot>
+      <error-info :error="error"></error-info>
     </div>
   </div>
 </template>
@@ -39,10 +40,12 @@ import { ModelFitMutation } from "../../store/modelFit/mutations";
 import { fitRequirementsExplanation, fitUpdateRequiredExplanation } from "./support";
 import { allTrue, anyTrue } from "../../utils";
 import LoadingButton from "../LoadingButton.vue";
+import ErrorInfo from "@/app/components/ErrorInfo.vue";
 
 export default defineComponent({
     name: "FitTab",
     components: {
+      ErrorInfo,
         LoadingSpinner,
         FitPlot,
         ActionRequiredMessage,
@@ -57,6 +60,7 @@ export default defineComponent({
         const canFitModel = computed(() => allTrue(fitRequirements.value));
         const compileRequired = computed(() => store.state.model.compileRequired);
         const fitUpdateRequired = computed(() => store.state.modelFit.fitUpdateRequired);
+        const error = computed(() => store.state.modelFit.error);
         const fitModel = () => store.dispatch(`${namespace}/${ModelFitAction.FitModel}`);
 
         const cancelFit = () => store.commit(`${namespace}/${ModelFitMutation.SetFitting}`, false);
@@ -68,6 +72,10 @@ export default defineComponent({
         const sumOfSquares = computed(() => store.state.modelFit.sumOfSquares);
 
         const actionRequiredMessage = computed(() => {
+            if (error.value) {
+              return userMessages.modelFit.errorOccurred;
+            }
+
             if (!allTrue(fitRequirements.value)) {
                 return fitRequirementsExplanation(fitRequirements.value);
             }
@@ -119,6 +127,7 @@ export default defineComponent({
             cancelledMsg,
             sumOfSquares,
             actionRequiredMessage,
+            error,
             iconType,
             iconClass
         };

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -45,7 +45,7 @@ import ErrorInfo from "../ErrorInfo.vue";
 export default defineComponent({
     name: "FitTab",
     components: {
-      ErrorInfo,
+        ErrorInfo,
         LoadingSpinner,
         FitPlot,
         ActionRequiredMessage,
@@ -73,7 +73,7 @@ export default defineComponent({
 
         const actionRequiredMessage = computed(() => {
             if (error.value) {
-              return userMessages.modelFit.errorOccurred;
+                return userMessages.modelFit.errorOccurred;
             }
 
             if (!allTrue(fitRequirements.value)) {

--- a/app/static/src/app/components/fit/FitTab.vue
+++ b/app/static/src/app/components/fit/FitTab.vue
@@ -40,7 +40,7 @@ import { ModelFitMutation } from "../../store/modelFit/mutations";
 import { fitRequirementsExplanation, fitUpdateRequiredExplanation } from "./support";
 import { allTrue, anyTrue } from "../../utils";
 import LoadingButton from "../LoadingButton.vue";
-import ErrorInfo from "@/app/components/ErrorInfo.vue";
+import ErrorInfo from "../ErrorInfo.vue";
 
 export default defineComponent({
     name: "FitTab",

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -130,7 +130,8 @@ function serialiseModelFit(modelFit: ModelFitState): SerialisedModelFitState {
         converged: modelFit.converged,
         sumOfSquares: modelFit.sumOfSquares,
         paramsToVary: modelFit.paramsToVary,
-        result: serialiseSolutionResult(modelFit.result)
+        result: serialiseSolutionResult(modelFit.result),
+        error: modelFit.error
     };
 }
 

--- a/app/static/src/app/store/appState/mutations.ts
+++ b/app/static/src/app/store/appState/mutations.ts
@@ -21,7 +21,8 @@ export enum AppStateMutation {
 export const StateUploadMutations = [
     AppStateMutation.ClearQueuedStateUpload,
     AppStateMutation.SetQueuedStateUpload,
-    AppStateMutation.SetStateUploadInProgress
+    AppStateMutation.SetStateUploadInProgress,
+    AppStateMutation.SetPersisted
 ] as string[];
 
 export const appStateMutations: MutationTree<AppState> = {

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -50,24 +50,28 @@ export const actions: ActionTree<ModelFitState, FitState> = {
             const { advancedSettings } = rootState.run;
             const advancedSettingsOdin = convertAdvancedSettingsToOdin(advancedSettings, pars.base);
 
-            const simplex = odinRunnerOde!.wodinFit(
-                odin!,
-                data,
-                pars,
-                linkedVariable,
-                advancedSettingsOdin,
-                {}
-            );
+            try {
+                const simplex = odinRunnerOde!.wodinFit(
+                    odin!,
+                    data,
+                    pars,
+                    linkedVariable,
+                    advancedSettingsOdin,
+                    {}
+                );
 
-            const inputs = {
-                data,
-                endTime,
-                link
-            };
-
-            commit(ModelFitMutation.SetFitUpdateRequired, null);
-            commit(ModelFitMutation.SetInputs, inputs);
-            dispatch(ModelFitAction.FitModelStep, simplex);
+                const inputs = {
+                    data,
+                    endTime,
+                    link
+                };
+                commit(ModelFitMutation.SetFitUpdateRequired, null);
+                commit(ModelFitMutation.SetInputs, inputs);
+                dispatch(ModelFitAction.FitModelStep, simplex);
+            } catch (e: unknown) {
+                commit(ModelFitMutation.SetError, {error: "Model fit error", detail: (e as Error).message});
+                commit(ModelFitMutation.SetFitting, false);
+            }
         }
     },
 

--- a/app/static/src/app/store/modelFit/actions.ts
+++ b/app/static/src/app/store/modelFit/actions.ts
@@ -69,7 +69,7 @@ export const actions: ActionTree<ModelFitState, FitState> = {
                 commit(ModelFitMutation.SetInputs, inputs);
                 dispatch(ModelFitAction.FitModelStep, simplex);
             } catch (e: unknown) {
-                commit(ModelFitMutation.SetError, {error: "Model fit error", detail: (e as Error).message});
+                commit(ModelFitMutation.SetError, { error: "Model fit error", detail: (e as Error).message });
                 commit(ModelFitMutation.SetFitting, false);
             }
         }

--- a/app/static/src/app/store/modelFit/modelFit.ts
+++ b/app/static/src/app/store/modelFit/modelFit.ts
@@ -18,7 +18,8 @@ export const defaultState: ModelFitState = {
     sumOfSquares: null,
     paramsToVary: [],
     inputs: null,
-    result: null
+    result: null,
+    error: null
 };
 
 export const modelFit = {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -1,6 +1,6 @@
 import { MutationTree } from "vuex";
 import { ModelFitInputs, ModelFitState, FitUpdateRequiredReasons } from "./state";
-import { SimplexResult } from "../../types/responseTypes";
+import {SimplexResult, WodinError} from "../../types/responseTypes";
 
 export enum ModelFitMutation {
     SetFitting = "SetFitting",
@@ -8,12 +8,16 @@ export enum ModelFitMutation {
     SetInputs = "SetInputs",
     SetParamsToVary = "SetParamsToVary",
     SetSumOfSquares = "SetSumOfSquares",
-    SetFitUpdateRequired = "SetFitUpdateRequired"
+    SetFitUpdateRequired = "SetFitUpdateRequired",
+    SetError = "SetError"
 }
 
 export const mutations: MutationTree<ModelFitState> = {
     [ModelFitMutation.SetFitting](state: ModelFitState, payload: boolean) {
         state.fitting = payload;
+        if (payload) {
+            state.error = null
+        }
     },
 
     [ModelFitMutation.SetResult](state: ModelFitState, payload: SimplexResult) {
@@ -41,6 +45,10 @@ export const mutations: MutationTree<ModelFitState> = {
 
     [ModelFitMutation.SetSumOfSquares](state: ModelFitState, payload: number | null) {
         state.sumOfSquares = payload;
+    },
+
+    [ModelFitMutation.SetError](state: ModelFitState, payload: WodinError) {
+        state.error = payload;
     },
 
     [ModelFitMutation.SetFitUpdateRequired](state: ModelFitState, payload: null | Partial<FitUpdateRequiredReasons>) {

--- a/app/static/src/app/store/modelFit/mutations.ts
+++ b/app/static/src/app/store/modelFit/mutations.ts
@@ -1,6 +1,6 @@
 import { MutationTree } from "vuex";
 import { ModelFitInputs, ModelFitState, FitUpdateRequiredReasons } from "./state";
-import {SimplexResult, WodinError} from "../../types/responseTypes";
+import { SimplexResult, WodinError } from "../../types/responseTypes";
 
 export enum ModelFitMutation {
     SetFitting = "SetFitting",
@@ -16,7 +16,7 @@ export const mutations: MutationTree<ModelFitState> = {
     [ModelFitMutation.SetFitting](state: ModelFitState, payload: boolean) {
         state.fitting = payload;
         if (payload) {
-            state.error = null
+            state.error = null;
         }
     },
 

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -1,6 +1,6 @@
 import { OdinFitResult } from "../../types/wrapperTypes";
 import type { FitData, FitDataLink } from "../fitData/state";
-import {WodinError} from "../../types/responseTypes";
+import { WodinError } from "../../types/responseTypes";
 
 export interface ModelFitInputs {
     data: FitData;

--- a/app/static/src/app/store/modelFit/state.ts
+++ b/app/static/src/app/store/modelFit/state.ts
@@ -1,5 +1,6 @@
 import { OdinFitResult } from "../../types/wrapperTypes";
 import type { FitData, FitDataLink } from "../fitData/state";
+import {WodinError} from "../../types/responseTypes";
 
 export interface ModelFitInputs {
     data: FitData;
@@ -25,6 +26,7 @@ export interface ModelFitState {
     paramsToVary: string[],
     inputs: ModelFitInputs | null, // all inputs except parameters, which vary
     result: OdinFitResult | null, // full solution for current best fit,
+    error: null | WodinError
 }
 
 export interface ModelFitRequirements {

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -77,7 +77,8 @@ export interface SerialisedModelFitState {
     converged: boolean | null,
     sumOfSquares: number | null,
     paramsToVary: string[],
-    result: SerialisedRunResult | null
+    result: SerialisedRunResult | null,
+    error: null | WodinError
 }
 
 export interface SerialisedAppState {

--- a/app/static/src/app/userMessages.ts
+++ b/app/static/src/app/userMessages.ts
@@ -56,6 +56,7 @@ export default {
         notFittedYet: "Model has not been fitted.",
         selectParamToVary: "Please select at least one parameter to vary during model fit.",
         compileRequired: "Model code has been updated. Compile code and Fit Model for updated best fit.",
+        errorOccurred: "An error occurred during model fit.",
         updateFitReasons: {
             prefix: "Fit is out of date:",
             unknown: "unknown reasons, contact the administrator, as this is unexpected",

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -163,7 +163,7 @@ test.describe("Wodin App model fit tests", () => {
         expect(newSumOfSquares).not.toEqual(sumOfSquares);
     });
 
-    test("can show model fit error", async ({page}) => {
+    test("can show model fit error", async ({ page }) => {
         // Upload data
         await uploadCSVData(page, realisticFitData);
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
@@ -179,7 +179,7 @@ test.describe("Wodin App model fit tests", () => {
         // select param to vary
         await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
         await expect(await page.innerText("#select-param-msg"))
-            .toBe("Please select at least one parameter to vary during model fit.")
+            .toBe("Please select at least one parameter to vary during model fit.");
         await page.click(":nth-match(input.vary-param-check, 1)");
         await page.click(":nth-match(input.vary-param-check, 2)");
 
@@ -194,7 +194,8 @@ test.describe("Wodin App model fit tests", () => {
         await page.click(".wodin-right .wodin-content div.mt-4 button#fit-btn");
         console.log("15");
 
-        await expect(await page.locator(".fit-tab .action-required-msg")).toHaveText("An error occurred during model fit.", {timeout});
+        await expect(await page.locator(".fit-tab .action-required-msg"))
+            .toHaveText("An error occurred during model fit.", { timeout });
         await expect(await page.innerText(".fit-tab #error-info")).toContain("Model fit error: Integration failure");
     });
 

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -192,7 +192,6 @@ test.describe("Wodin App model fit tests", () => {
         await input2.fill("-1");
 
         await page.click(".wodin-right .wodin-content div.mt-4 button#fit-btn");
-        console.log("15");
 
         await expect(await page.locator(".fit-tab .action-required-msg"))
             .toHaveText("An error occurred during model fit.", { timeout });

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -239,6 +239,7 @@ export const mockModelFitState = (state: Partial<ModelFitState> = {}): ModelFitS
         paramsToVary: [],
         inputs: null,
         result: null,
+        error: null,
         ...state
     };
 };

--- a/app/static/tests/unit/components/fit/fitTab.test.ts
+++ b/app/static/tests/unit/components/fit/fitTab.test.ts
@@ -1,6 +1,4 @@
 // Mock plotly before import RunTab, which indirectly imports plotly via FitPlot
-import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
-
 jest.mock("plotly.js-basic-dist-min", () => {});
 
 /* eslint-disable import/first */
@@ -13,7 +11,8 @@ import ActionRequiredMessage from "../../../../src/app/components/ActionRequired
 import LoadingSpinner from "../../../../src/app/components/LoadingSpinner.vue";
 import FitPlot from "../../../../src/app/components/fit/FitPlot.vue";
 import { mockFitState, mockGraphSettingsState } from "../../../mocks";
-import {WodinError} from "../../../../src/app/types/responseTypes";
+import { WodinError } from "../../../../src/app/types/responseTypes";
+import ErrorInfo from "../../../../src/app/components/ErrorInfo.vue";
 
 describe("Fit Tab", () => {
     const getWrapper = (
@@ -176,7 +175,7 @@ describe("Fit Tab", () => {
     });
 
     it("renders model fit error as expected", () => {
-        const error = {error: "test error", detail: "test detail"};
+        const error = { error: "test error", detail: "test detail" };
         const wrapper = getWrapper({}, false, {}, 10, true, false, 2.1, jest.fn(), jest.fn(), error);
         expect(wrapper.findComponent(ErrorInfo).props("error")).toStrictEqual(error);
         expect(wrapper.findComponent(ActionRequiredMessage).props("message"))

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -292,6 +292,7 @@ describe("serialise", () => {
 
     const modelFitState = {
         fitting: false,
+        error: { error: "fit run error", detail: "fit run detail" },
         fitUpdateRequired: {
             modelChanged: false,
             dataChanged: false,
@@ -482,6 +483,7 @@ describe("serialise", () => {
     };
 
     const expectedModelFit = {
+        error: { error: "fit run error", detail: "fit run detail" },
         fitUpdateRequired: {
             modelChanged: false,
             dataChanged: false,

--- a/app/static/tests/unit/store/modelFit/actions.test.ts
+++ b/app/static/tests/unit/store/modelFit/actions.test.ts
@@ -137,7 +137,7 @@ describe("ModelFit actions", () => {
 
     it("FitModel commits error thrown during wodinFit", () => {
         const runner = {
-            wodinFit: jest.fn().mockImplementation(() => { throw {message: "TEST ERROR"}; }),
+            wodinFit: jest.fn().mockImplementation(() => { throw new Error("TEST ERROR"); }),
             wodinFitValue: mockWodinFitValue
         } as any;
         const errorModelState = mockModelState({
@@ -145,7 +145,7 @@ describe("ModelFit actions", () => {
             odinRunnerOde: runner
         });
 
-        const errorRootState = {...rootState, model: errorModelState};
+        const errorRootState = { ...rootState, model: errorModelState };
 
         const getters = { fitRequirements: {} };
         const link = { time: "t", data: "v", model: "S" };
@@ -163,10 +163,9 @@ describe("ModelFit actions", () => {
         expect(commit.mock.calls[0][0]).toBe(ModelFitMutation.SetFitting);
         expect(commit.mock.calls[0][1]).toBe(true);
         expect(commit.mock.calls[1][0]).toBe(ModelFitMutation.SetError);
-        expect(commit.mock.calls[1][1]).toStrictEqual({error: "Model fit error", detail: "TEST ERROR"});
+        expect(commit.mock.calls[1][1]).toStrictEqual({ error: "Model fit error", detail: "TEST ERROR" });
         expect(commit.mock.calls[2][0]).toBe(ModelFitMutation.SetFitting);
         expect(commit.mock.calls[2][1]).toBe(false);
-
     });
 
     it("FitModelStep commits expected changes and dispatches further step if not converged", (done) => {

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -19,7 +19,7 @@ describe("ModelFit mutations", () => {
     });
 
     it("SetFitting sets error to null if fitting is true", () => {
-        const error = {error: "test", detail: "test detail"};
+        const error = { error: "test", detail: "test detail" };
         const state = mockModelFitState({ error });
         mutations.SetFitting(state, false);
         expect(state.error).toBe(error);
@@ -28,7 +28,7 @@ describe("ModelFit mutations", () => {
     });
 
     it("sets error", () => {
-        const error = {error: "test", detail: "test detail"};
+        const error = { error: "test", detail: "test detail" };
         const state = mockModelFitState();
         mutations.SetError(state, error);
         expect(state.error).toBe(error);

--- a/app/static/tests/unit/store/modelFit/mutations.test.ts
+++ b/app/static/tests/unit/store/modelFit/mutations.test.ts
@@ -18,6 +18,22 @@ describe("ModelFit mutations", () => {
         expect(state.fitting).toBe(true);
     });
 
+    it("SetFitting sets error to null if fitting is true", () => {
+        const error = {error: "test", detail: "test detail"};
+        const state = mockModelFitState({ error });
+        mutations.SetFitting(state, false);
+        expect(state.error).toBe(error);
+        mutations.SetFitting(state, true);
+        expect(state.error).toBe(null);
+    });
+
+    it("sets error", () => {
+        const error = {error: "test", detail: "test detail"};
+        const state = mockModelFitState();
+        mutations.SetError(state, error);
+        expect(state.error).toBe(error);
+    });
+
     it("sets model fit inputs", () => {
         const state = mockModelFitState();
         mutations.SetInputs(state, mockInputs);


### PR DESCRIPTION
This branch ensures that any error throws when a model fit starts running is saved to the state and displayed on the Fit tab. 

An ErrorInfo component has been added to the tab, and if an error is present any previous fit results are faded, with a message shown in the "Action Required" space. 

Steps to generate this error:
    - go to Fit app in Wodin
    - upload sample data ([influenza_data(1).csv](https://github.com/mrc-ide/wodin/files/13265172/influenza_data.1.csv)), go to options tab and fit tabs
    - link "E"
    - select "D" and "L" model parameters
    - Fit model
    - Change tolerance to 7 x 10^ -1
    - Fit model

There is another potential error which we should also display, in the modelFit result - this could arise if the modelFit gets further than it does in this case, where an error is thrown in the initial call. But let's do that in another ticket: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4680/Display-modelFit.result.error-in-Fit-tab