### PR TITLE
mrc-5484 Link x-axes across multiple graphs

### DIFF
--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -99,16 +99,24 @@ export default defineComponent({
             return result;
         };
 
-        const preserveYAxisRange = (layout: Partial<Layout>) => {
+        const preserveYAxisRange = (layout: Partial<Layout>): Partial<Layout> => {
           // When updating plot view in response to some data change or event, retain Y axis range in layout
           // either from the locked range, or from the last range user zoomed to.
           // (Locked range will survive re-mount and tab change, the last range from zoom will not)
+          const result = {...layout};
           if (lockYAxis.value) {
-            layout.yaxis!.range = [...yAxisRange.value];
-            layout.yaxis!.autorange = false;
+            result.yaxis = {
+              ...result.yaxis,
+              range: [...yAxisRange.value],
+              autorange: false
+            };
           } else if (lastYAxisFromZoom.value) {
-            layout.yaxis = {...layout.yaxis, ...lastYAxisFromZoom.value}
+            result.yaxis = {
+              ...result.yaxis,
+              ...lastYAxisFromZoom.value
+            }
           }
+          return result;
         };
 
         const updateXAxisRange = async (xAxis: Partial<LayoutAxis>) => {
@@ -119,8 +127,7 @@ export default defineComponent({
                 data = props.plotData(xAxis.range![0], xAxis.range![1], nPoints);
             }
 
-            const layout = defaultLayout();
-            preserveYAxisRange(layout);
+            const layout = preserveYAxisRange(defaultLayout());
 
             const el = plot.value as HTMLElement;
             await react(el, data, layout, config);
@@ -164,9 +171,9 @@ export default defineComponent({
 
                 if (hasPlotData.value) {
                     const el = plot.value as unknown;
-                    const layout = defaultLayout();
+                    let layout = defaultLayout();
                     if (!toggleLogScale) {
-                      preserveYAxisRange(layout);
+                      layout = preserveYAxisRange(layout);
                     }
                     const configCopy = { ...config } as Partial<Config>;
 

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -93,11 +93,15 @@ export default defineComponent({
 
         const defaultLayout = (): Partial<Layout> => {
             // Get generic layout, which will be modifed dynamically as required
-            return {
-                margin: {...margin, r: legendWidth.value},
+            const result =  {
+                margin: {...margin},
                 xaxis: { title: "Time" },
                 yaxis: { type: yAxisType.value }
             };
+            if (legendWidth.value) {
+              result.margin.r = legendWidth.value;
+            }
+            return result;
         };
 
         const preserveYAxisRange = (layout: Partial<Layout>) => {
@@ -135,7 +139,7 @@ export default defineComponent({
         }
 
         const relayout = async (event: PlotRelayoutEvent) => {
-            if (event["xaxis.autorange"] || event["xaxis.range[0]"]) {
+            if (event["xaxis.autorange"] || (event["xaxis.range[0]"] && event["xaxis.range[1]"])) {
                 const xAxis = axisFromEvent(event, "x");
                 if (props.hasLinkedXAxis) {
                   // Emit the x axis change, and handle update when options are propagated through prop
@@ -146,7 +150,7 @@ export default defineComponent({
                 }
             }
 
-          if (event["yaxis.autorange"] || event["yaxis.range[0]"]) {
+          if (event["yaxis.autorange"] || (event["yaxis.range[0]"] && event["yaxis.range[1]"])) {
               lastYAxisFromZoom.value = axisFromEvent(event, "y");
             }
         };

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -108,7 +108,6 @@ export default defineComponent({
 
             //const plotLayout = (plot.value as any).layout;
             //alert("updating xaxis with " + JSON.stringify(plotLayout.yaxis))
-            //TODO: comment on unsetting autorange!
             const layout: Partial<Layout> = {
                 margin: {...margin, r: legendWidth.value},
                 uirevision: "true",
@@ -148,36 +147,35 @@ export default defineComponent({
         };
 
         const relayout = async (event: PlotRelayoutEvent) => {
-            let xAxisOptions;
-            if (event["xaxis.autorange"] === true) {
-                xAxisOptions = { autorange: true };
-            } else {
-                const t0 = event["xaxis.range[0]"];
-                const t1 = event["xaxis.range[1]"];
-                if (t0 === undefined || t1 === undefined) {
-                    return;
-                }
-                xAxisOptions = {
+            //alert("RELAYOUT! " + JSON.stringify(event))
+            if (event["xaxis.autorange"] || event["xaxis.range[0]"]) {
+                let xAxisOptions;
+                if (event["xaxis.autorange"] === true) {
+                  xAxisOptions = {autorange: true};
+                } else {
+                  const t0 = event["xaxis.range[0]"];
+                  const t1 = event["xaxis.range[1]"];
+                  xAxisOptions = {
                     autorange: false,
                     min: t0,
                     max: t1
-                };
+                  };
+                }
+                if (props.hasLinkedXAxis) {
+                  // Emit the x axis change, and handle update when options are propagated through prop
+                  emit("updateXAxis", xAxisOptions);
+                } else {
+                  // No linked x axis, so this plot can just update itself directly
+                  await updateXAxisRange(xAxisOptions);
+                }
             }
 
-            lastYAxisOptionsFromZoom.value = {
-              autorange: event["yaxis.autorange"] || false,
-              min: event["yaxis.range[0]"],
-              max: event["yaxis.range[1]"]
-            };
-            //alert("saving last y axis: " + JSON.stringify(lastYAxisOptionsFromZoom.value))
-
-            // TODO: might not be an x axis change...
-            if (props.hasLinkedXAxis) {
-                // Emit the x axis change, and handle update when options are propagated through prop
-                emit("updateXAxis", xAxisOptions);
-            } else {
-                // No linked x axis, so this plot can just update itself directly
-                await updateXAxisRange(xAxisOptions);
+          if (event["yaxis.autorange"] || event["yaxis.range[0]"]) {
+              lastYAxisOptionsFromZoom.value = {
+                autorange: event["yaxis.autorange"] || false,
+                min: event["yaxis.range[0]"],
+                max: event["yaxis.range[1]"]
+              };
             }
         };
 

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -46,11 +46,6 @@ export default defineComponent({
             required: false,
             default: true
         },
-        hasLinkedXAxis: {
-            type: Boolean,
-            required: false,
-            default: false
-        },
         linkedXAxis: {
             type: Object as PropType<Partial<LayoutAxis> | null>,
             required: false,
@@ -141,7 +136,7 @@ export default defineComponent({
         const relayout = async (event: PlotRelayoutEvent) => {
             if (event["xaxis.autorange"] || (event["xaxis.range[0]"] && event["xaxis.range[1]"])) {
                 const xAxis = axisFromEvent(event, "x");
-                if (props.hasLinkedXAxis) {
+                if (props.linkedXAxis) {
                   // Emit the x axis change, and handle update when options are propagated through prop
                   emit("updateXAxis", xAxis);
                 } else {

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -10,15 +10,24 @@
 </template>
 
 <script lang="ts">
-import {computed, defineComponent, ref, watch, onMounted, onUnmounted, PropType, Ref} from "vue";
+import { computed, defineComponent, ref, watch, onMounted, onUnmounted, PropType, Ref } from "vue";
 import { useStore } from "vuex";
 import { EventEmitter } from "events";
-import {newPlot, react, PlotRelayoutEvent, Plots, AxisType, Layout, Config, LayoutAxis} from "plotly.js-basic-dist-min";
+import {
+    newPlot,
+    react,
+    PlotRelayoutEvent,
+    Plots,
+    AxisType,
+    Layout,
+    Config,
+    LayoutAxis
+} from "plotly.js-basic-dist-min";
 import { WodinPlotData, fadePlotStyle, margin, config } from "../plot";
 import WodinPlotDataSummary from "./WodinPlotDataSummary.vue";
 import { GraphsMutation } from "../store/graphs/mutations";
 import { YAxisRange } from "../store/graphs/state";
-import {GraphsGetter} from "../store/graphs/getters";
+import { GraphsGetter } from "../store/graphs/getters";
 
 export default defineComponent({
     name: "WodinPlot",
@@ -88,35 +97,35 @@ export default defineComponent({
 
         const defaultLayout = (): Partial<Layout> => {
             // Get generic layout, which will be modifed dynamically as required
-            const result =  {
-                margin: {...margin},
+            const result = {
+                margin: { ...margin },
                 xaxis: { title: "Time" },
                 yaxis: { type: yAxisType.value }
             };
             if (legendWidth.value) {
-              result.margin.r = legendWidth.value;
+                result.margin.r = legendWidth.value;
             }
             return result;
         };
 
         const preserveYAxisRange = (layout: Partial<Layout>): Partial<Layout> => {
-          // When updating plot view in response to some data change or event, retain Y axis range in layout
-          // either from the locked range, or from the last range user zoomed to.
-          // (Locked range will survive re-mount and tab change, the last range from zoom will not)
-          const result = {...layout};
-          if (lockYAxis.value) {
-            result.yaxis = {
-              ...result.yaxis,
-              range: [...yAxisRange.value],
-              autorange: false
-            };
-          } else if (lastYAxisFromZoom.value) {
-            result.yaxis = {
-              ...result.yaxis,
-              ...lastYAxisFromZoom.value
+            // When updating plot view in response to some data change or event, retain Y axis range in layout
+            // either from the locked range, or from the last range user zoomed to.
+            // (Locked range will survive re-mount and tab change, the last range from zoom will not)
+            const result = { ...layout };
+            if (lockYAxis.value) {
+                result.yaxis = {
+                    ...result.yaxis,
+                    range: [...yAxisRange.value],
+                    autorange: false
+                };
+            } else if (lastYAxisFromZoom.value) {
+                result.yaxis = {
+                    ...result.yaxis,
+                    ...lastYAxisFromZoom.value
+                };
             }
-          }
-          return result;
+            return result;
         };
 
         const updateXAxisRange = async (xAxis: Partial<LayoutAxis>) => {
@@ -134,26 +143,26 @@ export default defineComponent({
         };
 
         const axisFromEvent = (event: PlotRelayoutEvent, axisLetter: "x" | "y"): Partial<LayoutAxis> => {
-         return {
-            "autorange": event[`${axisLetter}axis.autorange`] || false,
-            "range": [event[`${axisLetter}axis.range[0]`], event[`${axisLetter}axis.range[1]`]]
-          };
-        }
+            return {
+                autorange: event[`${axisLetter}axis.autorange`] || false,
+                range: [event[`${axisLetter}axis.range[0]`], event[`${axisLetter}axis.range[1]`]]
+            };
+        };
 
         const relayout = async (event: PlotRelayoutEvent) => {
             if (event["xaxis.autorange"] || (event["xaxis.range[0]"] && event["xaxis.range[1]"])) {
                 const xAxis = axisFromEvent(event, "x");
                 if (props.linkedXAxis) {
-                  // Emit the x axis change, and handle update when options are propagated through prop
-                  emit("updateXAxis", xAxis);
+                    // Emit the x axis change, and handle update when options are propagated through prop
+                    emit("updateXAxis", xAxis);
                 } else {
-                  // No linked x axis, so this plot can just update itself directly
-                  await updateXAxisRange(xAxis);
+                    // No linked x axis, so this plot can just update itself directly
+                    await updateXAxisRange(xAxis);
                 }
             }
 
-          if (event["yaxis.autorange"] || (event["yaxis.range[0]"] && event["yaxis.range[1]"])) {
-              lastYAxisFromZoom.value = axisFromEvent(event, "y");
+            if (event["yaxis.autorange"] || (event["yaxis.range[0]"] && event["yaxis.range[1]"])) {
+                lastYAxisFromZoom.value = axisFromEvent(event, "y");
             }
         };
 
@@ -173,15 +182,15 @@ export default defineComponent({
                     const el = plot.value as unknown;
                     let layout = defaultLayout();
                     if (!toggleLogScale) {
-                      layout = preserveYAxisRange(layout);
+                        layout = preserveYAxisRange(layout);
                     }
                     const configCopy = { ...config } as Partial<Config>;
 
                     let data;
                     if (!props.linkedXAxis || props.linkedXAxis.autorange) {
-                      data = baseData.value;
+                        data = baseData.value;
                     } else {
-                      data = props.plotData(props.linkedXAxis.range![0], props.linkedXAxis.range![1], nPoints);
+                        data = props.plotData(props.linkedXAxis.range![0], props.linkedXAxis.range![1], nPoints);
                     }
 
                     newPlot(el as HTMLElement, data, layout, configCopy);
@@ -214,11 +223,14 @@ export default defineComponent({
                 drawPlot(true);
             }
         });
-        watch(() => props.linkedXAxis, () => {
-          if (props.linkedXAxis) {
-            updateXAxisRange(props.linkedXAxis);
-          }
-        });
+        watch(
+            () => props.linkedXAxis,
+            () => {
+                if (props.linkedXAxis) {
+                    updateXAxisRange(props.linkedXAxis);
+                }
+            }
+        );
 
         onUnmounted(() => {
             if (resizeObserver) {

--- a/app/static/src/app/components/WodinPlot.vue
+++ b/app/static/src/app/components/WodinPlot.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="wodin-plot-container" :style="plotStyle">
+        <div>{{JSON.stringify(linkedXAxisOptions)}}</div>
         <div class="plot" ref="plot" id="plot"></div>
         <div v-if="!hasPlotData" class="plot-placeholder">
             {{ placeholderMessage }}
@@ -10,7 +11,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, watch, onMounted, onUnmounted, PropType } from "vue";
+import {computed, defineComponent, ref, watch, onMounted, onUnmounted, PropType, Ref} from "vue";
 import { useStore } from "vuex";
 import { EventEmitter } from "events";
 import { newPlot, react, PlotRelayoutEvent, Plots, AxisType, Layout, Config } from "plotly.js-basic-dist-min";
@@ -20,7 +21,7 @@ import { GraphsMutation } from "../store/graphs/mutations";
 import { YAxisRange } from "../store/graphs/state";
 import {GraphsGetter} from "../store/graphs/getters";
 
-export interface XAxisOptions {
+export interface AxisOptions {
     autorange: boolean;
     min?: number;
     max?: number;
@@ -58,7 +59,7 @@ export default defineComponent({
             default: false
         },
         linkedXAxisOptions: {
-            type: Object as PropType<XAxisOptions | null>,
+            type: Object as PropType<AxisOptions | null>,
             required: false,
             default: null
         }
@@ -82,16 +83,21 @@ export default defineComponent({
         const yAxisRange = computed(() => store.state.graphs.settings.yAxisRange as YAxisRange);
         const legendWidth = computed(() => store.getters[`graphs/${GraphsGetter.legendWidth}`]);
 
-        const updateAxesRange = () => {
+        const lastYAxisOptionsFromZoom: Ref<AxisOptions | null> = ref(null);
+
+        const commitYAxisRange = () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const plotLayout = (plot.value as any).layout;
             const yRange = plotLayout.yaxis?.range;
             if (plotLayout) {
+                // TODO: We do not yet have per-graph settings, so YAxisRange committed here and used when user chooses
+                // to lock range will be overwritten by each graph, and will
                 store.commit(`graphs/${GraphsMutation.SetYAxisRange}`, yRange);
             }
         };
 
-        const updateXAxisRange = async (xAxisOptions: XAxisOptions) => {
+        const updateXAxisRange = async (xAxisOptions: AxisOptions) => {
+
             let data;
             if (xAxisOptions.autorange) {
                 data = baseData.value;
@@ -99,6 +105,10 @@ export default defineComponent({
                 data = props.plotData(xAxisOptions.min!, xAxisOptions.max!, nPoints);
             }
             console.log(`Legend width is ${legendWidth.value}`);
+
+            //const plotLayout = (plot.value as any).layout;
+            //alert("updating xaxis with " + JSON.stringify(plotLayout.yaxis))
+            //TODO: comment on unsetting autorange!
             const layout: Partial<Layout> = {
                 margin: {...margin, r: legendWidth.value},
                 uirevision: "true",
@@ -106,8 +116,35 @@ export default defineComponent({
                 yaxis: { autorange: true, type: yAxisType.value }
             };
 
+            // mrc-5485 - removed from above layout:
+            // ,
+            //  yaxis: { autorange: true, type: yAxisType.value }
+
+            // mrc-5484
+            /*if (lockYAxis.value) {
+                layout.yaxis!.range = [...yAxisRange.value];
+                layout.yaxis!.autorange = false;
+            } else if (lastYAxisOptionsFromZoom.value) {
+                layout.yaxis!.autorange = lastYAxisOptionsFromZoom.value.autorange;
+                layout.yaxis!.range = [lastYAxisOptionsFromZoom.value.min, lastYAxisOptionsFromZoom.value.max];
+            }*/
+            retainYAxisRange(layout);
+
             const el = plot.value as HTMLElement;
             await react(el, data, layout, config);
+        };
+
+        const retainYAxisRange = (layout: Partial<Layout>) => {
+            // When updating plot view in response to some data change or event, retain Y axis range in layout
+            // either from the locked range, or from the last range user zoomed to.
+            // (Locked range will survive re-mount and tab change, the last range from zoom will not)
+            if (lockYAxis.value) {
+              layout.yaxis!.range = [...yAxisRange.value];
+              layout.yaxis!.autorange = false;
+            } else if (lastYAxisOptionsFromZoom.value) {
+              layout.yaxis!.autorange = lastYAxisOptionsFromZoom.value.autorange;
+              layout.yaxis!.range = [lastYAxisOptionsFromZoom.value.min, lastYAxisOptionsFromZoom.value.max];
+            }
         };
 
         const relayout = async (event: PlotRelayoutEvent) => {
@@ -127,6 +164,14 @@ export default defineComponent({
                 };
             }
 
+            lastYAxisOptionsFromZoom.value = {
+              autorange: event["yaxis.autorange"] || false,
+              min: event["yaxis.range[0]"],
+              max: event["yaxis.range[1]"]
+            };
+            //alert("saving last y axis: " + JSON.stringify(lastYAxisOptionsFromZoom.value))
+
+            // TODO: might not be an x axis change...
             if (props.hasLinkedXAxis) {
                 // Emit the x axis change, and handle update when options are propagated through prop
                 emit("updateXAxis", xAxisOptions);
@@ -144,7 +189,21 @@ export default defineComponent({
 
         let resizeObserver: null | ResizeObserver = null;
 
+        /*const getLayout = (toggleLogScale: boolean) => {
+            return {
+              margin: {
+                  ...margin,
+                  r: legendWidth.value
+              },
+              yaxis: {
+                type: yAxisType.value
+              },
+              xaxis: { title: "Time" }
+            };
+        };*/
+
         const drawPlot = (toggleLogScale = false) => {
+            console.log("redrawing..");
             if (props.redrawWatches.length) {
                 baseData.value = props.plotData(startTime, props.endTime, nPoints);
 
@@ -162,15 +221,32 @@ export default defineComponent({
 
                     const configCopy = { ...config } as Partial<Config>;
 
-                    if (lockYAxis.value && !toggleLogScale) {
+                    /*if (lockYAxis.value && !toggleLogScale) {
+                        // We're configured to lock the y axis and we're not in the process of toggling the
+                        // log scale, so lock the y axis range
                         layout.yaxis!.range = [...yAxisRange.value];
                         layout.yaxis!.autorange = false;
+                    }*/
+                    if (!toggleLogScale) {
+                      retainYAxisRange(layout);
                     }
 
-                    newPlot(el as HTMLElement, baseData.value, layout, configCopy);
+                    // mrc-5484 - set data appropriate to xAxisOptions
+                    let data;
+                    if (!props.linkedXAxisOptions || props.linkedXAxisOptions.autorange) {
+                      data = baseData.value;
+                    } else {
+                      data = props.plotData(props.linkedXAxisOptions.min!, props.linkedXAxisOptions.max!, nPoints);
+                    }
 
+                    //newPlot(el as HTMLElement, baseData.value, layout, configCopy);
+                    newPlot(el as HTMLElement, data, layout, configCopy);
+
+                    // We're not locking the YAxis OR we are toggling the log scale (overriding any locked range)
+                    // so commit whatever Y axis range the plot auto-calculates, so we can lock to that in future
+                    // if the user chooses
                     if (!lockYAxis.value || toggleLogScale) {
-                        updateAxesRange();
+                        commitYAxisRange();
                     }
 
                     if (props.recalculateOnRelayout) {
@@ -186,11 +262,13 @@ export default defineComponent({
 
         watch([() => props.redrawWatches, lockYAxis], () => {
             if (plotStyle.value !== fadePlotStyle) {
+                //alert("drawing plot from redrawWatches or lockYAxis")
                 drawPlot();
             }
         });
         watch(yAxisType, () => {
             if (plotStyle.value !== fadePlotStyle) {
+                //alert("drawing plot from yAxisType")
                 drawPlot(true);
             }
         });

--- a/app/static/src/app/components/graphConfig/GraphConfigs.vue
+++ b/app/static/src/app/components/graphConfig/GraphConfigs.vue
@@ -4,9 +4,9 @@
         to move them to.
     </div>
     <graph-config
-        v-for="(_, index) in graphConfigs"
+        v-for="(config, index) in graphConfigs"
         :graph-index="index"
-        :key="index"
+        :key="config.id"
         :dragging="draggingVariable"
         @setDragging="setDraggingVariable"
     ></graph-config>

--- a/app/static/src/app/components/graphConfig/GraphConfigs.vue
+++ b/app/static/src/app/components/graphConfig/GraphConfigs.vue
@@ -4,9 +4,9 @@
         to move them to.
     </div>
     <graph-config
-        v-for="(config, index) in graphConfigs"
+        v-for="(_, index) in graphConfigs"
         :graph-index="index"
-        :key="config.id"
+        :key="index"
         :dragging="draggingVariable"
         @setDragging="setDraggingVariable"
     ></graph-config>

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -13,9 +13,9 @@
 </template>
 
 <script lang="ts">
-import {computed, defineComponent, PropType} from "vue";
+import { computed, defineComponent, PropType } from "vue";
 import { useStore } from "vuex";
-import {LayoutAxis, PlotData} from "plotly.js-basic-dist-min";
+import { LayoutAxis, PlotData } from "plotly.js-basic-dist-min";
 import { FitDataGetter } from "../../store/fitData/getters";
 import { odinToPlotly, allFitDataToPlotly, WodinPlotData, filterSeriesSet } from "../../plot";
 import WodinPlot from "../WodinPlot.vue";
@@ -34,15 +34,15 @@ export default defineComponent({
             default: 0
         },
         linkedXAxis: {
-          type: Object as PropType<Partial<LayoutAxis> | null>,
-          required: true
+            type: Object as PropType<Partial<LayoutAxis> | null>,
+            required: true
         }
     },
     components: {
         WodinPlot
     },
     emits: ["updateXAxis"],
-    setup(props, {emit}) {
+    setup(props, { emit }) {
         const store = useStore();
 
         const solution = computed(() => store.state.run.resultOde?.solution);
@@ -119,8 +119,8 @@ export default defineComponent({
         };
 
         const updateXAxis = (options: Partial<LayoutAxis>) => {
-          emit("updateXAxis", options);
-        }
+            emit("updateXAxis", options);
+        };
 
         return {
             placeholderMessage,

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -12,8 +12,8 @@
     </wodin-plot>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, PropType } from "vue";
+<script setup lang="ts">
+import { computed, defineEmits, defineProps, PropType } from "vue";
 import { useStore } from "vuex";
 import { LayoutAxis, PlotData } from "plotly.js-basic-dist-min";
 import { FitDataGetter } from "../../store/fitData/getters";
@@ -25,114 +25,92 @@ import { Dict } from "../../types/utilTypes";
 import { runPlaceholderMessage } from "../../utils";
 import { ParameterSet } from "../../store/run/state";
 
-export default defineComponent({
-    name: "RunPlot",
-    props: {
-        fadePlot: Boolean,
-        graphIndex: {
-            type: Number,
-            default: 0
-        },
-        linkedXAxis: {
-            type: Object as PropType<Partial<LayoutAxis> | null>,
-            required: true
-        }
-    },
-    components: {
-        WodinPlot
-    },
-    emits: ["updateXAxis"],
-    setup(props, { emit }) {
-        const store = useStore();
-
-        const solution = computed(() => store.state.run.resultOde?.solution);
-        const visibleParameterSetNames = computed(() => store.getters[`run/${RunGetter.visibleParameterSetNames}`]);
-        const parameterSets = computed(() => store.state.run.parameterSets as ParameterSet[]);
-        const displayNames = computed(() => {
-            return parameterSets.value.map((paramSet) => paramSet.displayName);
-        });
-
-        const parameterSetSolutions = computed(() => {
-            const result = {} as Dict<OdinSolution>;
-            Object.keys(store.state.run.parameterSetResults).forEach((name) => {
-                const sln = store.state.run.parameterSetResults[name].solution;
-                if (sln && visibleParameterSetNames.value.includes(name)) {
-                    result[name] = sln;
-                }
-            });
-            return result;
-        });
-
-        const endTime = computed(() => store.state.run.endTime);
-
-        const palette = computed(() => store.state.model.paletteModel);
-
-        const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
-
-        const selectedVariables = computed(() => store.state.graphs.config[props.graphIndex].selectedVariables);
-        const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
-
-        const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
-            const options = {
-                mode: "grid",
-                tStart: start,
-                tEnd: end,
-                nPoints: points
-            };
-            const result = solution.value && solution.value(options);
-            if (!result) {
-                return [];
-            }
-
-            // 1. Current parameter values
-            const plotOptions = { showLegend: true, includeLegendGroup: true };
-            const allData = [
-                ...odinToPlotly(filterSeriesSet(result, selectedVariables.value), palette.value, plotOptions),
-                ...allFitDataToPlotly(allFitData.value, palette.value, start, end)
-            ];
-
-            // 2. Parameter sets
-            const lineStylesForParamSets = computed(() => store.getters[`run/${RunGetter.lineStylesForParameterSets}`]);
-
-            const updatePlotTraceNameWithParameterSetName = (plotTrace: Partial<PlotData>, setName: string) => {
-                // eslint-disable-next-line no-param-reassign
-                plotTrace.name = `${plotTrace.name} (${setName})`;
-            };
-
-            Object.keys(parameterSetSolutions.value).forEach((name) => {
-                const paramSetSln = parameterSetSolutions.value[name];
-                const paramSetResult = paramSetSln!(options as Times);
-
-                const dash = lineStylesForParamSets.value[name];
-                if (paramSetResult) {
-                    const filteredSetData = filterSeriesSet(paramSetResult, selectedVariables.value);
-                    const paramSetOptions = { dash, showLegend: false, includeLegendGroup: true };
-                    const plotData = odinToPlotly(filteredSetData, palette.value, paramSetOptions);
-                    const currentParamSet = parameterSets.value.find((paramSet) => paramSet.name === name);
-                    plotData.forEach((plotTrace) => {
-                        updatePlotTraceNameWithParameterSetName(plotTrace, currentParamSet!.displayName);
-                    });
-                    allData.push(...plotData);
-                }
-            });
-            return allData;
-        };
-
-        const updateXAxis = (options: Partial<LayoutAxis>) => {
-            emit("updateXAxis", options);
-        };
-
-        return {
-            placeholderMessage,
-            endTime,
-            solution,
-            allFitData,
-            allPlotData,
-            selectedVariables,
-            parameterSetSolutions,
-            displayNames,
-            updateXAxis
-        };
-    }
+const props = defineProps({
+    fadePlot: Boolean,
+    graphIndex: { type: Number, default: 0 },
+    linkedXAxis: { type: Object as PropType<Partial<LayoutAxis> | null>, required: true }
 });
+
+const emit = defineEmits<{
+    (e: "updateXAxis", options: Partial<LayoutAxis>): void;
+}>();
+
+const store = useStore();
+
+const solution = computed(() => store.state.run.resultOde?.solution);
+const visibleParameterSetNames = computed(() => store.getters[`run/${RunGetter.visibleParameterSetNames}`]);
+const parameterSets = computed(() => store.state.run.parameterSets as ParameterSet[]);
+const displayNames = computed(() => {
+    return parameterSets.value.map((paramSet) => paramSet.displayName);
+});
+
+const parameterSetSolutions = computed(() => {
+    const result = {} as Dict<OdinSolution>;
+    Object.keys(store.state.run.parameterSetResults).forEach((name) => {
+        const sln = store.state.run.parameterSetResults[name].solution;
+        if (sln && visibleParameterSetNames.value.includes(name)) {
+            result[name] = sln;
+        }
+    });
+    return result;
+});
+
+const endTime = computed(() => store.state.run.endTime);
+
+const palette = computed(() => store.state.model.paletteModel);
+
+const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`]);
+
+const selectedVariables = computed(() => store.state.graphs.config[props.graphIndex].selectedVariables);
+const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
+
+const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
+    const options = {
+        mode: "grid",
+        tStart: start,
+        tEnd: end,
+        nPoints: points
+    };
+    const result = solution.value && solution.value(options);
+    if (!result) {
+        return [];
+    }
+
+    // 1. Current parameter values
+    const plotOptions = { showLegend: true, includeLegendGroup: true };
+    const allData = [
+        ...odinToPlotly(filterSeriesSet(result, selectedVariables.value), palette.value, plotOptions),
+        ...allFitDataToPlotly(allFitData.value, palette.value, start, end)
+    ];
+
+    // 2. Parameter sets
+    const lineStylesForParamSets = computed(() => store.getters[`run/${RunGetter.lineStylesForParameterSets}`]);
+
+    const updatePlotTraceNameWithParameterSetName = (plotTrace: Partial<PlotData>, setName: string) => {
+        // eslint-disable-next-line no-param-reassign
+        plotTrace.name = `${plotTrace.name} (${setName})`;
+    };
+
+    Object.keys(parameterSetSolutions.value).forEach((name) => {
+        const paramSetSln = parameterSetSolutions.value[name];
+        const paramSetResult = paramSetSln!(options as Times);
+
+        const dash = lineStylesForParamSets.value[name];
+        if (paramSetResult) {
+            const filteredSetData = filterSeriesSet(paramSetResult, selectedVariables.value);
+            const paramSetOptions = { dash, showLegend: false, includeLegendGroup: true };
+            const plotData = odinToPlotly(filteredSetData, palette.value, paramSetOptions);
+            const currentParamSet = parameterSets.value.find((paramSet) => paramSet.name === name);
+            plotData.forEach((plotTrace) => {
+                updatePlotTraceNameWithParameterSetName(plotTrace, currentParamSet!.displayName);
+            });
+            allData.push(...plotData);
+        }
+    });
+    return allData;
+};
+
+const updateXAxis = (options: Partial<LayoutAxis>) => {
+    emit("updateXAxis", options);
+};
 </script>

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -6,7 +6,7 @@
         :plot-data="allPlotData"
         :redrawWatches="solution ? [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames] : []"
         :has-linked-x-axis="true"
-        :linked-x-axis-options="linkedXAxisOptions"
+        :linked-x-axis="linkedXAxis"
         @updateXAxis="updateXAxis"
     >
         <slot></slot>
@@ -16,10 +16,10 @@
 <script lang="ts">
 import {computed, defineComponent, PropType} from "vue";
 import { useStore } from "vuex";
-import { PlotData } from "plotly.js-basic-dist-min";
+import {LayoutAxis, PlotData} from "plotly.js-basic-dist-min";
 import { FitDataGetter } from "../../store/fitData/getters";
 import { odinToPlotly, allFitDataToPlotly, WodinPlotData, filterSeriesSet } from "../../plot";
-import WodinPlot, {AxisOptions} from "../WodinPlot.vue";
+import WodinPlot from "../WodinPlot.vue";
 import { RunGetter } from "../../store/run/getters";
 import { OdinSolution, Times } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
@@ -34,8 +34,8 @@ export default defineComponent({
             type: Number,
             default: 0
         },
-        linkedXAxisOptions: {
-          type: Object as PropType<AxisOptions | null>,
+        linkedXAxis: {
+          type: Object as PropType<Partial<LayoutAxis> | null>,
           required: true
         }
     },
@@ -119,7 +119,7 @@ export default defineComponent({
             return allData;
         };
 
-        const updateXAxis = (options: AxisOptions) => {
+        const updateXAxis = (options: Partial<LayoutAxis>) => {
           emit("updateXAxis", options);
         }
 

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -5,18 +5,21 @@
         :end-time="endTime"
         :plot-data="allPlotData"
         :redrawWatches="solution ? [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames] : []"
+        :has-linked-x-axis="true"
+        :linked-x-axis-options="linkedXAxisOptions"
+        @updateXAxis="updateXAxis"
     >
         <slot></slot>
     </wodin-plot>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from "vue";
+import {computed, defineComponent, PropType} from "vue";
 import { useStore } from "vuex";
 import { PlotData } from "plotly.js-basic-dist-min";
 import { FitDataGetter } from "../../store/fitData/getters";
 import { odinToPlotly, allFitDataToPlotly, WodinPlotData, filterSeriesSet } from "../../plot";
-import WodinPlot from "../WodinPlot.vue";
+import WodinPlot, {XAxisOptions} from "../WodinPlot.vue";
 import { RunGetter } from "../../store/run/getters";
 import { OdinSolution, Times } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
@@ -30,12 +33,17 @@ export default defineComponent({
         graphIndex: {
             type: Number,
             default: 0
+        },
+        linkedXAxisOptions: {
+          type: Object as PropType<XAxisOptions | null>,
+          required: true
         }
     },
     components: {
         WodinPlot
     },
-    setup(props) {
+    emits: ["updateXAxis"],
+    setup(props, {emit}) {
         const store = useStore();
 
         const solution = computed(() => store.state.run.resultOde?.solution);
@@ -111,6 +119,10 @@ export default defineComponent({
             return allData;
         };
 
+        const updateXAxis = (options: XAxisOptions) => {
+          emit("updateXAxis", options);
+        }
+
         return {
             placeholderMessage,
             endTime,
@@ -119,7 +131,8 @@ export default defineComponent({
             allPlotData,
             selectedVariables,
             parameterSetSolutions,
-            displayNames
+            displayNames,
+            updateXAxis
         };
     }
 });

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -19,7 +19,7 @@ import { useStore } from "vuex";
 import { PlotData } from "plotly.js-basic-dist-min";
 import { FitDataGetter } from "../../store/fitData/getters";
 import { odinToPlotly, allFitDataToPlotly, WodinPlotData, filterSeriesSet } from "../../plot";
-import WodinPlot, {XAxisOptions} from "../WodinPlot.vue";
+import WodinPlot, {AxisOptions} from "../WodinPlot.vue";
 import { RunGetter } from "../../store/run/getters";
 import { OdinSolution, Times } from "../../types/responseTypes";
 import { Dict } from "../../types/utilTypes";
@@ -35,7 +35,7 @@ export default defineComponent({
             default: 0
         },
         linkedXAxisOptions: {
-          type: Object as PropType<XAxisOptions | null>,
+          type: Object as PropType<AxisOptions | null>,
           required: true
         }
     },
@@ -119,7 +119,7 @@ export default defineComponent({
             return allData;
         };
 
-        const updateXAxis = (options: XAxisOptions) => {
+        const updateXAxis = (options: AxisOptions) => {
           emit("updateXAxis", options);
         }
 

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -5,7 +5,6 @@
         :end-time="endTime"
         :plot-data="allPlotData"
         :redrawWatches="solution ? [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames] : []"
-        :has-linked-x-axis="true"
         :linked-x-axis="linkedXAxis"
         @updateXAxis="updateXAxis"
     >

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -5,14 +5,18 @@
         :end-time="endTime"
         :plot-data="allPlotData"
         :redrawWatches="solution ? [solution] : []"
+        :has-linked-x-axis="true"
+        :linked-x-axis="linkedXAxis"
+        @updateXAxis="updateXAxis"
     >
         <slot></slot>
     </wodin-plot>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, PropType } from "vue";
 import { useStore } from "vuex";
+import {LayoutAxis} from "plotly.js-basic-dist-min";
 import { WodinPlotData, discreteSeriesSetToPlotly, filterSeriesSet } from "../../plot";
 import WodinPlot from "../WodinPlot.vue";
 import { runPlaceholderMessage } from "../../utils";
@@ -25,12 +29,17 @@ export default defineComponent({
         graphIndex: {
             type: Number,
             default: 0
+        },
+        linkedXAxis: {
+          type: Object as PropType<Partial<LayoutAxis> | null>,
+          required: true
         }
     },
     components: {
         WodinPlot
     },
-    setup(props) {
+    emits: ["updateXAxis"],
+    setup(props, {emit}) {
         const store = useStore();
 
         const selectedVariables = computed(() => store.state.graphs.config[props.graphIndex].selectedVariables);
@@ -65,11 +74,16 @@ export default defineComponent({
             );
         };
 
+      const updateXAxis = (options: Partial<LayoutAxis>) => {
+        emit("updateXAxis", options);
+      }
+
         return {
             placeholderMessage,
             endTime,
             allPlotData,
-            solution
+            solution,
+            updateXAxis
         };
     }
 });

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
 import { useStore } from "vuex";
-import {LayoutAxis} from "plotly.js-basic-dist-min";
+import { LayoutAxis } from "plotly.js-basic-dist-min";
 import { WodinPlotData, discreteSeriesSetToPlotly, filterSeriesSet } from "../../plot";
 import WodinPlot from "../WodinPlot.vue";
 import { runPlaceholderMessage } from "../../utils";
@@ -30,15 +30,15 @@ export default defineComponent({
             default: 0
         },
         linkedXAxis: {
-          type: Object as PropType<Partial<LayoutAxis> | null>,
-          required: true
+            type: Object as PropType<Partial<LayoutAxis> | null>,
+            required: true
         }
     },
     components: {
         WodinPlot
     },
     emits: ["updateXAxis"],
-    setup(props, {emit}) {
+    setup(props, { emit }) {
         const store = useStore();
 
         const selectedVariables = computed(() => store.state.graphs.config[props.graphIndex].selectedVariables);
@@ -73,9 +73,9 @@ export default defineComponent({
             );
         };
 
-      const updateXAxis = (options: Partial<LayoutAxis>) => {
-        emit("updateXAxis", options);
-      }
+        const updateXAxis = (options: Partial<LayoutAxis>) => {
+            emit("updateXAxis", options);
+        };
 
         return {
             placeholderMessage,

--- a/app/static/src/app/components/run/RunStochasticPlot.vue
+++ b/app/static/src/app/components/run/RunStochasticPlot.vue
@@ -5,7 +5,6 @@
         :end-time="endTime"
         :plot-data="allPlotData"
         :redrawWatches="solution ? [solution] : []"
-        :has-linked-x-axis="true"
         :linked-x-axis="linkedXAxis"
         @updateXAxis="updateXAxis"
     >

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -10,7 +10,12 @@
                 :fade-plot="!!updateMsg"
                 :graph-index="index"
             ></run-stochastic-plot>
-            <run-plot v-else :fade-plot="!!updateMsg" :model-fit="false" :graph-index="index">
+            <run-plot v-else
+                      :fade-plot="!!updateMsg"
+                      :model-fit="false"
+                      :graph-index="index"
+                      :linked-x-axis-options="xAxisOptions"
+                      @updateXAxis="updateXAxisOptions">
                 <div v-if="sumOfSquares">
                     <span>Sum of squares: {{ sumOfSquares }}</span>
                 </div>
@@ -46,7 +51,7 @@
 
 <script lang="ts">
 import { useStore } from "vuex";
-import { computed, defineComponent, ref } from "vue";
+import {computed, defineComponent, Ref, ref} from "vue";
 import VueFeather from "vue-feather";
 import { RunMutation } from "../../store/run/mutations";
 import RunPlot from "./RunPlot.vue";
@@ -62,6 +67,7 @@ import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
+import {XAxisOptions} from "../WodinPlot.vue";
 
 export default defineComponent({
     name: "RunTab",
@@ -78,6 +84,8 @@ export default defineComponent({
         const store = useStore();
 
         const showDownloadOutput = ref(false);
+        const xAxisOptions: Ref<XAxisOptions> = ref({ autorange: true });
+
         const isStochastic = computed(() => store.state.appType === AppType.Stochastic);
 
         const error = computed(() => {
@@ -127,6 +135,10 @@ export default defineComponent({
         const download = (payload: { fileName: string; points: number }) =>
             store.dispatch(`run/${RunAction.DownloadOutput}`, payload);
 
+        const updateXAxisOptions = (options: XAxisOptions) => {
+            xAxisOptions.value = options;
+        };
+
         return {
             canRunModel,
             isStochastic,
@@ -140,7 +152,9 @@ export default defineComponent({
             downloadUserFileName,
             toggleShowDownloadOutput,
             download,
-            graphConfigs
+            graphConfigs,
+            xAxisOptions,
+            updateXAxisOptions
         };
     }
 });

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="run-tab">
-      <div>{{JSON.stringify(xAxisOptions)}}</div>
         <div>
             <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
         </div>
@@ -15,7 +14,7 @@
                       :fade-plot="!!updateMsg"
                       :model-fit="false"
                       :graph-index="index"
-                      :linked-x-axis-options="xAxisOptions"
+                      :linked-x-axis="xAxisOptions"
                       @updateXAxis="updateXAxisOptions">
                 <div v-if="sumOfSquares">
                     <span>Sum of squares: {{ sumOfSquares }}</span>
@@ -68,7 +67,7 @@ import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
-import {AxisOptions} from "../WodinPlot.vue";
+import {LayoutAxis} from "plotly.js-basic-dist-min";
 
 export default defineComponent({
     name: "RunTab",
@@ -85,7 +84,7 @@ export default defineComponent({
         const store = useStore();
 
         const showDownloadOutput = ref(false);
-        const xAxisOptions: Ref<AxisOptions> = ref({ autorange: true });
+        const xAxis: Ref<Partial<LayoutAxis>> = ref({ autorange: true });
 
         const isStochastic = computed(() => store.state.appType === AppType.Stochastic);
 
@@ -136,8 +135,8 @@ export default defineComponent({
         const download = (payload: { fileName: string; points: number }) =>
             store.dispatch(`run/${RunAction.DownloadOutput}`, payload);
 
-        const updateXAxisOptions = (options: AxisOptions) => {
-            xAxisOptions.value = options;
+        const updateXAxisOptions = (options: Partial<LayoutAxis>) => {
+            xAxis.value = options;
         };
 
         return {
@@ -154,7 +153,7 @@ export default defineComponent({
             toggleShowDownloadOutput,
             download,
             graphConfigs,
-            xAxisOptions,
+            xAxisOptions: xAxis,
             updateXAxisOptions
         };
     }

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -55,6 +55,7 @@
 import { useStore } from "vuex";
 import {computed, defineComponent, Ref, ref} from "vue";
 import VueFeather from "vue-feather";
+import {LayoutAxis} from "plotly.js-basic-dist-min";
 import { RunMutation } from "../../store/run/mutations";
 import RunPlot from "./RunPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";
@@ -69,7 +70,6 @@ import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
-import {LayoutAxis} from "plotly.js-basic-dist-min";
 
 export default defineComponent({
     name: "RunTab",

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -9,13 +9,15 @@
                 v-if="isStochastic"
                 :fade-plot="!!updateMsg"
                 :graph-index="index"
+                :linked-x-axis="xAxis"
+                @updateXAxis="updateXAxis"
             ></run-stochastic-plot>
             <run-plot v-else
                       :fade-plot="!!updateMsg"
                       :model-fit="false"
                       :graph-index="index"
-                      :linked-x-axis="xAxisOptions"
-                      @updateXAxis="updateXAxisOptions">
+                      :linked-x-axis="xAxis"
+                      @updateXAxis="updateXAxis">
                 <div v-if="sumOfSquares">
                     <span>Sum of squares: {{ sumOfSquares }}</span>
                 </div>
@@ -135,8 +137,8 @@ export default defineComponent({
         const download = (payload: { fileName: string; points: number }) =>
             store.dispatch(`run/${RunAction.DownloadOutput}`, payload);
 
-        const updateXAxisOptions = (options: Partial<LayoutAxis>) => {
-            xAxis.value = options;
+        const updateXAxis = (newAxis: Partial<LayoutAxis>) => {
+            xAxis.value = newAxis;
         };
 
         return {
@@ -153,8 +155,8 @@ export default defineComponent({
             toggleShowDownloadOutput,
             download,
             graphConfigs,
-            xAxisOptions: xAxis,
-            updateXAxisOptions
+            xAxis,
+            updateXAxis
         };
     }
 });

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -4,7 +4,7 @@
             <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
         </div>
         <action-required-message :message="updateMsg"></action-required-message>
-        <template v-for="(_, index) in graphConfigs" :key="index">
+        <template v-for="(config, index) in graphConfigs" :key="config.id">
             <run-stochastic-plot
                 v-if="isStochastic"
                 :fade-plot="!!updateMsg"

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -12,12 +12,14 @@
                 :linked-x-axis="xAxis"
                 @updateXAxis="updateXAxis"
             ></run-stochastic-plot>
-            <run-plot v-else
-                      :fade-plot="!!updateMsg"
-                      :model-fit="false"
-                      :graph-index="index"
-                      :linked-x-axis="xAxis"
-                      @updateXAxis="updateXAxis">
+            <run-plot
+                v-else
+                :fade-plot="!!updateMsg"
+                :model-fit="false"
+                :graph-index="index"
+                :linked-x-axis="xAxis"
+                @updateXAxis="updateXAxis"
+            >
                 <div v-if="sumOfSquares">
                     <span>Sum of squares: {{ sumOfSquares }}</span>
                 </div>
@@ -53,9 +55,9 @@
 
 <script lang="ts">
 import { useStore } from "vuex";
-import {computed, defineComponent, Ref, ref} from "vue";
+import { computed, defineComponent, Ref, ref } from "vue";
 import VueFeather from "vue-feather";
-import {LayoutAxis} from "plotly.js-basic-dist-min";
+import { LayoutAxis } from "plotly.js-basic-dist-min";
 import { RunMutation } from "../../store/run/mutations";
 import RunPlot from "./RunPlot.vue";
 import ActionRequiredMessage from "../ActionRequiredMessage.vue";

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="run-tab">
+      <div>{{JSON.stringify(xAxisOptions)}}</div>
         <div>
             <button class="btn btn-primary" id="run-btn" :disabled="!canRunModel" @click="runModel">Run model</button>
         </div>
@@ -67,7 +68,7 @@ import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
-import {XAxisOptions} from "../WodinPlot.vue";
+import {AxisOptions} from "../WodinPlot.vue";
 
 export default defineComponent({
     name: "RunTab",
@@ -84,7 +85,7 @@ export default defineComponent({
         const store = useStore();
 
         const showDownloadOutput = ref(false);
-        const xAxisOptions: Ref<XAxisOptions> = ref({ autorange: true });
+        const xAxisOptions: Ref<AxisOptions> = ref({ autorange: true });
 
         const isStochastic = computed(() => store.state.appType === AppType.Stochastic);
 
@@ -135,7 +136,7 @@ export default defineComponent({
         const download = (payload: { fileName: string; points: number }) =>
             store.dispatch(`run/${RunAction.DownloadOutput}`, payload);
 
-        const updateXAxisOptions = (options: XAxisOptions) => {
+        const updateXAxisOptions = (options: AxisOptions) => {
             xAxisOptions.value = options;
         };
 

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,4 +1,4 @@
-import { Dash, PlotData } from "plotly.js-basic-dist-min";
+import {Dash, Margin, PlotData} from "plotly.js-basic-dist-min";
 import { format } from "d3-format";
 import { Palette, paletteData } from "./palette";
 import type { AllFitData, FitData, FitDataLink } from "./store/fitData/state";
@@ -14,7 +14,7 @@ export const fadePlotStyle = "opacity:0.5;";
 // legend.
 export const margin = {
     t: 25
-};
+} as Partial<Margin>;
 
 export const config = {
     responsive: true

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -1,4 +1,4 @@
-import {Dash, Margin, PlotData} from "plotly.js-basic-dist-min";
+import { Dash, Margin, PlotData } from "plotly.js-basic-dist-min";
 import { format } from "d3-format";
 import { Palette, paletteData } from "./palette";
 import type { AllFitData, FitData, FitDataLink } from "./store/fitData/state";

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -15,11 +15,13 @@ import {
     SerialisedRunResult,
     SerialisedSensitivityResult,
     SerialisedModelFitState,
-    SerialisedMultiSensitivityState
+    SerialisedMultiSensitivityState,
+    SerialisedGraphsState
 } from "./types/serialisationTypes";
-import { GraphsState } from "./store/graphs/state";
+import { GraphConfig, GraphsState } from "./store/graphs/state";
 import { Dict } from "./types/utilTypes";
 import { MultiSensitivityState } from "./store/multiSensitivity/state";
+import { newUid } from "./utils";
 
 function serialiseCode(code: CodeState): CodeState {
     return {
@@ -140,8 +142,26 @@ function serialiseModelFit(modelFit: ModelFitState): SerialisedModelFitState {
     };
 }
 
-export const serialiseGraphs = (state: GraphsState): GraphsState => {
-    return { ...state };
+// Do not include graph config uids in serialised as we don't want them to contribute to duplicate checks
+export const serialiseGraphs = (state: GraphsState): SerialisedGraphsState => {
+    return {
+        ...state,
+        config: state.config.map((c: GraphConfig) => ({
+            selectedVariables: c.selectedVariables,
+            unselectedVariables: c.unselectedVariables
+        }))
+    };
+};
+
+export const deserialiseGraphs = (serialised: SerialisedGraphsState): GraphsState => {
+    return {
+        ...serialised,
+        config: serialised.config.map((s) => ({
+            id: newUid(),
+            selectedVariables: s.selectedVariables,
+            unselectedVariables: s.unselectedVariables
+        }))
+    };
 };
 
 export const serialiseState = (state: AppState): string => {
@@ -168,6 +188,7 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
     Object.assign(targetState, {
         ...targetState,
         ...serialised,
+        graphs: deserialiseGraphs(serialised.graphs),
         persisted: true
     });
 

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -188,7 +188,7 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
     Object.assign(targetState, {
         ...targetState,
         ...serialised,
-        graphs: deserialiseGraphs(serialised.graphs),
+        graphs: serialised.graphs ? deserialiseGraphs(serialised.graphs) : targetState.graphs,
         persisted: true
     });
 

--- a/app/static/src/app/serialise.ts
+++ b/app/static/src/app/serialise.ts
@@ -184,6 +184,7 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
 
         targetState.graphs.config = [
             {
+                id: graphs!.config[0].id,
                 selectedVariables,
                 unselectedVariables
             }

--- a/app/static/src/app/store/basic/basic.ts
+++ b/app/static/src/app/store/basic/basic.ts
@@ -9,7 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { logMutations, persistState } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
-import { newSessionId } from "../../utils";
+import { newUid } from "../../utils";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphs } from "../graphs/graphs";
@@ -22,7 +22,7 @@ const language = getStoreModule();
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        sessionId: newSessionId(),
+        sessionId: newUid(),
         sessionLabel: null,
         appType: AppType.Basic,
         openVisualisationTab: VisualisationTab.Run,

--- a/app/static/src/app/store/fit/fit.ts
+++ b/app/static/src/app/store/fit/fit.ts
@@ -11,7 +11,7 @@ import { fitData } from "../fitData/fitData";
 import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
 import { logMutations, persistState } from "../plugins";
-import { newSessionId } from "../../utils";
+import { newUid } from "../../utils";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphs } from "../graphs/graphs";
@@ -24,7 +24,7 @@ const language = getStoreModule();
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        sessionId: newSessionId(),
+        sessionId: newUid(),
         sessionLabel: null,
         appType: AppType.Fit,
         openVisualisationTab: VisualisationTab.Run,

--- a/app/static/src/app/store/graphs/actions.ts
+++ b/app/static/src/app/store/graphs/actions.ts
@@ -3,6 +3,7 @@ import { GraphsMutation } from "./mutations";
 import { AppState, AppType } from "../appState/state";
 import { FitDataAction } from "../fitData/actions";
 import { GraphsState } from "./state";
+import {newUid} from "../../utils";
 
 export enum GraphsAction {
     UpdateSelectedVariables = "UpdateSelectedVariables",
@@ -29,6 +30,6 @@ export const actions: ActionTree<GraphsState, AppState> = {
     NewGraph(context) {
         const { rootState, commit } = context;
         const unselectedVariables = [...(rootState.model.odinModelResponse?.metadata?.variables || [])];
-        commit(GraphsMutation.AddGraph, { selectedVariables: [], unselectedVariables });
+        commit(GraphsMutation.AddGraph, { id: newUid(), selectedVariables: [], unselectedVariables });
     }
 };

--- a/app/static/src/app/store/graphs/actions.ts
+++ b/app/static/src/app/store/graphs/actions.ts
@@ -3,7 +3,7 @@ import { GraphsMutation } from "./mutations";
 import { AppState, AppType } from "../appState/state";
 import { FitDataAction } from "../fitData/actions";
 import { GraphsState } from "./state";
-import {newUid} from "../../utils";
+import { newUid } from "../../utils";
 
 export enum GraphsAction {
     UpdateSelectedVariables = "UpdateSelectedVariables",

--- a/app/static/src/app/store/graphs/getters.ts
+++ b/app/static/src/app/store/graphs/getters.ts
@@ -30,7 +30,8 @@ export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
     },
     [GraphsGetter.legendWidth]: (_, graphsGetters): number  => {
         // Heuristic for setting graph legend width based on string length of longest variable name
-        const longestVar = graphsGetters[GraphsGetter.allSelectedVariables].sort((a: string, b: string) => a.length < b.length ? 1 : -1)[0];
+        const longestVar = graphsGetters[GraphsGetter.allSelectedVariables]
+            .sort((a: string, b: string) => a.length < b.length ? 1 : -1)[0];
         return (longestVar.length * 10) + 40;
     }
 };

--- a/app/static/src/app/store/graphs/getters.ts
+++ b/app/static/src/app/store/graphs/getters.ts
@@ -28,10 +28,11 @@ export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
         const allSelected = graphsGetters[GraphsGetter.allSelectedVariables];
         return rootState.model.odinModelResponse?.metadata?.variables.filter((s) => !allSelected.includes(s)) || [];
     },
-    [GraphsGetter.legendWidth]: (_, graphsGetters): number  => {
+    [GraphsGetter.legendWidth]: (_, graphsGetters): number => {
         // Heuristic for setting graph legend width based on string length of longest variable name
-        const longestVar = graphsGetters[GraphsGetter.allSelectedVariables]
-            .sort((a: string, b: string) => a.length < b.length ? 1 : -1)[0];
-        return (longestVar.length * 10) + 40;
+        const longestVar = graphsGetters[GraphsGetter.allSelectedVariables].sort((a: string, b: string) =>
+            a.length < b.length ? 1 : -1
+        )[0];
+        return longestVar.length * 10 + 40;
     }
 };

--- a/app/static/src/app/store/graphs/getters.ts
+++ b/app/static/src/app/store/graphs/getters.ts
@@ -20,6 +20,9 @@ export interface GraphsGettersValues {
     [GraphsGetter.legendWidth]: number;
 }
 
+const LEGEND_LINE_PADDING = 40;
+const LEGEND_WIDTH_PER_CHAR = 10;
+
 export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
     [GraphsGetter.allSelectedVariables]: (state: GraphsState): string[] => {
         return state.config.flatMap((c) => c.selectedVariables); // TODO: dedupe, in mrc-5443
@@ -33,6 +36,6 @@ export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
         const longestVar = graphsGetters[GraphsGetter.allSelectedVariables].sort((a: string, b: string) =>
             a.length < b.length ? 1 : -1
         )[0];
-        return longestVar.length * 10 + 40;
+        return longestVar.length * LEGEND_WIDTH_PER_CHAR + LEGEND_LINE_PADDING;
     }
 };

--- a/app/static/src/app/store/graphs/getters.ts
+++ b/app/static/src/app/store/graphs/getters.ts
@@ -4,17 +4,20 @@ import { AppState } from "../appState/state";
 
 export enum GraphsGetter {
     allSelectedVariables = "allSelectedVariables",
-    hiddenVariables = "hiddenVariables" // variable which are not selected in any graph
+    hiddenVariables = "hiddenVariables", // variable which are not selected in any graph
+    legendWidth = "legendWidth" // plot legend width, in pixels, derived from max selected variable name length
 }
 
 export interface GraphsGetters {
     [GraphsGetter.allSelectedVariables]: Getter<GraphsState, AppState>;
     [GraphsGetter.hiddenVariables]: Getter<GraphsState, AppState>;
+    [GraphsGetter.legendWidth]: Getter<GraphsState, AppState>;
 }
 
 export interface GraphsGettersValues {
     [GraphsGetter.allSelectedVariables]: string[];
     [GraphsGetter.hiddenVariables]: string[];
+    [GraphsGetter.legendWidth]: number;
 }
 
 export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
@@ -24,5 +27,9 @@ export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
     [GraphsGetter.hiddenVariables]: (_, graphsGetters: GraphsGettersValues, rootState: AppState): string[] => {
         const allSelected = graphsGetters[GraphsGetter.allSelectedVariables];
         return rootState.model.odinModelResponse?.metadata?.variables.filter((s) => !allSelected.includes(s)) || [];
+    },
+    [GraphsGetter.legendWidth]: (_, graphsGetters): number  => {
+        const longestVar = graphsGetters[GraphsGetter.allSelectedVariables].sort((a: string, b: string) => a.length < b.length ? 1 : -1)[0];
+        return (longestVar.length * 10) + 40;
     }
 };

--- a/app/static/src/app/store/graphs/getters.ts
+++ b/app/static/src/app/store/graphs/getters.ts
@@ -29,6 +29,7 @@ export const getters: GraphsGetters & GetterTree<GraphsState, AppState> = {
         return rootState.model.odinModelResponse?.metadata?.variables.filter((s) => !allSelected.includes(s)) || [];
     },
     [GraphsGetter.legendWidth]: (_, graphsGetters): number  => {
+        // Heuristic for setting graph legend width based on string length of longest variable name
         const longestVar = graphsGetters[GraphsGetter.allSelectedVariables].sort((a: string, b: string) => a.length < b.length ? 1 : -1)[0];
         return (longestVar.length * 10) + 40;
     }

--- a/app/static/src/app/store/graphs/graphs.ts
+++ b/app/static/src/app/store/graphs/graphs.ts
@@ -2,10 +2,12 @@ import { GraphsState } from "./state";
 import { actions } from "./actions";
 import { getters } from "./getters";
 import { mutations } from "./mutations";
+import {newUid} from "../../utils";
 
-export const defaultState: GraphsState = {
+export const defaultState = (): GraphsState => ({
     config: [
         {
+            id: newUid(),
             selectedVariables: [],
             unselectedVariables: []
         }
@@ -15,11 +17,11 @@ export const defaultState: GraphsState = {
         lockYAxis: false,
         yAxisRange: [0, 0]
     }
-};
+});
 
 export const graphs = {
     namespaced: true,
-    state: defaultState,
+    state: defaultState(),
     actions,
     getters,
     mutations

--- a/app/static/src/app/store/graphs/graphs.ts
+++ b/app/static/src/app/store/graphs/graphs.ts
@@ -2,7 +2,7 @@ import { GraphsState } from "./state";
 import { actions } from "./actions";
 import { getters } from "./getters";
 import { mutations } from "./mutations";
-import {newUid} from "../../utils";
+import { newUid } from "../../utils";
 
 export const defaultState = (): GraphsState => ({
     config: [

--- a/app/static/src/app/store/graphs/state.ts
+++ b/app/static/src/app/store/graphs/state.ts
@@ -7,6 +7,7 @@ export interface GraphSettings {
 }
 
 export interface GraphConfig {
+    id: string; // We need to keep a persistent id to identify configs in vue when a graph is deleted from the array
     selectedVariables: string[];
     unselectedVariables: string[]; // We keep track of unselected variables too so we can retain on model update
 }

--- a/app/static/src/app/store/stochastic/stochastic.ts
+++ b/app/static/src/app/store/stochastic/stochastic.ts
@@ -8,7 +8,7 @@ import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
-import { newSessionId } from "../../utils";
+import { newUid } from "../../utils";
 import { logMutations, persistState } from "../plugins";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
@@ -22,7 +22,7 @@ const language = getStoreModule();
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const defaultState: () => any = () => {
     return {
-        sessionId: newSessionId(),
+        sessionId: newUid(),
         sessionLabel: null,
         appType: AppType.Stochastic,
         openVisualisationTab: VisualisationTab.Run,

--- a/app/static/src/app/types/serialisationTypes.ts
+++ b/app/static/src/app/types/serialisationTypes.ts
@@ -11,7 +11,7 @@ import { VisualisationTab } from "../store/appState/state";
 import { CodeState } from "../store/code/state";
 import { FitDataState } from "../store/fitData/state";
 import { Palette } from "../palette";
-import { GraphsState } from "../store/graphs/state";
+import { GraphSettings } from "../store/graphs/state";
 import { Dict } from "./utilTypes";
 
 export interface SerialisedRunResult {
@@ -73,6 +73,11 @@ export interface SerialisedModelFitState {
     error: null | WodinError;
 }
 
+export interface SerialisedGraphsState {
+    config: { selectedVariables: string[]; unselectedVariables: string[] }[];
+    settings: GraphSettings; // TODO: this will be replaced by per-graph settings in mrc-5442
+}
+
 export interface SerialisedAppState {
     openVisualisationTab: VisualisationTab;
     code: CodeState;
@@ -80,7 +85,7 @@ export interface SerialisedAppState {
     run: SerialisedRunState;
     sensitivity: SerialisedSensitivityState;
     multiSensitivity: SerialisedMultiSensitivityState;
-    graphs: GraphsState;
+    graphs: SerialisedGraphsState;
     fitData?: FitDataState;
     modelFit?: SerialisedModelFitState;
 }

--- a/app/static/src/app/utils.ts
+++ b/app/static/src/app/utils.ts
@@ -203,7 +203,7 @@ export function generateBatchPars(
     };
 }
 
-export const newSessionId = (): string => uid(32);
+export const newUid = (): string => uid(32);
 
 export const joinStringsSentence = (strings: string[], last = " and ", sep = ", "): string => {
     const n = strings.length;

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -293,24 +293,6 @@ test.describe("Code Tab tests", () => {
         );
     });
 
-    const expectGraphVariables = async (page: Page, graphIndex: number, expectedVariables: string[]) => {
-        // expect to find these variables in config panel and on plot series
-        const configPanel = await page.locator(`:nth-match(.graph-config-panel, ${graphIndex + 1})`);
-        const configVars = await configPanel.locator(".variable .variable-name");
-        await expect(configVars).toHaveCount(expectedVariables.length);
-
-        const plotSummary = await page.locator(
-            `:nth-match(.wodin-plot-container .wodin-plot-data-summary, ${graphIndex + 1})`
-        );
-        for (let i = 0; i < expectedVariables.length; i++) {
-            await expect(configVars.nth(i)).toHaveText(expectedVariables[i]);
-            await expect(plotSummary.locator(`:nth-match(.wodin-plot-data-summary-series, ${i + 1})`)).toHaveAttribute(
-                "name",
-                expectedVariables[i]
-            );
-        }
-    };
-
     test("can hide and unhide variables", async ({ page }) => {
         // drag I to Hidden Variables
         const iVariable = await page.locator(":nth-match(.graph-config-panel span.variable, 2)");

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -1,6 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
 import PlaywrightConfig from "../../playwright.config";
-import { saveSessionTimeout, writeCode ,expectGraphVariables} from "./utils";
+import { saveSessionTimeout, writeCode, expectGraphVariables } from "./utils";
 
 export const newValidCode = `## Derivatives
 deriv(y1) <- sigma * (y2 - y1)

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -1,7 +1,6 @@
 import { expect, test, Page } from "@playwright/test";
-import { plot } from "plotly.js-basic-dist-min";
 import PlaywrightConfig from "../../playwright.config";
-import { saveSessionTimeout, writeCode } from "./utils";
+import { saveSessionTimeout, writeCode ,expectGraphVariables} from "./utils";
 
 export const newValidCode = `## Derivatives
 deriv(y1) <- sigma * (y2 - y1)

--- a/app/static/tests/e2e/run.etest.ts
+++ b/app/static/tests/e2e/run.etest.ts
@@ -1,0 +1,50 @@
+import { expect, test, Page } from "@playwright/test";
+import {expectGraphVariables} from "./utils";
+
+const addGraphWithVariable = async (page: Page, variableIdx: number) => {
+    await page.click("#add-graph-btn");
+    const count = await page.locator(".graph-config-panel").count();
+    // assume we drag variable from first graph config
+    const firstGraphConfig = await page.locator(":nth-match(.graph-config-panel, 1)")
+    const variable = await firstGraphConfig.locator(`:nth-match(.variable, ${variableIdx})`);
+    await page.locator(`:nth-match(.graph-config-panel .drop-zone, ${count})`).scrollIntoViewIfNeeded();
+    await variable.dragTo(page.locator(`:nth-match(.graph-config-panel .drop-zone, ${count})`));
+};
+
+const expectXTicks = async (page: Page, expectedGraphCount: number, expectedXTicks: number[]) => {
+    const graphs = await page.locator(".plot-container");
+    expect(await graphs.count()).toBe(expectedGraphCount);
+    for(let i = 0; i < expectedGraphCount; i++) {
+        const graph = graphs.nth(i);
+        const ticks = await graph.locator(".xtick text");
+        expect(await ticks.count()).toBe(expectedXTicks.length);
+        for(let tickIdx = 0; tickIdx < expectedXTicks.length; tickIdx++) {
+            await expect(ticks.nth(tickIdx)).toHaveText(expectedXTicks[tickIdx].toString());
+        }
+    }
+};
+
+test.describe("Run Tab", () => {
+    test("x axis zoom on plot is replicated in other plots", async ({ page }) => {
+        await page.goto("/apps/day1");
+
+        // 1. Add 2 additional graphs, and drag one variable to each of them
+        await addGraphWithVariable(page, 1);
+        await addGraphWithVariable(page, 1);
+        await expectGraphVariables(page, 0, ["R"]);
+        await expectGraphVariables(page, 1, ["S"]);
+        await expectGraphVariables(page, 2, ["I"]);
+        //Sanity check that each graph has expected initial x axis ticks for full 0-100 time range
+        await expectXTicks(page, 3, [0, 20, 40, 60, 80, 100]);
+
+        // 2. Drag to zoom to an area on the first graph
+        const firstGraphBoundingBox = await page.locator(":nth-match(.plot-container .draglayer .xy .nsewdrag, 1)").boundingBox()!;
+        await page.mouse.move(firstGraphBoundingBox.x + 100, firstGraphBoundingBox.y + 50);
+        await page.mouse.down();
+        await page.mouse.move(firstGraphBoundingBox.x + 300, firstGraphBoundingBox.y + 100);
+        await page.mouse.up();
+
+        // 3. Check - using x axis ticks - that the expected x axis values are shown on all three graphs.
+        await expectXTicks(page, 3, [15, 20, 25, 30, 35, 40]);
+    });
+});

--- a/app/static/tests/e2e/run.etest.ts
+++ b/app/static/tests/e2e/run.etest.ts
@@ -34,14 +34,14 @@ test.describe("Run Tab", () => {
         await expectGraphVariables(page, 0, ["R"]);
         await expectGraphVariables(page, 1, ["S"]);
         await expectGraphVariables(page, 2, ["I"]);
-        //Sanity check that each graph has expected initial x axis ticks for full 0-100 time range
+        // Sanity check that each graph has expected initial x axis ticks for full 0-100 time range
         await expectXTicks(page, 3, [0, 20, 40, 60, 80, 100]);
 
         // 2. Drag to zoom to an area on the first graph
-        const firstGraphBoundingBox = await page.locator(":nth-match(.plot-container .draglayer .xy .nsewdrag, 1)").boundingBox()!;
-        await page.mouse.move(firstGraphBoundingBox.x + 100, firstGraphBoundingBox.y + 50);
+        const graphBounds = await page.locator(":nth-match(.plot .draglayer .xy .nsewdrag, 1)").boundingBox()!;
+        await page.mouse.move(graphBounds.x + 100, graphBounds.y + 50);
         await page.mouse.down();
-        await page.mouse.move(firstGraphBoundingBox.x + 300, firstGraphBoundingBox.y + 100);
+        await page.mouse.move(graphBounds.x + 300, graphBounds.y + 100);
         await page.mouse.up();
 
         // 3. Check - using x axis ticks - that the expected x axis values are shown on all three graphs.

--- a/app/static/tests/e2e/run.etest.ts
+++ b/app/static/tests/e2e/run.etest.ts
@@ -1,11 +1,11 @@
 import { expect, test, Page } from "@playwright/test";
-import {expectGraphVariables} from "./utils";
+import { expectGraphVariables } from "./utils";
 
 const addGraphWithVariable = async (page: Page, variableIdx: number) => {
     await page.click("#add-graph-btn");
     const count = await page.locator(".graph-config-panel").count();
     // assume we drag variable from first graph config
-    const firstGraphConfig = await page.locator(":nth-match(.graph-config-panel, 1)")
+    const firstGraphConfig = await page.locator(":nth-match(.graph-config-panel, 1)");
     const variable = await firstGraphConfig.locator(`:nth-match(.variable, ${variableIdx})`);
     await page.locator(`:nth-match(.graph-config-panel .drop-zone, ${count})`).scrollIntoViewIfNeeded();
     await variable.dragTo(page.locator(`:nth-match(.graph-config-panel .drop-zone, ${count})`));
@@ -14,11 +14,11 @@ const addGraphWithVariable = async (page: Page, variableIdx: number) => {
 const expectXTicks = async (page: Page, expectedGraphCount: number, expectedXTicks: number[]) => {
     const graphs = await page.locator(".plot-container");
     expect(await graphs.count()).toBe(expectedGraphCount);
-    for(let i = 0; i < expectedGraphCount; i++) {
+    for (let i = 0; i < expectedGraphCount; i++) {
         const graph = graphs.nth(i);
         const ticks = await graph.locator(".xtick text");
         expect(await ticks.count()).toBe(expectedXTicks.length);
-        for(let tickIdx = 0; tickIdx < expectedXTicks.length; tickIdx++) {
+        for (let tickIdx = 0; tickIdx < expectedXTicks.length; tickIdx++) {
             await expect(ticks.nth(tickIdx)).toHaveText(expectedXTicks[tickIdx].toString());
         }
     }

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -205,4 +205,3 @@ export const expectGraphVariables = async (page: Page, graphIndex: number, expec
         );
     }
 };
-

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -187,3 +187,22 @@ export const expectCanRunMultiSensitivity = async (page: Page, timeout = 10000) 
     );
     await expect(await page.locator("#download-summary-btn")).toBeEnabled();
 };
+
+export const expectGraphVariables = async (page: Page, graphIndex: number, expectedVariables: string[]) => {
+    // expect to find these variables in config panel and on plot series
+    const configPanel = await page.locator(`:nth-match(.graph-config-panel, ${graphIndex + 1})`);
+    const configVars = await configPanel.locator(".variable .variable-name");
+    await expect(configVars).toHaveCount(expectedVariables.length);
+
+    const plotSummary = await page.locator(
+        `:nth-match(.wodin-plot-container .wodin-plot-data-summary, ${graphIndex + 1})`
+    );
+    for (let i = 0; i < expectedVariables.length; i++) {
+        await expect(configVars.nth(i)).toHaveText(expectedVariables[i]);
+        await expect(plotSummary.locator(`:nth-match(.wodin-plot-data-summary-series, ${i + 1})`)).toHaveAttribute(
+            "name",
+            expectedVariables[i]
+        );
+    }
+};
+

--- a/app/static/tests/mocks.ts
+++ b/app/static/tests/mocks.ts
@@ -126,6 +126,7 @@ export const mockGraphsState = (state: Partial<GraphsState> = {}): GraphsState =
     return {
         config: [
             {
+                id: "123",
                 selectedVariables: [],
                 unselectedVariables: []
             }

--- a/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
+++ b/app/static/tests/unit/components/mixins/baseSensitivity.test.ts
@@ -7,7 +7,6 @@ import { AppState } from "../../../../src/app/store/appState/state";
 import { BaseSensitivityMutation } from "../../../../src/app/store/sensitivity/mutations";
 import { BaseSensitivityAction } from "../../../../src/app/store/sensitivity/actions";
 import { getters as graphGetters } from "../../../../src/app/store/graphs/getters";
-import mock = jest.mock;
 import { mockGraphsState } from "../../../mocks";
 
 describe("baseSensitivity mixin", () => {
@@ -30,7 +29,7 @@ describe("baseSensitivity mixin", () => {
                 graphs: {
                     namespaced: true,
                     state: mockGraphsState({
-                        config: [{ selectedVariables, unselectedVariables: [] }]
+                        config: [{ id: "123", selectedVariables, unselectedVariables: [] }]
                     }),
                     getters: graphGetters
                 },

--- a/app/static/tests/unit/components/options/linkData.test.ts
+++ b/app/static/tests/unit/components/options/linkData.test.ts
@@ -33,7 +33,7 @@ describe("LinkData", () => {
                 graphs: {
                     namespaced: true,
                     state: mockGraphsState({
-                        config: [{ selectedVariables: ["I", "R"], unselectedVariables: [] }]
+                        config: [{ id: "123", selectedVariables: ["I", "R"], unselectedVariables: [] }]
                     }),
                     getters: graphGetters
                 },

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -9,7 +9,7 @@ import WodinPlot from "../../../../src/app/components/WodinPlot.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 import { getters as runGetters } from "../../../../src/app/store/run/getters";
-import { mockBasicState, mockGraphsState, mockRunState } from "../../../mocks";
+import {mockBasicState, mockGraphsState, mockModelState, mockRunState} from "../../../mocks";
 
 describe("RunPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({
@@ -418,7 +418,8 @@ describe("RunPlot", () => {
         const store = new Vuex.Store<BasicState>({
             state: {
                 graphs: graphsState,
-                run: mockRunState()
+                run: mockRunState(),
+                model: mockModelState()
             } as any
         });
         const wrapper = shallowMount(RunPlot, {
@@ -558,7 +559,8 @@ describe("RunPlot", () => {
                 graphs: mockGraphsState({
                     config: [{ selectedVariables: [] }]
                 } as any),
-                run: mockRunState()
+                run: mockRunState(),
+                model: mockModelState()
             } as any
         });
         const wrapper = shallowMount(RunPlot, {

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -9,7 +9,7 @@ import WodinPlot from "../../../../src/app/components/WodinPlot.vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
 import { FitDataGetter } from "../../../../src/app/store/fitData/getters";
 import { getters as runGetters } from "../../../../src/app/store/run/getters";
-import {mockBasicState, mockGraphsState, mockModelState, mockRunState} from "../../../mocks";
+import { mockBasicState, mockGraphsState, mockModelState, mockRunState } from "../../../mocks";
 
 describe("RunPlot", () => {
     const mockSolution = jest.fn().mockReturnValue({

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -87,6 +87,29 @@ describe("RunPlot", () => {
         config: [{ selectedVariables, unselectedVariables: [] }]
     };
 
+    const linkedXAxis = { autorange: false, range: [1, 2] };
+
+    const defaultRunState = () => mockRunState({
+        endTime: 99,
+        resultOde: mockResult,
+        parameterSets: [
+            {
+                name: "Set 1",
+                displayName: "Hey",
+                displayNameErrorMsg: "",
+                hidden: false,
+                parameterValues: { a: 2 }
+            },
+            {
+                name: "Set 2",
+                displayName: "Bye",
+                displayNameErrorMsg: "",
+                hidden: false,
+                parameterValues: { a: 4 }
+            }
+        ]
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -98,32 +121,14 @@ describe("RunPlot", () => {
                 model: {
                     paletteModel
                 },
-                run: mockRunState({
-                    endTime: 99,
-                    resultOde: mockResult,
-                    parameterSets: [
-                        {
-                            name: "Set 1",
-                            displayName: "Hey",
-                            displayNameErrorMsg: "",
-                            hidden: false,
-                            parameterValues: { a: 2 }
-                        },
-                        {
-                            name: "Set 2",
-                            displayName: "Bye",
-                            displayNameErrorMsg: "",
-                            hidden: false,
-                            parameterValues: { a: 4 }
-                        }
-                    ]
-                })
+                run: defaultRunState()
             } as any
         });
         const wrapper = shallowMount(RunPlot, {
             props: {
                 fadePlot: false,
-                graphIndex: 0
+                graphIndex: 0,
+                linkedXAxis
             },
             global: {
                 plugins: [store]
@@ -141,6 +146,7 @@ describe("RunPlot", () => {
             {},
             ["Hey", "Bye"]
         ]);
+        expect(wodinPlot.props("linkedXAxis")).toStrictEqual(linkedXAxis);
 
         // Generates expected plot data from model
         const plotData = wodinPlot.props("plotData");
@@ -182,6 +188,32 @@ describe("RunPlot", () => {
             tEnd: 1,
             nPoints: 10
         });
+    });
+
+    it("emits updateXAxis event", () => {
+        const store = new Vuex.Store<BasicState>({
+            state: {
+                graphs: graphsState,
+                model: {
+                    paletteModel
+                },
+                run: defaultRunState()
+            } as any
+        });
+        const wrapper = shallowMount(RunPlot, {
+            props: {
+                fadePlot: false,
+                graphIndex: 0,
+                linkedXAxis
+            },
+            global: {
+                plugins: [store]
+            }
+        });
+        const wodinPlot = wrapper.findComponent(WodinPlot);
+        const xAxis = {autorange: false, range: [111, 222]}
+        wodinPlot.vm.$emit("updateXAxis", xAxis);
+        expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([xAxis]);
     });
 
     it("renders as expected when there are parameter set solutions", () => {

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -89,26 +89,27 @@ describe("RunPlot", () => {
 
     const linkedXAxis = { autorange: false, range: [1, 2] };
 
-    const defaultRunState = () => mockRunState({
-        endTime: 99,
-        resultOde: mockResult,
-        parameterSets: [
-            {
-                name: "Set 1",
-                displayName: "Hey",
-                displayNameErrorMsg: "",
-                hidden: false,
-                parameterValues: { a: 2 }
-            },
-            {
-                name: "Set 2",
-                displayName: "Bye",
-                displayNameErrorMsg: "",
-                hidden: false,
-                parameterValues: { a: 4 }
-            }
-        ]
-    });
+    const defaultRunState = () =>
+        mockRunState({
+            endTime: 99,
+            resultOde: mockResult,
+            parameterSets: [
+                {
+                    name: "Set 1",
+                    displayName: "Hey",
+                    displayNameErrorMsg: "",
+                    hidden: false,
+                    parameterValues: { a: 2 }
+                },
+                {
+                    name: "Set 2",
+                    displayName: "Bye",
+                    displayNameErrorMsg: "",
+                    hidden: false,
+                    parameterValues: { a: 4 }
+                }
+            ]
+        });
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -211,7 +212,7 @@ describe("RunPlot", () => {
             }
         });
         const wodinPlot = wrapper.findComponent(WodinPlot);
-        const xAxis = {autorange: false, range: [111, 222]}
+        const xAxis = { autorange: false, range: [111, 222] };
         wodinPlot.vm.$emit("updateXAxis", xAxis);
         expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([xAxis]);
     });

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -33,11 +33,13 @@ describe("RunPlot for stochastic", () => {
     const selectedVariables = ["S", "I", "R"];
 
     const graphsState = mockGraphsState({
-            config: [{
-            id: "1234",
-            selectedVariables,
-            unselectedVariables: []
-        }]
+        config: [
+            {
+                id: "1234",
+                selectedVariables,
+                unselectedVariables: []
+            }
+        ]
     });
 
     const linkedXAxis = { autorange: false, range: [1, 2] };
@@ -140,7 +142,7 @@ describe("RunPlot for stochastic", () => {
             }
         });
         const wodinPlot = wrapper.findComponent(WodinPlot);
-        const xAxis = {autorange: false, range: [111, 222]}
+        const xAxis = { autorange: false, range: [111, 222] };
         wodinPlot.vm.$emit("updateXAxis", xAxis);
         expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([xAxis]);
     });

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -32,7 +32,15 @@ describe("RunPlot for stochastic", () => {
 
     const selectedVariables = ["S", "I", "R"];
 
-    const graphsState = mockGraphsState({ config: [{ selectedVariables, unselectedVariables: [] }] });
+    const graphsState = mockGraphsState({
+            config: [{
+            id: "1234",
+            selectedVariables,
+            unselectedVariables: []
+        }]
+    });
+
+    const linkedXAxis = { autorange: false, range: [1, 2] };
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -57,7 +65,8 @@ describe("RunPlot for stochastic", () => {
         const wrapper = shallowMount(RunStochasticPlot, {
             props: {
                 fadePlot: false,
-                graphIndex: 0
+                graphIndex: 0,
+                linkedXAxis
             },
             global: {
                 plugins: [store]
@@ -69,6 +78,7 @@ describe("RunPlot for stochastic", () => {
         expect(wodinPlot.props("endTime")).toBe(99);
         expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution]);
         expect(wodinPlot.props("recalculateOnRelayout")).toBe(true);
+        expect(wodinPlot.props("linkedXAxis")).toStrictEqual(linkedXAxis);
 
         // Generates expected plot data from model
         const plotData = wodinPlot.props("plotData");
@@ -101,6 +111,38 @@ describe("RunPlot for stochastic", () => {
                 legendgroup: "I (mean)"
             }
         ]);
+    });
+
+    it("emits updateXAxis event", () => {
+        const store = new Vuex.Store<StochasticState>({
+            state: {
+                graphs: graphsState,
+                model: mockModelState({ paletteModel }),
+                run: {
+                    endTime: 99,
+                    numberOfReplicates: 20,
+                    resultDiscrete: mockResult
+                },
+                config: {
+                    maxReplicatesDisplay: 50,
+                    maxReplicatesRun: 1000
+                }
+            } as any
+        });
+        const wrapper = shallowMount(RunStochasticPlot, {
+            props: {
+                fadePlot: false,
+                graphIndex: 0,
+                linkedXAxis
+            },
+            global: {
+                plugins: [store]
+            }
+        });
+        const wodinPlot = wrapper.findComponent(WodinPlot);
+        const xAxis = {autorange: false, range: [111, 222]}
+        wodinPlot.vm.$emit("updateXAxis", xAxis);
+        expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([xAxis]);
     });
 
     it("renders as expected when model has no stochastic result", () => {

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -66,8 +66,8 @@ describe("RunTab", () => {
                     namespaced: true,
                     state: mockGraphsState({
                         config: [
-                            { selectedVariables, unselectedVariables: [] },
-                            { selectedVariables: [], unselectedVariables: [] }
+                            { id: "123", selectedVariables, unselectedVariables: [] },
+                            { id: "456", selectedVariables: [], unselectedVariables: [] }
                         ]
                     }),
                     getters: graphGetters
@@ -112,8 +112,8 @@ describe("RunTab", () => {
                     namespaced: true,
                     state: mockGraphsState({
                         config: [
-                            { selectedVariables: ["S"], unselectedVariables: [] },
-                            { selectedVariables: [], unselectedVariables: [] }
+                            { id: "123", selectedVariables: ["S"], unselectedVariables: [] },
+                            { id: "456", selectedVariables: [], unselectedVariables: [] }
                         ]
                     }),
                     getters: graphGetters
@@ -154,8 +154,10 @@ describe("RunTab", () => {
         expect(plots.length).toBe(2);
         expect(plots.at(0)!.props("graphIndex")).toBe(0);
         expect(plots.at(0)!.props("fadePlot")).toBe(false);
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({autorange: true});
         expect(plots.at(1)!.props("graphIndex")).toBe(1);
         expect(plots.at(1)!.props("fadePlot")).toBe(false);
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({autorange: true});
 
         // Download button disabled because there is no model solution
         const downloadBtn = wrapper.find("button#download-btn");
@@ -172,6 +174,17 @@ describe("RunTab", () => {
         expect(wrapper.findComponent(RunStochasticPlot).exists()).toBe(false);
     });
 
+    it("propagates x axis changes to all run plots", async () => {
+       const wrapper = getWrapper();
+       const plots = wrapper.findAllComponents(RunPlot);
+       expect(plots.length).toBe(2);
+       const newXAxis = {autorange: false, range: [1, 10]};
+       plots.at(0)!.vm.$emit("updateXAxis", newXAxis);
+       await nextTick();
+       expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual(newXAxis);
+       expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual(newXAxis);
+    });
+
     it("renders as expected when app is stochastic", () => {
         const wrapper = getStochasticWrapper(
             {},
@@ -183,11 +196,24 @@ describe("RunTab", () => {
         expect(plots.length).toBe(2);
         expect(plots.at(0)!.props("graphIndex")).toBe(0);
         expect(plots.at(0)!.props("fadePlot")).toBe(false);
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({autorange: true});
         expect(plots.at(1)!.props("graphIndex")).toBe(1);
         expect(plots.at(1)!.props("fadePlot")).toBe(false);
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({autorange: true});
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(RunPlot).exists()).toBe(false);
         expect((wrapper.find("button#run-btn").element as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it("propagates x axis changes to all run stochastic plots", async () => {
+        const wrapper = getStochasticWrapper();
+        const plots = wrapper.findAllComponents(RunStochasticPlot);
+        expect(plots.length).toBe(2);
+        const newXAxis = {autorange: false, range: [1, 10]};
+        plots.at(0)!.vm.$emit("updateXAxis", newXAxis);
+        await nextTick();
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual(newXAxis);
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual(newXAxis);
     });
 
     it("disables run button when state has no runner", () => {

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -154,10 +154,10 @@ describe("RunTab", () => {
         expect(plots.length).toBe(2);
         expect(plots.at(0)!.props("graphIndex")).toBe(0);
         expect(plots.at(0)!.props("fadePlot")).toBe(false);
-        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({autorange: true});
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({ autorange: true });
         expect(plots.at(1)!.props("graphIndex")).toBe(1);
         expect(plots.at(1)!.props("fadePlot")).toBe(false);
-        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({autorange: true});
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({ autorange: true });
 
         // Download button disabled because there is no model solution
         const downloadBtn = wrapper.find("button#download-btn");
@@ -175,14 +175,14 @@ describe("RunTab", () => {
     });
 
     it("propagates x axis changes to all run plots", async () => {
-       const wrapper = getWrapper();
-       const plots = wrapper.findAllComponents(RunPlot);
-       expect(plots.length).toBe(2);
-       const newXAxis = {autorange: false, range: [1, 10]};
-       plots.at(0)!.vm.$emit("updateXAxis", newXAxis);
-       await nextTick();
-       expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual(newXAxis);
-       expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual(newXAxis);
+        const wrapper = getWrapper();
+        const plots = wrapper.findAllComponents(RunPlot);
+        expect(plots.length).toBe(2);
+        const newXAxis = { autorange: false, range: [1, 10] };
+        plots.at(0)!.vm.$emit("updateXAxis", newXAxis);
+        await nextTick();
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual(newXAxis);
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual(newXAxis);
     });
 
     it("renders as expected when app is stochastic", () => {
@@ -196,10 +196,10 @@ describe("RunTab", () => {
         expect(plots.length).toBe(2);
         expect(plots.at(0)!.props("graphIndex")).toBe(0);
         expect(plots.at(0)!.props("fadePlot")).toBe(false);
-        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({autorange: true});
+        expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual({ autorange: true });
         expect(plots.at(1)!.props("graphIndex")).toBe(1);
         expect(plots.at(1)!.props("fadePlot")).toBe(false);
-        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({autorange: true});
+        expect(plots.at(1)!.props("linkedXAxis")).toStrictEqual({ autorange: true });
         expect(wrapper.findComponent(ActionRequiredMessage).props("message")).toBe("");
         expect(wrapper.findComponent(RunPlot).exists()).toBe(false);
         expect((wrapper.find("button#run-btn").element as HTMLButtonElement).disabled).toBe(false);
@@ -209,7 +209,7 @@ describe("RunTab", () => {
         const wrapper = getStochasticWrapper();
         const plots = wrapper.findAllComponents(RunStochasticPlot);
         expect(plots.length).toBe(2);
-        const newXAxis = {autorange: false, range: [1, 10]};
+        const newXAxis = { autorange: false, range: [1, 10] };
         plots.at(0)!.vm.$emit("updateXAxis", newXAxis);
         await nextTick();
         expect(plots.at(0)!.props("linkedXAxis")).toStrictEqual(newXAxis);

--- a/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
+++ b/app/static/tests/unit/components/sensitivity/sensitivitySummaryDownload.test.ts
@@ -86,6 +86,7 @@ describe("SensitivitySummaryDownload", () => {
                     state: mockGraphsState({
                         config: [
                             {
+                                id: "123",
                                 selectedVariables: ["S"],
                                 unselectedVariables: []
                             }

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -522,7 +522,7 @@ describe("WodinPlot", () => {
     });
 
     it("relayout emits updateXAxis event, if component has linked x axis and xaxis is in event", async () => {
-        const wrapper = getWrapper({ hasLinkedXAxis: true });
+        const wrapper = getWrapper({ linkedXAxis: { autorange: true } });
         const relayoutEvent = {
             "xaxis.autorange": false,
             "xaxis.range[0]": 2,
@@ -535,7 +535,7 @@ describe("WodinPlot", () => {
     });
 
     it("relayout does not emit updateXAxis event, if xaxis is not in event", async () => {
-        const wrapper = getWrapper({ hasLinkedXAxis: true });
+        const wrapper = getWrapper({ linkedXAxis: {autorange: true} });
         const relayoutEvent = {
             "yaxis.autorange": false,
             "yaxis.range[0]": 2,
@@ -548,7 +548,7 @@ describe("WodinPlot", () => {
     });
 
     it("update to linkedXAxis triggers relayout", async () => {
-        const wrapper = getWrapper({hasLInkedXAxis: true, linkedXAxis: {autorange: true}});
+        const wrapper = getWrapper({linkedXAxis: {autorange: true}});
         mockPlotElementOn(wrapper);
         wrapper.setProps({ linkedXAxis: { autorange: false, range: [4, 6] } });
         await nextTick();
@@ -564,7 +564,6 @@ describe("WodinPlot", () => {
 
     it("drawPlot uses linked x axis to generate data", async () => {
         const wrapper = getWrapper({
-            hasLinkedXAxis: true,
             linkedXAxis: { autorange: false, range: [3, 5] }
         });
         mockPlotElementOn(wrapper);

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -1,6 +1,4 @@
 // Mock the import of plotly so we can mock Plotly methods
-import {margin} from "../../../src/app/plot";
-
 jest.mock("plotly.js-basic-dist-min", () => ({
     newPlot: jest.fn(),
     react: jest.fn(),

--- a/app/static/tests/unit/components/wodinPlot.test.ts
+++ b/app/static/tests/unit/components/wodinPlot.test.ts
@@ -529,11 +529,11 @@ describe("WodinPlot", () => {
 
         const { relayout } = wrapper.vm as any;
         await relayout(relayoutEvent);
-        expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([{autorange: false, range: [2, 4]}]);
+        expect(wrapper.emitted("updateXAxis")![0]).toStrictEqual([{ autorange: false, range: [2, 4] }]);
     });
 
     it("relayout does not emit updateXAxis event, if xaxis is not in event", async () => {
-        const wrapper = getWrapper({ linkedXAxis: {autorange: true} });
+        const wrapper = getWrapper({ linkedXAxis: { autorange: true } });
         const relayoutEvent = {
             "yaxis.autorange": false,
             "yaxis.range[0]": 2,
@@ -546,7 +546,7 @@ describe("WodinPlot", () => {
     });
 
     it("update to linkedXAxis triggers relayout", async () => {
-        const wrapper = getWrapper({linkedXAxis: {autorange: true}});
+        const wrapper = getWrapper({ linkedXAxis: { autorange: true } });
         mockPlotElementOn(wrapper);
         wrapper.setProps({ linkedXAxis: { autorange: false, range: [4, 6] } });
         await nextTick();

--- a/app/static/tests/unit/serialiser.test.ts
+++ b/app/static/tests/unit/serialiser.test.ts
@@ -371,6 +371,7 @@ describe("serialise", () => {
         },
         config: [
             {
+                id: "123",
                 selectedVariables: ["S", "I"],
                 unselectedVariables: ["R"]
             }
@@ -709,8 +710,6 @@ describe("serialise", () => {
             openVisualisationTab: VisualisationTab.Fit,
             code: mockCodeState(),
             model: mockModelState({
-                selectedVariables: undefined,
-                unselectedVariables: undefined,
                 odinModelResponse: {
                     metadata: {
                         variables: ["S", "I", "R"]
@@ -736,12 +735,13 @@ describe("serialise", () => {
             sensitivity: {},
             fitData: {},
             modelFit: {},
-            graphs: defaultGraphsState,
+            graphs: defaultGraphsState(),
             versions: null
         } as any;
         deserialiseState(target, serialised);
         expect(target.graphs.config[0].selectedVariables).toStrictEqual(["S", "I", "R"]);
         expect(target.graphs.config[0].unselectedVariables).toStrictEqual([]);
+        expect(target.graphs.config[0].id.length).toBe(32);
     });
 
     it("deserialises default graph settings when undefined in serialised state", () => {
@@ -771,7 +771,7 @@ describe("serialise", () => {
             fitData: {},
             modelFit: {},
             versions: null,
-            graphs: defaultGraphsState
+            graphs: defaultGraphsState()
         } as any;
         // sanity check
         expect(target.graphs.settings.logScaleYAxis).toBe(false);

--- a/app/static/tests/unit/store/basic/basic.test.ts
+++ b/app/static/tests/unit/store/basic/basic.test.ts
@@ -2,7 +2,7 @@ import { localStorageManager } from "../../../../src/app/localStorageManager";
 
 jest.mock("../../../../src/app/utils", () => {
     return {
-        newSessionId: jest.fn().mockReturnValue("12345")
+        newUid: jest.fn().mockReturnValue("12345")
     };
 });
 

--- a/app/static/tests/unit/store/fit/fit.test.ts
+++ b/app/static/tests/unit/store/fit/fit.test.ts
@@ -2,7 +2,7 @@ import { localStorageManager } from "../../../../src/app/localStorageManager";
 
 jest.mock("../../../../src/app/utils", () => {
     return {
-        newSessionId: jest.fn().mockReturnValue("12345")
+        newUid: jest.fn().mockReturnValue("12345")
     };
 });
 

--- a/app/static/tests/unit/store/graphs/actions.test.ts
+++ b/app/static/tests/unit/store/graphs/actions.test.ts
@@ -84,9 +84,8 @@ describe("Graphs actions", () => {
         });
         expect(commit).toHaveBeenCalledTimes(1);
         expect(commit.mock.calls[0][0]).toBe(GraphsMutation.AddGraph);
-        expect(commit.mock.calls[0][1]).toStrictEqual({
-            selectedVariables: [],
-            unselectedVariables: ["b", "a", "c"]
-        });
+        expect(commit.mock.calls[0][1].selectedVariables).toStrictEqual([]);
+        expect(commit.mock.calls[0][1].unselectedVariables).toStrictEqual(["b", "a", "c"]);
+        expect(commit.mock.calls[0][1].id.length).toBe(32);
     });
 });

--- a/app/static/tests/unit/store/graphs/getters.test.ts
+++ b/app/static/tests/unit/store/graphs/getters.test.ts
@@ -6,7 +6,7 @@ describe("GraphsGetters", () => {
         const state = mockGraphsState({
             config: [
                 { id: "123", selectedVariables: ["a", "b"], unselectedVariables: ["c", "d"] },
-                { id: "456",selectedVariables: ["d"], unselectedVariables: ["a", "b", "c"] }
+                { id: "456", selectedVariables: ["d"], unselectedVariables: ["a", "b", "c"] }
             ]
         });
         expect((getters[GraphsGetter.allSelectedVariables] as any)(state)).toStrictEqual(["a", "b", "d"]);

--- a/app/static/tests/unit/store/graphs/getters.test.ts
+++ b/app/static/tests/unit/store/graphs/getters.test.ts
@@ -5,8 +5,8 @@ describe("GraphsGetters", () => {
     it("gets allSelectedVariables", () => {
         const state = mockGraphsState({
             config: [
-                { selectedVariables: ["a", "b"], unselectedVariables: ["c", "d"] },
-                { selectedVariables: ["d"], unselectedVariables: ["a", "b", "c"] }
+                { id: "123", selectedVariables: ["a", "b"], unselectedVariables: ["c", "d"] },
+                { id: "456",selectedVariables: ["d"], unselectedVariables: ["a", "b", "c"] }
             ]
         });
         expect((getters[GraphsGetter.allSelectedVariables] as any)(state)).toStrictEqual(["a", "b", "d"]);
@@ -26,5 +26,12 @@ describe("GraphsGetters", () => {
             }
         } as any;
         expect((getters[GraphsGetter.hiddenVariables] as any)({}, testGetters, rootState)).toStrictEqual(["e", "c"]);
+    });
+
+    it("gets legend width", () => {
+        const testGetters = {
+            allSelectedVariables: ["a", "zz", "a longer name"]
+        };
+        expect((getters[GraphsGetter.legendWidth] as any)({}, testGetters)).toBe(170);
     });
 });

--- a/app/static/tests/unit/store/graphs/mutations.test.ts
+++ b/app/static/tests/unit/store/graphs/mutations.test.ts
@@ -54,7 +54,7 @@ describe("Graphs mutations", () => {
         expect(testState.config).toStrictEqual([
             { id: "123", selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
             { id: "456", selectedVariables: [], unselectedVariables: ["b", "a", "c"] }
-        ])
+        ]);
     });
 
     it("DeleteGraph removes graph from config", () => {

--- a/app/static/tests/unit/store/graphs/mutations.test.ts
+++ b/app/static/tests/unit/store/graphs/mutations.test.ts
@@ -38,7 +38,11 @@ describe("Graphs mutations", () => {
             selectedVariables: ["x", "z"],
             unselectedVariables: ["y"]
         });
-        expect(testState.config[1]).toStrictEqual({ id: "456", selectedVariables: ["x", "z"], unselectedVariables: ["y"] });
+        expect(testState.config[1]).toStrictEqual({
+            id: "456",
+            selectedVariables: ["x", "z"],
+            unselectedVariables: ["y"]
+        });
         expect(testState.config[0]).toStrictEqual({ id: "123", selectedVariables: [], unselectedVariables: [] });
     });
 

--- a/app/static/tests/unit/store/graphs/mutations.test.ts
+++ b/app/static/tests/unit/store/graphs/mutations.test.ts
@@ -29,8 +29,8 @@ describe("Graphs mutations", () => {
     it("SetSelectedVariables sets selected and unselected variables", () => {
         const testState = mockGraphsState({
             config: [
-                { selectedVariables: [], unselectedVariables: [] },
-                { selectedVariables: [], unselectedVariables: [] }
+                { id: "123", selectedVariables: [], unselectedVariables: [] },
+                { id: "456", selectedVariables: [], unselectedVariables: [] }
             ]
         });
         mutations.SetSelectedVariables(testState, {
@@ -38,33 +38,33 @@ describe("Graphs mutations", () => {
             selectedVariables: ["x", "z"],
             unselectedVariables: ["y"]
         });
-        expect(testState.config[1]).toStrictEqual({ selectedVariables: ["x", "z"], unselectedVariables: ["y"] });
-        expect(testState.config[0]).toStrictEqual({ selectedVariables: [], unselectedVariables: [] });
+        expect(testState.config[1]).toStrictEqual({ id: "456", selectedVariables: ["x", "z"], unselectedVariables: ["y"] });
+        expect(testState.config[0]).toStrictEqual({ id: "123", selectedVariables: [], unselectedVariables: [] });
     });
 
     it("AddGraph pushes new graph to config", () => {
         const testState = mockGraphsState({
-            config: [{ selectedVariables: ["a"], unselectedVariables: ["b", "c"] }]
+            config: [{ id: "123", selectedVariables: ["a"], unselectedVariables: ["b", "c"] }]
         });
-        mutations.AddGraph(testState, { selectedVariables: [], unselectedVariables: ["b", "a", "c"] });
+        mutations.AddGraph(testState, { id: "456", selectedVariables: [], unselectedVariables: ["b", "a", "c"] });
         expect(testState.config).toStrictEqual([
-            { selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
-            { selectedVariables: [], unselectedVariables: ["b", "a", "c"] }
-        ]);
+            { id: "123", selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
+            { id: "456", selectedVariables: [], unselectedVariables: ["b", "a", "c"] }
+        ])
     });
 
     it("DeleteGraph removes graph from config", () => {
         const testState = mockGraphsState({
             config: [
-                { selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
-                { selectedVariables: ["b"], unselectedVariables: ["a", "c"] },
-                { selectedVariables: ["c"], unselectedVariables: ["a", "b"] }
+                { id: "1", selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
+                { id: "2", selectedVariables: ["b"], unselectedVariables: ["a", "c"] },
+                { id: "3", selectedVariables: ["c"], unselectedVariables: ["a", "b"] }
             ]
         });
         mutations.DeleteGraph(testState, 1);
         expect(testState.config).toStrictEqual([
-            { selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
-            { selectedVariables: ["c"], unselectedVariables: ["a", "b"] }
+            { id: "1", selectedVariables: ["a"], unselectedVariables: ["b", "c"] },
+            { id: "3", selectedVariables: ["c"], unselectedVariables: ["a", "b"] }
         ]);
     });
 });

--- a/app/static/tests/unit/store/stochastic/stochastic.test.ts
+++ b/app/static/tests/unit/store/stochastic/stochastic.test.ts
@@ -2,11 +2,11 @@ import { localStorageManager } from "../../../../src/app/localStorageManager";
 
 jest.mock("../../../../src/app/utils", () => {
     return {
-        newSessionId: jest.fn().mockReturnValue("12345")
+        newUid: jest.fn().mockReturnValue("12345")
     };
 });
 
-describe("basic", () => {
+describe("stochasic", () => {
     it("generates and saves sessionId", async () => {
         const { storeOptions } = await import("../../../../src/app/store/stochastic/stochastic");
         const state = storeOptions.state as any;

--- a/app/static/tests/unit/utils.test.ts
+++ b/app/static/tests/unit/utils.test.ts
@@ -4,7 +4,7 @@ import {
     generateBatchPars,
     getCodeErrorFromResponse,
     processFitData,
-    newSessionId,
+    newUid,
     joinStringsSentence
 } from "../../src/app/utils";
 import { SensitivityScaleType, SensitivityVariationType } from "../../src/app/store/sensitivity/state";
@@ -485,7 +485,7 @@ describe("generateBatchPars", () => {
 
 describe("newSessionId", () => {
     it("generates expected id format", () => {
-        const id = newSessionId();
+        const id = newUid();
         expect(id).toMatch(/^[a-z0-9]{32}$/);
     });
 });


### PR DESCRIPTION
This branch implements synchronising the x axes when there are multiple graphs on the Run Tab - in other words, when the user zooms in on one graph, changing the x axis zoom from the default, the other graphs should likewise zoom to the same x axis range, so the user can view values for all variables across the same time sub-range. 

The mechanism for doing this is through a shared `linkedXAxis` prop which is emitted to the parent tab, and propagated to all child graphs by updating the prop value. This prop is optional, as not all graphs have linked x axes (it's not yet in Sensitivity, and possibly won't ever be in Fit). 

I've lightly refactored the plot updating code, which was already a bit of a confusing tangle, and added some comments which I find meaningful, but let me know if that doesn't work for you! I have added a `lastYAxisFromZoom` value to the plot, which enables a previous Y-only zoom to be retained, across an x-axis emit and propagate.  This value will be overriden by locked y axis range, if any. 

Lock y axis currently behaves weirdly if you have multiple graphs because the final graph's current y axis range is used and propagates to the other graphs. This will be fixed in the next ticket when we have separate graph settings for each graph. 

We also set the right margin on the plot so that legend width is fixed for all graphs. We currently just use a heuristic to calculate a reasonable width from the maximum variable length. 

As mentioned in standup, I've added an id to the GraphConfig which can be used as a key for the plot component - this is so that the component and its internal state (particularly `lastYAxisFromZoom`) can be retained when an earlier plot is deleted (which is not the case if you just use the array index as the key). This id is a generated uid, which is not serialised (so that sessions which only differ by this id are correctly identified as duplicates). 

Some outstanding issues:
- Should we reset 'lastYAxisFromZoom' if add new variable to graph? i.e. should user's y-axis zoom selection be overridden when a new variable appears whose values may not intersect with the current y zoom?
- Unrelated to x axis, but something I've just noticed for Fit apps - after link, should we only render data points on graphs with data variable selected? (And only show sum of squares on that graph too?) Update: yes, we'll make a ticket to do this. 
- The 'reset axes` button currently resets the x axis but not the y axis. I think this is because we've deliberately remembered and specified the y range, and so we get that y range in the relayout event from the 'reset axes' button - whereas we actually want to go back to autorange for both axes. I think we can fix that by putting in a custom handler for that button - but I'd prefer to do that in another ticket. 
- Legend width is going to need tweaking for stochasitc, as that adds `(mean)` to some variable labels... It's also going to be wider than it needs to be for Fit potentially, which does not show all selected variables, only the linked ones. 

