### PR TITLE
mrc-5455-v2 POC: Can add graphs to Run and drag variables to select or hide

### DIFF
--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -16,11 +16,10 @@
         <error-info :error="error"></error-info>
         <div class="mt-3">
             <vertical-collapse v-if="showSelectedVariables" title="Select variables" collapse-id="select-variables">
-                <div class="ms-2">
-                    Click to toggle variables to include in graphs. Drag variable to move to another graph.
-                </div>
+                <div class="ms-2">Drag variables to move to another graph, or to hide variable.</div>
                 <selected-variables v-for="graphKey in graphKeys" :graph-key="graphKey"></selected-variables>
-                <button class="btn btn-primary mt-2" id="add-graph-btn" @click="addGraph">Add Graph</button>
+                <hidden-variables style="clear: both"></hidden-variables>
+                <button class="btn btn-primary mt-2 float-end" id="add-graph-btn" @click="addGraph">Add Graph</button>
             </vertical-collapse>
         </div>
     </div>
@@ -37,6 +36,7 @@ import { ModelAction } from "../../store/model/actions";
 import userMessages from "../../userMessages";
 import ErrorInfo from "../ErrorInfo.vue";
 import SelectedVariables from "./SelectedVariables.vue";
+import HiddenVariables from "./HiddenVariables.vue";
 import VerticalCollapse from "../VerticalCollapse.vue";
 import GenericHelp from "../help/GenericHelp.vue";
 
@@ -45,6 +45,7 @@ export default defineComponent({
     components: {
         GenericHelp,
         SelectedVariables,
+        HiddenVariables,
         ErrorInfo,
         CodeEditor,
         VueFeather,

--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -16,7 +16,9 @@
         <error-info :error="error"></error-info>
         <div class="mt-3">
             <vertical-collapse v-if="showSelectedVariables" title="Select variables" collapse-id="select-variables">
-                <div class="ms-2">Click to toggle variables to include in graphs.</div>
+                <div class="ms-2">
+                    Click to toggle variables to include in graphs. Drag variable to move to another graph.
+                </div>
                 <selected-variables v-for="graphKey in graphKeys" :graph-key="graphKey"></selected-variables>
                 <button class="btn btn-primary mt-2" id="add-graph-btn" @click="addGraph">Add Graph</button>
             </vertical-collapse>

--- a/app/static/src/app/components/code/CodeTab.vue
+++ b/app/static/src/app/components/code/CodeTab.vue
@@ -16,7 +16,9 @@
         <error-info :error="error"></error-info>
         <div class="mt-3">
             <vertical-collapse v-if="showSelectedVariables" title="Select variables" collapse-id="select-variables">
-                <selected-variables></selected-variables>
+                <div class="ms-2">Click to toggle variables to include in graphs.</div>
+                <selected-variables v-for="graphKey in graphKeys" :graph-key="graphKey"></selected-variables>
+                <button class="btn btn-primary mt-2" id="add-graph-btn" @click="addGraph">Add Graph</button>
             </vertical-collapse>
         </div>
     </div>
@@ -60,6 +62,11 @@ export default defineComponent({
         const appIsConfigured = computed(() => store.state.configured);
         const compile = () => store.dispatch(`model/${ModelAction.CompileModel}`);
         const loadingMessage = userMessages.code.isValidating;
+        const graphKeys = computed(() => Object.keys(store.state.model.graphs));
+        const addGraph = () => {
+            const newGraphKey = `Graph ${Object.keys(store.state.model.graphs).length + 1}`;
+            store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, { key: newGraphKey, selectedVariables: [] });
+        };
 
         return {
             appIsConfigured,
@@ -72,7 +79,9 @@ export default defineComponent({
             showSelectedVariables,
             codeHelp,
             codeValidating,
-            loadingMessage
+            loadingMessage,
+            graphKeys,
+            addGraph
         };
     }
 });

--- a/app/static/src/app/components/code/HiddenVariables.vue
+++ b/app/static/src/app/components/code/HiddenVariables.vue
@@ -1,0 +1,91 @@
+<template>
+    <div class="selected-variables-panel m-2" @drop="onDrop($event)" @dragover.prevent @dragenter.prevent>
+        <h5>Hidden variables</h5>
+        <template v-for="variable in hiddenVariables" :key="variable">
+            <span
+                class="badge variable me-2 mb-2"
+                :style="getStyle(variable)"
+                draggable="true"
+                @dragstart="startDrag($event, variable)"
+            >
+                {{ variable }}
+            </span>
+        </template>
+        <div v-if="!hiddenVariables.length" style="height: 3rem; background-color: #eee" class="p-2 me-4">
+            Drag variables here to hide them on all graphs.
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "vue";
+import { useStore } from "vuex";
+import { ModelAction } from "../../store/model/actions";
+import VueFeather from "vue-feather";
+import tooltip from "../../directives/tooltip";
+import { ModelMutation } from "../../store/model/mutations";
+import { ModelGetter } from "../../store/model/getters";
+
+export default defineComponent({
+    name: "SelectedVariables",
+    computed: {
+        tooltip() {
+            return tooltip;
+        }
+    },
+    components: { VueFeather },
+    setup(props) {
+        const store = useStore();
+        const hiddenVariables = computed<string[]>(() => store.getters[`model/${ModelGetter.unselectedVariables}`]);
+        const palette = computed(() => store.state.model.paletteModel!);
+
+        const getStyle = (variable: string) => {
+            const bgcolor = palette.value ? palette.value[variable] : "#eee";
+            return { "background-color": bgcolor };
+        };
+
+        const startDrag = (evt: DragEvent, variable: string) => {
+            console.log(`started dragging ${variable}`);
+            const { dataTransfer } = evt;
+            dataTransfer!!.dropEffect = "move";
+            dataTransfer!!.effectAllowed = "move";
+            dataTransfer!!.setData("variable", variable);
+            dataTransfer!!.setData("srcGraph", "hidden");
+        };
+
+        const onDrop = (evt: DragEvent) => {
+            const { dataTransfer } = evt;
+            const variable = dataTransfer!!.getData("variable");
+            const srcGraph = dataTransfer!!.getData("srcGraph");
+            if (srcGraph !== "hidden") {
+                // remove from source graph
+                const srcVariables = [...store.state.model.graphs[srcGraph].selectedVariables].filter(
+                    (v) => v !== variable
+                );
+                store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, {
+                    key: srcGraph,
+                    selectedVariables: srcVariables
+                });
+            }
+        };
+
+        return {
+            hiddenVariables,
+            getStyle,
+            startDrag,
+            onDrop
+        };
+    }
+});
+</script>
+
+<style scoped lang="scss">
+.selected-variables-panel {
+    width: 100%;
+
+    .variable {
+        font-size: large;
+        cursor: pointer;
+    }
+}
+</style>

--- a/app/static/src/app/components/code/HiddenVariables.vue
+++ b/app/static/src/app/components/code/HiddenVariables.vue
@@ -45,7 +45,6 @@ export default defineComponent({
         };
 
         const startDrag = (evt: DragEvent, variable: string) => {
-            console.log(`started dragging ${variable}`);
             const { dataTransfer } = evt;
             dataTransfer!!.dropEffect = "move";
             dataTransfer!!.effectAllowed = "move";

--- a/app/static/src/app/components/code/SelectedVariables.vue
+++ b/app/static/src/app/components/code/SelectedVariables.vue
@@ -26,7 +26,7 @@ export default defineComponent({
     setup() {
         const store = useStore();
         const allVariables = computed<string[]>(() => store.state.model.odinModelResponse?.metadata?.variables || []);
-        const selectedVariables = computed<string[]>(() => store.state.model.selectedVariables);
+        const selectedVariables = computed<string[]>(() => store.state.model.graphs["graph1"].selectedVariables);
         const palette = computed(() => store.state.model.paletteModel!);
 
         const getStyle = (variable: string) => {
@@ -38,7 +38,10 @@ export default defineComponent({
         };
 
         const updateSelectedVariables = (newVariables: string[]) => {
-            store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, newVariables);
+            store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, {
+                key: "graph1",
+                selectedVariables: newVariables
+            });
         };
 
         const toggleVariable = (variable: string) => {

--- a/app/static/src/app/components/code/SelectedVariables.vue
+++ b/app/static/src/app/components/code/SelectedVariables.vue
@@ -1,14 +1,16 @@
 <template>
-    <div class="selected-variables-panel m-2">
+    <div class="selected-variables-panel m-2" @drop="onDrop($event)" @dragover.prevent @dragenter.prevent>
         <h5>{{ graphKey }}</h5>
         <span
             v-for="variable in allVariables"
             class="badge variable me-2 mb-2"
             :style="getStyle(variable)"
             :key="variable"
-            @click="toggleVariable(variable)"
-            >{{ variable }}</span
+            draggable="true"
+            @dragstart="startDrag($event, variable)"
         >
+            {{ variable }}
+        </span>
     </div>
     <div class="ms-2">
         <span class="clickable text-primary" id="select-variables-all" @click="selectAll">Select all</span> |
@@ -68,12 +70,26 @@ export default defineComponent({
             updateSelectedVariables([]);
         };
 
+        const startDrag = (evt: DragEvent, variable: string) => {
+            console.log(`started dragging ${variable}`);
+            evt!!.dataTransfer!!.dropEffect = "move";
+            evt!!.dataTransfer!!.effectAllowed = "move";
+            evt!!.dataTransfer!!.setData("variable", variable);
+        };
+
+        const onDrop = (evt: DragEvent) => {
+            const variable = evt.dataTransfer!!.getData("variable");
+            console.log(`${variable} got dropped!`);
+        };
+
         return {
             allVariables,
             getStyle,
             toggleVariable,
             selectAll,
-            selectNone
+            selectNone,
+            startDrag,
+            onDrop
         };
     }
 });

--- a/app/static/src/app/components/code/SelectedVariables.vue
+++ b/app/static/src/app/components/code/SelectedVariables.vue
@@ -5,6 +5,7 @@
             <button
                 type="button"
                 class="btn btn-light mx-2"
+                style="background-color: #fff; border-width: 0"
                 v-if="graphKey !== 'Graph 1'"
                 @click="deleteGraph"
                 v-tooltip="'Delete Graph'"
@@ -98,21 +99,25 @@ export default defineComponent({
         };
 
         const startDrag = (evt: DragEvent, variable: string) => {
-            console.log(`started dragging ${variable}`);
             const { dataTransfer } = evt;
+            const copy = evt.ctrlKey;
+            console.log(`started dragging ${variable} with ctrlKey ${copy}`);
             dataTransfer!!.dropEffect = "move";
             dataTransfer!!.effectAllowed = "move";
             dataTransfer!!.setData("variable", variable);
             dataTransfer!!.setData("srcGraph", props.graphKey);
+            dataTransfer!!.setData("copyVar", copy.toString());
         };
 
         const onDrop = (evt: DragEvent) => {
             const { dataTransfer } = evt;
             const variable = dataTransfer!!.getData("variable");
             const srcGraph = dataTransfer!!.getData("srcGraph");
+            console.log(`copy on drop is ${dataTransfer!!.getData("copyVar")}`);
+            const copy = dataTransfer!!.getData("copyVar") === "true";
             if (srcGraph !== props.graphKey) {
-                // remove from source graph
-                if (srcGraph !== "hidden") {
+                // remove from source graph - but not if ctrl key was held on start drag
+                if (srcGraph !== "hidden" && !copy) {
                     const srcVariables = [...store.state.model.graphs[srcGraph].selectedVariables].filter(
                         (v) => v !== variable
                     );

--- a/app/static/src/app/components/code/SelectedVariables.vue
+++ b/app/static/src/app/components/code/SelectedVariables.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="ms-2">Click to toggle variables to include in graphs.</div>
     <div class="selected-variables-panel m-2">
+        <h5>{{ graphKey }}</h5>
         <span
             v-for="variable in allVariables"
             class="badge variable me-2 mb-2"
@@ -23,10 +23,16 @@ import { ModelAction } from "../../store/model/actions";
 
 export default defineComponent({
     name: "SelectedVariables",
-    setup() {
+    props: {
+        graphKey: {
+            type: String,
+            required: true
+        }
+    },
+    setup(props) {
         const store = useStore();
         const allVariables = computed<string[]>(() => store.state.model.odinModelResponse?.metadata?.variables || []);
-        const selectedVariables = computed<string[]>(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed<string[]>(() => store.state.model.graphs[props.graphKey].selectedVariables);
         const palette = computed(() => store.state.model.paletteModel!);
 
         const getStyle = (variable: string) => {
@@ -39,7 +45,7 @@ export default defineComponent({
 
         const updateSelectedVariables = (newVariables: string[]) => {
             store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, {
-                key: "graph1",
+                key: props.graphKey,
                 selectedVariables: newVariables
             });
         };

--- a/app/static/src/app/components/code/SelectedVariables.vue
+++ b/app/static/src/app/components/code/SelectedVariables.vue
@@ -15,21 +15,20 @@
                 ></vue-feather>
             </button>
         </h5>
-        <span
-            v-for="variable in allVariables"
-            class="badge variable me-2 mb-2"
-            :style="getStyle(variable)"
-            :key="variable"
-            :draggable="selectedVariables.includes(variable) ? true : false"
-            @dragstart="startDrag($event, variable)"
-            @click="toggleVariable(variable)"
-        >
-            {{ variable }}
-        </span>
-    </div>
-    <div class="ms-2">
-        <span class="clickable text-primary" id="select-variables-all" @click="selectAll">Select all</span> |
-        <span class="clickable text-primary" id="select-variables-none" @click="selectNone">Select none</span>
+        <template v-for="variable in allVariables" :key="variable">
+            <span
+                v-if="selectedVariables.includes(variable)"
+                class="badge variable me-2 mb-2"
+                :style="getStyle(variable)"
+                :draggable="selectedVariables.includes(variable) ? true : false"
+                @dragstart="startDrag($event, variable)"
+            >
+                {{ variable }}
+            </span>
+        </template>
+        <div v-if="!selectedVariables.length" style="height: 3rem; background-color: #eee" class="p-2 me-4">
+            Drag variables here to select them for this graph.
+        </div>
     </div>
 </template>
 
@@ -113,13 +112,15 @@ export default defineComponent({
             const srcGraph = dataTransfer!!.getData("srcGraph");
             if (srcGraph !== props.graphKey) {
                 // remove from source graph
-                const srcVariables = [...store.state.model.graphs[srcGraph].selectedVariables].filter(
-                    (v) => v !== variable
-                );
-                store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, {
-                    key: srcGraph,
-                    selectedVariables: srcVariables
-                });
+                if (srcGraph !== "hidden") {
+                    const srcVariables = [...store.state.model.graphs[srcGraph].selectedVariables].filter(
+                        (v) => v !== variable
+                    );
+                    store.dispatch(`model/${ModelAction.UpdateSelectedVariables}`, {
+                        key: srcGraph,
+                        selectedVariables: srcVariables
+                    });
+                }
 
                 // add to this graph if necessary
                 if (!selectedVariables.value.includes(variable)) {

--- a/app/static/src/app/components/mixins/baseSensitivity.ts
+++ b/app/static/src/app/components/mixins/baseSensitivity.ts
@@ -37,7 +37,7 @@ export default (store: Store<AppState>, multiSensitivity: boolean): BaseSensitiv
             }
 
             // TODO: will need to tweak this to use combined set
-            if (!store.state.model.graphs["graph1"].selectedVariables.length) {
+            if (!store.state.model.graphs["Graph 1"].selectedVariables.length) {
                 return userMessages.model.selectAVariable;
             }
 

--- a/app/static/src/app/components/mixins/baseSensitivity.ts
+++ b/app/static/src/app/components/mixins/baseSensitivity.ts
@@ -36,7 +36,8 @@ export default (store: Store<AppState>, multiSensitivity: boolean): BaseSensitiv
                 return userMessages.sensitivity.compileRequiredForUpdate(multiSensitivity);
             }
 
-            if (!store.state.model.selectedVariables.length) {
+            // TODO: will need to tweak this to use combined set
+            if (!store.state.model.graphs["graph1"].selectedVariables.length) {
                 return userMessages.model.selectAVariable;
             }
 

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -42,7 +42,7 @@ export default defineComponent({
         const dataColumns = computed(() => store.getters[`${namespace}/${FitDataGetter.nonTimeColumns}`]);
         const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
         // TODO: will need to tweak this to use combined set
-        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs["Graph 1"].selectedVariables);
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
         const linkPrerequisitesMessage = computed(() => {
             const messages = [];

--- a/app/static/src/app/components/options/LinkData.vue
+++ b/app/static/src/app/components/options/LinkData.vue
@@ -41,7 +41,8 @@ export default defineComponent({
         const store = useStore();
         const dataColumns = computed(() => store.getters[`${namespace}/${FitDataGetter.nonTimeColumns}`]);
         const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
-        const selectedVariables = computed(() => store.state.model.selectedVariables);
+        // TODO: will need to tweak this to use combined set
+        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
         const linkPrerequisitesMessage = computed(() => {
             const messages = [];

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -1,4 +1,5 @@
 <template>
+    <h5>{{ graphKey }}</h5>
     <wodin-plot
         :fade-plot="fadePlot"
         :placeholder-message="placeholderMessage"
@@ -26,12 +27,16 @@ import { ParameterSet } from "../../store/run/state";
 export default defineComponent({
     name: "RunPlot",
     props: {
-        fadePlot: Boolean
+        fadePlot: Boolean,
+        graphKey: {
+            type: String,
+            default: "Graph 1"
+        }
     },
     components: {
         WodinPlot
     },
-    setup() {
+    setup(props) {
         const store = useStore();
 
         const solution = computed(() => store.state.run.resultOde?.solution);
@@ -58,8 +63,7 @@ export default defineComponent({
 
         const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 
-        // TODO: tweak for multiple plots
-        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs[props.graphKey].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -1,5 +1,4 @@
 <template>
-    <h5>{{ graphKey }}</h5>
     <wodin-plot
         :fade-plot="fadePlot"
         :placeholder-message="placeholderMessage"

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -58,7 +58,8 @@ export default defineComponent({
 
         const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
 
-        const selectedVariables = computed(() => store.state.model.selectedVariables);
+        // TODO: tweak for multiple plots
+        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
 
         const allPlotData = (start: number, end: number, points: number): WodinPlotData => {

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -29,7 +29,8 @@ export default defineComponent({
     setup() {
         const store = useStore();
 
-        const selectedVariables = computed(() => store.state.model.selectedVariables);
+        // TODO: tweak for multiple graphs
+        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
 
         const solution = computed(() => store.state.run.resultDiscrete?.solution);

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -30,7 +30,7 @@ export default defineComponent({
         const store = useStore();
 
         // TODO: tweak for multiple graphs
-        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs["Graph 1"].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
 
         const solution = computed(() => store.state.run.resultDiscrete?.solution);

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -5,7 +5,13 @@
         </div>
         <action-required-message :message="updateMsg"></action-required-message>
         <run-stochastic-plot v-if="isStochastic" :fade-plot="!!updateMsg"></run-stochastic-plot>
-        <run-plot v-else :fade-plot="!!updateMsg" :model-fit="false">
+        <run-plot
+            v-for="graphKey in graphKeys"
+            v-else
+            :fade-plot="!!updateMsg"
+            :model-fit="false"
+            :graph-key="graphKey"
+        >
             <div v-if="sumOfSquares">
                 <span>Sum of squares: {{ sumOfSquares }}</span>
             </div>
@@ -100,7 +106,7 @@ export default defineComponent({
                 return userMessages.run.compileRequired;
             }
             // TODO: tweak for multiple graphs
-            if (!store.state.model.graphs["graph1"].selectedVariables.length) {
+            if (!store.state.model.graphs["Graph 1"].selectedVariables.length) {
                 return userMessages.model.selectAVariable;
             }
             // TODO: eventually make runRequired to runUpdateRequired I think?
@@ -119,6 +125,8 @@ export default defineComponent({
         const download = (payload: { fileName: string; points: number }) =>
             store.dispatch(`run/${RunAction.DownloadOutput}`, payload);
 
+        const graphKeys = computed(() => Object.keys(store.state.model.graphs));
+
         return {
             canRunModel,
             isStochastic,
@@ -131,7 +139,8 @@ export default defineComponent({
             canDownloadOutput,
             downloadUserFileName,
             toggleShowDownloadOutput,
-            download
+            download,
+            graphKeys
         };
     }
 });

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -99,7 +99,8 @@ export default defineComponent({
             if (store.state.model.compileRequired) {
                 return userMessages.run.compileRequired;
             }
-            if (!store.state.model.selectedVariables.length) {
+            // TODO: tweak for multiple graphs
+            if (!store.state.model.graphs["graph1"].selectedVariables.length) {
                 return userMessages.model.selectAVariable;
             }
             // TODO: eventually make runRequired to runUpdateRequired I think?

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -39,7 +39,7 @@ export default defineComponent({
         const batch = computed(() => store.state.sensitivity.result?.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
-        const selectedVariables = computed(() => store.state.model.selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, true));
 
         const xAxisSettings = computed(() => {

--- a/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivitySummaryPlot.vue
@@ -39,7 +39,7 @@ export default defineComponent({
         const batch = computed(() => store.state.sensitivity.result?.batch);
         const plotSettings = computed(() => store.state.sensitivity.plotSettings);
         const palette = computed(() => store.state.model.paletteModel);
-        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs["Graph 1"].selectedVariables);
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, true));
 
         const xAxisSettings = computed(() => {

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -78,7 +78,8 @@ export default defineComponent({
 
         const palette = computed(() => store.state.model.paletteModel);
 
-        const selectedVariables = computed(() => store.state.model.selectedVariables);
+        // TODO: tweak for multiple graphs
+        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
 
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, true));
 

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -79,7 +79,7 @@ export default defineComponent({
         const palette = computed(() => store.state.model.paletteModel);
 
         // TODO: tweak for multiple graphs
-        const selectedVariables = computed(() => store.state.model.graphs["graph1"].selectedVariables);
+        const selectedVariables = computed(() => store.state.model.graphs["Graph 1"].selectedVariables);
 
         const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, true));
 

--- a/app/static/src/app/excel/wodinModelOutputDownload.ts
+++ b/app/static/src/app/excel/wodinModelOutputDownload.ts
@@ -46,7 +46,7 @@ export class WodinModelOutputDownload extends WodinExcelDownload {
                 nPoints: this._points
             });
             // TODO: tweak for multiple graphs
-            const { selectedVariables } = this._state.model.graphs["graph1"];
+            const { selectedVariables } = this._state.model.graphs["Graph 1"];
 
             const worksheet = WodinModelOutputDownload._generateModelledOutput(
                 selectedVariables,
@@ -69,7 +69,7 @@ export class WodinModelOutputDownload extends WodinExcelDownload {
                 const times = fitData.map((row: Dict<number>) => row[timeVariable]);
                 const solutionOutput = solution({ mode: "given", times });
                 // TODO: Tweak for multiple graphs
-                const { selectedVariables } = this._state.model.graphs["graph1"];
+                const { selectedVariables } = this._state.model.graphs["Graph 1"];
 
                 const worksheet = WodinModelOutputDownload._generateModelledOutput(
                     selectedVariables,

--- a/app/static/src/app/excel/wodinModelOutputDownload.ts
+++ b/app/static/src/app/excel/wodinModelOutputDownload.ts
@@ -45,7 +45,8 @@ export class WodinModelOutputDownload extends WodinExcelDownload {
                 tEnd: end,
                 nPoints: this._points
             });
-            const { selectedVariables } = this._state.model;
+            // TODO: tweak for multiple graphs
+            const { selectedVariables } = this._state.model.graphs["graph1"];
 
             const worksheet = WodinModelOutputDownload._generateModelledOutput(
                 selectedVariables,
@@ -67,7 +68,8 @@ export class WodinModelOutputDownload extends WodinExcelDownload {
             if (fitData && timeVariable) {
                 const times = fitData.map((row: Dict<number>) => row[timeVariable]);
                 const solutionOutput = solution({ mode: "given", times });
-                const { selectedVariables } = this._state.model;
+                // TODO: Tweak for multiple graphs
+                const { selectedVariables } = this._state.model.graphs["graph1"];
 
                 const worksheet = WodinModelOutputDownload._generateModelledOutput(
                     selectedVariables,

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -179,15 +179,15 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
     // TODO: tweak for multiple graphs
     if (
         model.odinModelResponse?.metadata?.variables &&
-        !model.graphs["graph1"].selectedVariables.length &&
-        !model.graphs["graph1"].unselectedVariables?.length
+        !model.graphs["Graph 1"].selectedVariables.length &&
+        !model.graphs["Graph 1"].unselectedVariables?.length
     ) {
         /* eslint-disable no-param-reassign */
         const selectedVariables = [...(model.odinModelResponse?.metadata?.variables || [])];
         const unselectedVariables: string[] = [];
 
         targetState.model.graphs = {
-            graph1: {
+            "Graph 1": {
                 selectedVariables,
                 unselectedVariables
             }

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -35,8 +35,9 @@ function serialiseModel(model: ModelState): SerialisedModelState {
         hasOdin: !!model.odin,
         odinModelCodeError: model.odinModelCodeError,
         paletteModel: model.paletteModel,
-        selectedVariables: model.selectedVariables,
-        unselectedVariables: model.unselectedVariables
+        //selectedVariables: model.selectedVariables,
+        //unselectedVariables: model.unselectedVariables
+        graphs: model.graphs
     };
 }
 
@@ -175,13 +176,21 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
 
     // Initialise selected variables if required
     const { model } = targetState;
+    // TODO: tweak for multiple graphs
     if (
         model.odinModelResponse?.metadata?.variables &&
-        !model.selectedVariables?.length &&
-        !model.unselectedVariables?.length
+        !model.graphs["graph1"].selectedVariables.length &&
+        !model.graphs["graph1"].unselectedVariables?.length
     ) {
         /* eslint-disable no-param-reassign */
-        targetState.model.selectedVariables = [...model.odinModelResponse.metadata.variables];
-        targetState.model.unselectedVariables = [];
+        const selectedVariables = [...(model.odinModelResponse?.metadata?.variables || [])];
+        const unselectedVariables: string[] = [];
+
+        targetState.model.graphs = {
+            graph1: {
+                selectedVariables,
+                unselectedVariables
+            }
+        };
     }
 };

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -24,7 +24,7 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     const { commit, state, rootState, getters } = context;
     const modelResponse = rootState.model.odinModelResponse;
     // TODO: tweak for multiple graphs
-    const modelVariables = modelResponse?.valid ? rootState.model.graphs["graph1"].selectedVariables : [];
+    const modelVariables = modelResponse?.valid ? rootState.model.graphs["Graph 1"].selectedVariables : [];
     const dataColumns = getters.nonTimeColumns;
     let newLinks = {};
     if (dataColumns) {

--- a/app/static/src/app/store/fitData/actions.ts
+++ b/app/static/src/app/store/fitData/actions.ts
@@ -23,7 +23,8 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     // Empty string means no link
     const { commit, state, rootState, getters } = context;
     const modelResponse = rootState.model.odinModelResponse;
-    const modelVariables = modelResponse?.valid ? rootState.model.selectedVariables : [];
+    // TODO: tweak for multiple graphs
+    const modelVariables = modelResponse?.valid ? rootState.model.graphs["graph1"].selectedVariables : [];
     const dataColumns = getters.nonTimeColumns;
     let newLinks = {};
     if (dataColumns) {

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -70,8 +70,8 @@ const compileModelAndUpdateStore = (context: ActionContext<ModelState, AppState>
 
         // Retain variable selections. Newly added variables will be selected by default
         // TODO: tweak for multiple graphs
-        const select = variables.filter((s) => !state.graphs["graph1"].unselectedVariables.includes(s));
-        commit(ModelMutation.SetSelectedVariables, { key: "graph1", selectedVariables: select });
+        const select = variables.filter((s) => !state.graphs["Graph 1"].unselectedVariables.includes(s));
+        commit(ModelMutation.SetSelectedVariables, { key: "Graph 1", selectedVariables: select });
 
         if (state.compileRequired) {
             commit(ModelMutation.SetCompileRequired, false);

--- a/app/static/src/app/store/model/actions.ts
+++ b/app/static/src/app/store/model/actions.ts
@@ -69,8 +69,9 @@ const compileModelAndUpdateStore = (context: ActionContext<ModelState, AppState>
         commit(ModelMutation.SetPaletteModel, paletteModel(variables));
 
         // Retain variable selections. Newly added variables will be selected by default
-        const select = variables.filter((s) => !state.unselectedVariables.includes(s));
-        commit(ModelMutation.SetSelectedVariables, select);
+        // TODO: tweak for multiple graphs
+        const select = variables.filter((s) => !state.graphs["graph1"].unselectedVariables.includes(s));
+        commit(ModelMutation.SetSelectedVariables, { key: "graph1", selectedVariables: select });
 
         if (state.compileRequired) {
             commit(ModelMutation.SetCompileRequired, false);
@@ -147,7 +148,7 @@ export const actions: ActionTree<ModelState, AppState> = {
         context.dispatch(`run/${RunAction.RunModel}`, null, { root: true });
     },
 
-    UpdateSelectedVariables(context, payload: string[]) {
+    UpdateSelectedVariables(context, payload: { key: string; selectedVariables: string[] }) {
         const { commit, dispatch, rootState } = context;
         commit(ModelMutation.SetSelectedVariables, payload);
         if (rootState.appType === AppType.Fit) {

--- a/app/static/src/app/store/model/getters.ts
+++ b/app/static/src/app/store/model/getters.ts
@@ -3,7 +3,8 @@ import { ModelState } from "./state";
 import { AppState, AppType } from "../appState/state";
 
 export enum ModelGetter {
-    hasRunner = "hasRunner"
+    hasRunner = "hasRunner",
+    unselectedVariables = "unselectedVariables" //variables which are unselected in any graph
 }
 
 export interface ModelGetters {
@@ -13,5 +14,9 @@ export interface ModelGetters {
 export const getters: ModelGetters & GetterTree<ModelState, AppState> = {
     [ModelGetter.hasRunner]: (state: ModelState, _: ModelGetters, rootState: AppState): boolean => {
         return rootState.appType === AppType.Stochastic ? !!state.odinRunnerDiscrete : !!state.odinRunnerOde;
+    },
+    [ModelGetter.unselectedVariables]: (state: ModelState): string[] => {
+        const selectedInAny = Object.values(state.graphs).flatMap((v) => v.selectedVariables);
+        return state.odinModelResponse?.metadata?.variables.filter((s) => !selectedInAny.includes(s)) || [];
     }
 };

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -14,7 +14,7 @@ export const defaultState: ModelState = {
     //selectedVariables: [],
     //unselectedVariables: []
     graphs: {
-        graph1: {
+        "Graph 1": {
             selectedVariables: [],
             unselectedVariables: []
         }

--- a/app/static/src/app/store/model/model.ts
+++ b/app/static/src/app/store/model/model.ts
@@ -11,8 +11,14 @@ export const defaultState: ModelState = {
     odin: null,
     paletteModel: null,
     odinModelCodeError: null,
-    selectedVariables: [],
-    unselectedVariables: []
+    //selectedVariables: [],
+    //unselectedVariables: []
+    graphs: {
+        graph1: {
+            selectedVariables: [],
+            unselectedVariables: []
+        }
+    }
 };
 
 export const model = {

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -44,6 +44,12 @@ export const mutations: MutationTree<ModelState> = {
     },
 
     [ModelMutation.SetSelectedVariables](state: ModelState, payload: { key: string; selectedVariables: string[] }) {
+        if (!Object.keys(state.graphs).includes(payload.key)) {
+            state.graphs[payload.key] = {
+                selectedVariables: [],
+                unselectedVariables: []
+            };
+        }
         state.graphs[payload.key].selectedVariables = payload.selectedVariables;
         // Maintain unselected variables too, so we know which variables had been explicitly unselected when model
         // updates

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -11,7 +11,8 @@ export enum ModelMutation {
     SetOdin = "SetOdin",
     SetCompileRequired = "SetCompileRequired",
     SetPaletteModel = "SetPaletteModel",
-    SetSelectedVariables = "SetSelectedVariables"
+    SetSelectedVariables = "SetSelectedVariables",
+    DeleteGraph = "DeleteGraph"
 }
 
 export const mutations: MutationTree<ModelState> = {
@@ -55,5 +56,10 @@ export const mutations: MutationTree<ModelState> = {
         // updates
         state.graphs[payload.key].unselectedVariables =
             state.odinModelResponse?.metadata?.variables.filter((s) => !payload.selectedVariables.includes(s)) || [];
+    },
+
+    [ModelMutation.DeleteGraph](state: ModelState, payload: string) {
+        console.log(`deleting ${payload}`);
+        delete state.graphs[payload];
     }
 };

--- a/app/static/src/app/store/model/mutations.ts
+++ b/app/static/src/app/store/model/mutations.ts
@@ -43,11 +43,11 @@ export const mutations: MutationTree<ModelState> = {
         state.paletteModel = payload;
     },
 
-    [ModelMutation.SetSelectedVariables](state: ModelState, payload: string[]) {
-        state.selectedVariables = payload;
+    [ModelMutation.SetSelectedVariables](state: ModelState, payload: { key: string; selectedVariables: string[] }) {
+        state.graphs[payload.key].selectedVariables = payload.selectedVariables;
         // Maintain unselected variables too, so we know which variables had been explicitly unselected when model
         // updates
-        state.unselectedVariables =
-            state.odinModelResponse?.metadata?.variables.filter((s) => !payload.includes(s)) || [];
+        state.graphs[payload.key].unselectedVariables =
+            state.odinModelResponse?.metadata?.variables.filter((s) => !payload.selectedVariables.includes(s)) || [];
     }
 };

--- a/app/static/src/app/store/model/state.ts
+++ b/app/static/src/app/store/model/state.ts
@@ -1,5 +1,11 @@
 import { Odin, OdinModelResponse, OdinRunnerDiscrete, OdinRunnerOde, WodinError } from "../../types/responseTypes";
 import type { Palette } from "../../palette";
+import { Dict } from "../../types/utilTypes";
+
+export interface GraphConfig {
+    selectedVariables: string[];
+    unselectedVariables: string[];
+}
 
 export interface ModelState {
     compileRequired: boolean;
@@ -13,6 +19,8 @@ export interface ModelState {
     paletteModel: null | Palette;
     // TODO: rename to simply error
     odinModelCodeError: WodinError | null;
-    selectedVariables: string[];
-    unselectedVariables: string[]; // We keep track of unselected variables too so we can retain on model update
+    //selectedVariables: string[];
+    //unselectedVariables: string[]; // We keep track of unselected variables too so we can retain on model update
+    // TODO: This is just for POC - this may get moved into another module
+    graphs: Dict<GraphConfig>;
 }

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -13,6 +13,7 @@ import { FitDataState } from "../store/fitData/state";
 import { Palette } from "../palette";
 import { GraphSettingsState } from "../store/graphSettings/state";
 import { Dict } from "./utilTypes";
+import { GraphConfig } from "../store/model/state";
 
 export interface SerialisedRunResult {
     inputs: OdinRunInputs | OdinFitInputs;
@@ -26,8 +27,9 @@ export interface SerialisedModelState {
     hasOdin: boolean;
     odinModelCodeError: WodinError | null;
     paletteModel: Palette | null;
-    selectedVariables: string[];
-    unselectedVariables: string[];
+    //selectedVariables: string[];
+    //unselectedVariables: string[];
+    graphs: Dict<GraphConfig>;
 }
 
 export interface SerialisedRunState {


### PR DESCRIPTION
TODO:
- desaturate hidden variables
- put x button on duplicates (can still drag)
- show drop zones on start drag
- can delete all graphs apart from the final one (NB reassigning ids in this case!)
- pulse view of any duplicates when hide another instance
- hide Time axis label except for final graph

Maybe:
- make add to new graph available as additional drop zone
- delayed tooltips with actions
- make graph height variable
- include extra graphs in Sensitivity
- eye icon in graph label header to hide or show graph

In another branch:
- ensure new model variables are added to Graph1 only (I think this already happens)
- cog icon in graph label header for changing settings
- harmonise Time axes and legend width in plotly (can link plots?). Show or hide legend globally (ensure legend always appear on downloaded plots). 