### PR TITLE
mrc-5545 Do not show linked variables on graphs which are not showing those variables

### DIFF
--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -53,13 +53,14 @@ export default (
         const variable = dataTransfer!.getData("variable");
         const srcGraphConfig = dataTransfer!.getData("srcGraphConfig");
         if (srcGraphConfig !== thisSrcGraphConfig) {
-            if (srcGraphConfig !== "hidden") {
-                removeVariable(parseInt(srcGraphConfig, 10), variable);
-            }
-            // add to this graph if necessary
+            // add to this graph if necessary - do this before remove so it is not unlinked if linked variables
             if (!hasHiddenVariables && !selectedVariables.value.includes(variable)) {
                 const newVars = [...selectedVariables.value, variable];
                 updateSelectedVariables(graphIndex!, newVars);
+            }
+
+            if (srcGraphConfig !== "hidden") {
+                removeVariable(parseInt(srcGraphConfig, 10), variable);
             }
         }
     };

--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -53,7 +53,7 @@ export default (
         const variable = dataTransfer!.getData("variable");
         const srcGraphConfig = dataTransfer!.getData("srcGraphConfig");
         if (srcGraphConfig !== thisSrcGraphConfig) {
-            // add to this graph if necessary - do this before remove so it is not unlinked if linked variables
+            // add to this graph if necessary - do this before remove so, if a linked variable, it is not unlinked
             if (!hasHiddenVariables && !selectedVariables.value.includes(variable)) {
                 const newVars = [...selectedVariables.value, variable];
                 updateSelectedVariables(graphIndex!, newVars);

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -4,7 +4,9 @@
         :placeholder-message="placeholderMessage"
         :end-time="endTime"
         :plot-data="allPlotData"
-        :redrawWatches="solution ? [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames] : []"
+        :redrawWatches="solution ?
+              [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames, graphCount] :
+              []"
         :linked-x-axis="linkedXAxis"
         :fit-plot="false"
         :graph-index="graphIndex"
@@ -68,6 +70,9 @@ const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData
 
 const selectedVariables = computed(() => props.graphConfig.selectedVariables);
 const placeholderMessage = computed(() => runPlaceholderMessage(selectedVariables.value, false));
+
+// TODO: put this in the composable in mrc-5572
+const graphCount = computed(() => store.state.graphs.config.length);
 
 const allPlotData = (start: number, end: number, points: number): WodinPlotData => {
     const options = {

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -85,7 +85,7 @@ const allPlotData = (start: number, end: number, points: number): WodinPlotData 
     const plotOptions = { showLegend: true, includeLegendGroup: true };
     const allData = [
         ...odinToPlotly(filterSeriesSet(result, selectedVariables.value), palette.value, plotOptions),
-        ...allFitDataToPlotly(allFitData.value, palette.value, start, end)
+        ...allFitDataToPlotly(allFitData.value, palette.value, start, end, props.graphConfig.selectedVariables)
     ];
 
     // 2. Parameter sets

--- a/app/static/src/app/components/run/RunPlot.vue
+++ b/app/static/src/app/components/run/RunPlot.vue
@@ -4,9 +4,9 @@
         :placeholder-message="placeholderMessage"
         :end-time="endTime"
         :plot-data="allPlotData"
-        :redrawWatches="solution ?
-              [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames, graphCount] :
-              []"
+        :redrawWatches="
+            solution ? [solution, allFitData, selectedVariables, parameterSetSolutions, displayNames, graphCount] : []
+        "
         :linked-x-axis="linkedXAxis"
         :fit-plot="false"
         :graph-index="graphIndex"

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -25,7 +25,7 @@
             </run-plot>
         </template>
         <div v-if="sumOfSquares">
-          <span>Sum of squares: {{ sumOfSquares }}</span>
+          <span id="squares">Sum of squares: {{ sumOfSquares }}</span>
         </div>
         <error-info :error="error"></error-info>
         <div>

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -22,11 +22,11 @@
                 :linked-x-axis="xAxis"
                 @updateXAxis="updateXAxis"
             >
-                <div v-if="sumOfSquares">
-                    <span>Sum of squares: {{ sumOfSquares }}</span>
-                </div>
             </run-plot>
         </template>
+        <div v-if="sumOfSquares">
+          <span>Sum of squares: {{ sumOfSquares }}</span>
+        </div>
         <error-info :error="error"></error-info>
         <div>
             <button

--- a/app/static/src/app/components/run/RunTab.vue
+++ b/app/static/src/app/components/run/RunTab.vue
@@ -25,7 +25,7 @@
             </run-plot>
         </template>
         <div v-if="sumOfSquares">
-          <span id="squares">Sum of squares: {{ sumOfSquares }}</span>
+            <span id="squares">Sum of squares: {{ sumOfSquares }}</span>
         </div>
         <error-info :error="error"></error-info>
         <div>

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -200,7 +200,8 @@ export default defineComponent({
                 });
 
                 if (allFitData.value) {
-                    result.push(...allFitDataToPlotly(allFitData.value, palette.value, start, end));
+                    result.push(
+                        ...allFitDataToPlotly(allFitData.value, palette.value, start, end, props.graphConfig.selectedVariables));
                 }
             }
 

--- a/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
+++ b/app/static/src/app/components/sensitivity/SensitivityTracesPlot.vue
@@ -201,7 +201,14 @@ export default defineComponent({
 
                 if (allFitData.value) {
                     result.push(
-                        ...allFitDataToPlotly(allFitData.value, palette.value, start, end, props.graphConfig.selectedVariables));
+                        ...allFitDataToPlotly(
+                            allFitData.value,
+                            palette.value,
+                            start,
+                            end,
+                            props.graphConfig.selectedVariables
+                        )
+                    );
                 }
             }
 

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -155,8 +155,8 @@ export function allFitDataToPlotly(
         let color = palette[name];
         const variable = linkedVariables[name];
         if (variable) {
-            // If there is a linked variable, only show data if the variable is selected - if not selected, render the series,
-            // but as transparent so that all graph x axes are consistent
+            // If there is a linked variable, only show data if the variable is selected - if not selected, render the
+            // series, but as transparent so that all graph x axes are consistent
             color = selectedVariables.includes(variable) ? paletteModel[variable] : "transparent";
         }
         return {

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -148,23 +148,30 @@ export function allFitDataToPlotly(
         return [];
     }
     const { data, linkedVariables, timeVariable } = allFitData;
-    console.log("linked variables")
-    console.log(JSON.stringify(linkedVariables))
     const filteredData = filterData(data, timeVariable, start, end);
     const palette = paletteData(Object.keys(linkedVariables));
-    // Display column data if it is not linked OR if its linked variable is selected
-    const columns = Object.keys(linkedVariables)
-        .filter((column) => !linkedVariables[column] || selectedVariables.includes(linkedVariables[column]!));
-    return columns.map((name: string) => ({
-        name,
-        x: filteredData.map((row: Dict<number>) => row[timeVariable]),
-        y: filteredData.map((row: Dict<number>) => row[name]),
-        mode: "markers",
-        type: "scatter",
-        marker: {
-            color: linkedVariables[name] ? paletteModel[linkedVariables[name]!] : palette[name]
+
+    return Object.keys(linkedVariables).map((name: string) => {
+        // Display column data if it is not linked OR if its linked variable is selected - render the series, but as
+        // transparent so that all graph x axes match
+        let color = palette[name];
+        const variable = linkedVariables[name];
+        if (variable) {
+            // If there is a linked variable, only show data if the variable is selected - if not ,render the series,
+            // but as transparent so that all graph x axes match
+            color = selectedVariables.includes(variable) ? paletteModel[variable] : "transparent";
         }
-    }));
+        return {
+            name,
+            x: filteredData.map((row: Dict<number>) => row[timeVariable]),
+            y: filteredData.map((row: Dict<number>) => row[name]),
+            mode: "markers",
+            type: "scatter",
+            marker: {
+                color
+            }
+        };
+    });
 }
 
 const lineStyles = ["dot", "dash", "longdash", "dashdot", "longdashdot"];

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -156,7 +156,7 @@ export function allFitDataToPlotly(
         const variable = linkedVariables[name];
         if (variable) {
             // If there is a linked variable, only show data if the variable is selected - if not ,render the series,
-            // but as transparent so that all graph x axes match
+            // but as transparent so that all graph x axes are consistent
             color = selectedVariables.includes(variable) ? paletteModel[variable] : "transparent";
         }
         return {

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -155,7 +155,7 @@ export function allFitDataToPlotly(
         let color = palette[name];
         const variable = linkedVariables[name];
         if (variable) {
-            // If there is a linked variable, only show data if the variable is selected - if not ,render the series,
+            // If there is a linked variable, only show data if the variable is selected - if not selected, render the series,
             // but as transparent so that all graph x axes are consistent
             color = selectedVariables.includes(variable) ? paletteModel[variable] : "transparent";
         }

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -152,8 +152,6 @@ export function allFitDataToPlotly(
     const palette = paletteData(Object.keys(linkedVariables));
 
     return Object.keys(linkedVariables).map((name: string) => {
-        // Display column data if it is not linked OR if its linked variable is selected - render the series, but as
-        // transparent so that all graph x axes match
         let color = palette[name];
         const variable = linkedVariables[name];
         if (variable) {

--- a/app/static/src/app/plot.ts
+++ b/app/static/src/app/plot.ts
@@ -141,15 +141,21 @@ export function allFitDataToPlotly(
     allFitData: AllFitData | null,
     paletteModel: Palette,
     start: number,
-    end: number
+    end: number,
+    selectedVariables: string[]
 ): WodinPlotData {
     if (!allFitData) {
         return [];
     }
     const { data, linkedVariables, timeVariable } = allFitData;
+    console.log("linked variables")
+    console.log(JSON.stringify(linkedVariables))
     const filteredData = filterData(data, timeVariable, start, end);
     const palette = paletteData(Object.keys(linkedVariables));
-    return Object.keys(linkedVariables).map((name: string) => ({
+    // Display column data if it is not linked OR if its linked variable is selected
+    const columns = Object.keys(linkedVariables)
+        .filter((column) => !linkedVariables[column] || selectedVariables.includes(linkedVariables[column]!));
+    return columns.map((name: string) => ({
         name,
         x: filteredData.map((row: Dict<number>) => row[timeVariable]),
         y: filteredData.map((row: Dict<number>) => row[name]),

--- a/app/static/tests/e2e/fit.etest.ts
+++ b/app/static/tests/e2e/fit.etest.ts
@@ -1,11 +1,14 @@
-import {expect, test, Page, Locator} from "@playwright/test";
+import { expect, test, Page, Locator } from "@playwright/test";
 import {
     newFitCode,
     uploadCSVData,
     writeCode,
     startModelFit,
     waitForModelFitCompletion,
-    realisticFitData, linkData, addGraphWithVariable, expectWodinPlotDataSummary
+    realisticFitData,
+    linkData,
+    addGraphWithVariable,
+    expectWodinPlotDataSummary
 } from "./utils";
 import PlaywrightConfig from "../../playwright.config";
 
@@ -346,8 +349,8 @@ test.describe("Wodin App model fit tests", () => {
     });
 
     const expectDataSummaryOnGraph = async (graph: Locator, dataSummaryIdx: number, dataColor: string) => {
-        const dataSummaryLocator = await graph.locator(`:nth-match(.wodin-plot-data-summary-series, ${dataSummaryIdx})`);
-        await expectWodinPlotDataSummary(dataSummaryLocator, "Cases", 32, 0, 31, 0, 13, "markers", null, dataColor );
+        const summaryLocator = await graph.locator(`:nth-match(.wodin-plot-data-summary-series, ${dataSummaryIdx})`);
+        await expectWodinPlotDataSummary(summaryLocator, "Cases", 32, 0, 31, 0, 13, "markers", null, dataColor);
     };
 
     test("data is displayed as expected with multiple graphs", async ({ page }) => {

--- a/app/static/tests/e2e/sensitivity.etest.ts
+++ b/app/static/tests/e2e/sensitivity.etest.ts
@@ -104,7 +104,7 @@ test.describe("Sensitivity tests", () => {
         await expect(await page.innerText(".sensitivity-tab .plot-placeholder")).toBe("Sensitivity has not been run.");
 
         // run and see all traces
-        page.click("#run-sens-btn");
+        await page.click("#run-sens-btn");
         const linesSelector = `${plotSelector} .scatterlayer .trace .lines path`;
         expect((await page.locator(`:nth-match(${linesSelector}, 30)`).getAttribute("d"))!.startsWith("M0")).toBe(true);
 

--- a/app/static/tests/e2e/utils.ts
+++ b/app/static/tests/e2e/utils.ts
@@ -81,20 +81,22 @@ export const writeCode = async (page: Page, code: string) => {
     await page.fill(".monaco-editor textarea", code);
 };
 
+export const linkData = async (page: Page) => {
+    const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
+    const select1 = await linkContainer.locator(":nth-match(select, 1)");
+    await select1.selectOption("I");
+};
+
 export const startModelFit = async (page: Page, data: string = realisticFitData) => {
     // Upload data
     await uploadCSVData(page, data);
     await page.click(":nth-match(.wodin-right .nav-tabs a, 2)");
 
-    // link variables
     await page.click(":nth-match(.wodin-left .nav-tabs a, 3)");
     await expect(await page.innerText("#optimisation")).toBe(
         "Please link at least one column in order to set target to fit."
     );
-    const linkContainer = await page.locator(":nth-match(.collapse .container, 1)");
-    const select1 = await linkContainer.locator(":nth-match(select, 1)");
-    await select1.selectOption("I");
-
+    await linkData(page);
     await expect(await page.innerText("#optimisation label#target-fit-label")).toBe("Cases ~ I");
 
     // select param to vary

--- a/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
+++ b/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
@@ -120,11 +120,11 @@ describe("GraphConfig", () => {
         const dropPanel = wrapper.find(".graph-config-panel");
         await dropPanel.trigger("drop", { dataTransfer });
         expect(mockUpdateSelectedVariables.mock.calls.length).toBe(2);
-        expect(mockUpdateSelectedVariables.mock.calls[0][1]).toStrictEqual({ graphIndex: 1, selectedVariables: ["J"] });
-        expect(mockUpdateSelectedVariables.mock.calls[1][1]).toStrictEqual({
+        expect(mockUpdateSelectedVariables.mock.calls[0][1]).toStrictEqual({
             graphIndex: 0,
             selectedVariables: ["S", "R", "I"]
         });
+        expect(mockUpdateSelectedVariables.mock.calls[1][1]).toStrictEqual({ graphIndex: 1, selectedVariables: ["J"] });
     });
 
     it("onDrop does not attempt to remove variable if source was hidden variables", async () => {

--- a/app/static/tests/unit/components/run/runPlot.test.ts
+++ b/app/static/tests/unit/components/run/runPlot.test.ts
@@ -153,7 +153,8 @@ describe("RunPlot", () => {
             mockAllFitData,
             selectedVariables,
             {},
-            ["Hey", "Bye"]
+            ["Hey", "Bye"],
+            1
         ]);
         expect(wodinPlot.props("linkedXAxis")).toStrictEqual(linkedXAxis);
 
@@ -292,7 +293,8 @@ describe("RunPlot", () => {
             mockAllFitData,
             selectedVariables,
             { Set1: mockParamSetResult1.solution, Set2: mockParamSetResult2.solution },
-            ["rand1", "rand2", "rand3"]
+            ["rand1", "rand2", "rand3"],
+            1
         ]);
 
         // Generates expected plot data from model
@@ -517,7 +519,8 @@ describe("RunPlot", () => {
             mockAllFitData,
             selectedVariables,
             {},
-            ["Hey", "Bye"]
+            ["Hey", "Bye"],
+            1
         ]);
 
         // Generates expected plot data from model

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -8,7 +8,14 @@ import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import { BasicState } from "../../../../src/app/store/basic/state";
-import { mockBasicState, mockGraphsState, mockModelState, mockRunState, mockStochasticState } from "../../../mocks";
+import {
+    mockBasicState,
+    mockFitState,
+    mockGraphsState, mockModelFitState,
+    mockModelState,
+    mockRunState,
+    mockStochasticState
+} from "../../../mocks";
 import { ModelState } from "../../../../src/app/store/model/state";
 import { RunState } from "../../../../src/app/store/run/state";
 import RunTab from "../../../../src/app/components/run/RunTab.vue";
@@ -26,6 +33,7 @@ import { AppType } from "../../../../src/app/store/appState/state";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
 import { RunAction } from "../../../../src/app/store/run/actions";
 import { getters as graphGetters } from "../../../../src/app/store/graphs/getters";
+import {FitState} from "../../../../src/app/store/fit/state";
 
 describe("RunTab", () => {
     const defaultModelState = {
@@ -144,6 +152,35 @@ describe("RunTab", () => {
         });
     };
 
+    const getFitWrapper = () => {
+        const store = new Vuex.Store<FitState>({
+            state: mockFitState(),
+            modules: {
+                graphs: {
+                    namespaced: true,
+                    state: mockGraphsState({
+                        config: [
+                            { id: "123", selectedVariables: ["S"], unselectedVariables: [] },
+                            { id: "456", selectedVariables: [], unselectedVariables: [] }
+                        ]
+                    } as any),
+                    getters: graphGetters
+                },
+                modelFit: {
+                    namespaced: true,
+                    state: mockModelFitState({
+                        sumOfSquares: 21.2
+                    })
+                }
+            }
+        });
+        return shallowMount(RunTab, {
+            global: {
+                plugins: [store]
+            }
+        });
+    };
+
     it("renders as expected when can run model", () => {
         const runState = { ...defaultRunState, userDownloadFileName: "test.xlsx" };
         const wrapper = getWrapper(defaultModelState, runState);
@@ -182,6 +219,12 @@ describe("RunTab", () => {
 
         expect(wrapper.find("#downloading").exists()).toBe(false);
         expect(wrapper.findComponent(RunStochasticPlot).exists()).toBe(false);
+    });
+
+    it("renders sumOfSquares for Fit app", () => {
+        const wrapper = getFitWrapper();
+        expect(wrapper.findAll("#squares").length).toBe(1);
+        expect(wrapper.find("#squares").text()).toBe("Sum of squares: 21.2");
     });
 
     it("propagates x axis changes to all run plots", async () => {

--- a/app/static/tests/unit/components/run/runTab.test.ts
+++ b/app/static/tests/unit/components/run/runTab.test.ts
@@ -11,7 +11,8 @@ import { BasicState } from "../../../../src/app/store/basic/state";
 import {
     mockBasicState,
     mockFitState,
-    mockGraphsState, mockModelFitState,
+    mockGraphsState,
+    mockModelFitState,
     mockModelState,
     mockRunState,
     mockStochasticState
@@ -33,7 +34,7 @@ import { AppType } from "../../../../src/app/store/appState/state";
 import { RunMutation } from "../../../../src/app/store/run/mutations";
 import { RunAction } from "../../../../src/app/store/run/actions";
 import { getters as graphGetters } from "../../../../src/app/store/graphs/getters";
-import {FitState} from "../../../../src/app/store/fit/state";
+import { FitState } from "../../../../src/app/store/fit/state";
 
 describe("RunTab", () => {
     const defaultModelState = {

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -114,7 +114,7 @@ describe("allFitDataToPlotly", () => {
     };
 
     it("creates unlinked data", () => {
-        const res = allFitDataToPlotly(allFitData, palette, 0, 4);
+        const res = allFitDataToPlotly(allFitData, palette, 0, 4, ["B"]);
         expect(res).toStrictEqual([
             {
                 marker: { color: "#1c0a00" }, // first data colour
@@ -136,12 +136,12 @@ describe("allFitDataToPlotly", () => {
     });
 
     it("returns empty set if data missing", () => {
-        const res = allFitDataToPlotly(null, palette, 0, 4);
+        const res = allFitDataToPlotly(null, palette, 0, 4, ["B"]);
         expect(res).toStrictEqual([]);
     });
 
     it("filters data by time", () => {
-        const res = allFitDataToPlotly(allFitData, palette, 1, 3);
+        const res = allFitDataToPlotly(allFitData, palette, 1, 3, ["B"]);
         expect(res).toStrictEqual([
             {
                 marker: { color: "#1c0a00" },
@@ -168,7 +168,8 @@ describe("allFitDataToPlotly", () => {
             linkedVariables: { a: null, b: "B" },
             timeVariable: "t"
         };
-        const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4);
+        const selectedVariables = ["A", "B"];
+        const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4, selectedVariables);
         expect(res).toStrictEqual([
             {
                 marker: { color: "#1c0a00" }, // first data colour
@@ -187,6 +188,24 @@ describe("allFitDataToPlotly", () => {
                 y: [2, 4, 6, 8, 10]
             }
         ]);
+    });
+
+    it("adds transparent data for unselected variable", () => {
+        const allFitDataLinked = {
+            data,
+            linkedVariables: { a: null, b: "B" },
+            timeVariable: "t"
+        };
+        const selectedVariables = ["A"];
+        const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4, selectedVariables);
+        expect(res[1]).toStrictEqual({
+                marker: { color: "transparent" }, // Model colour
+                mode: "markers",
+                name: "b",
+                type: "scatter",
+                x: [0, 1, 2, 3, 4],
+                y: [2, 4, 6, 8, 10]
+            });
     });
 });
 

--- a/app/static/tests/unit/plot.test.ts
+++ b/app/static/tests/unit/plot.test.ts
@@ -199,13 +199,13 @@ describe("allFitDataToPlotly", () => {
         const selectedVariables = ["A"];
         const res = allFitDataToPlotly(allFitDataLinked, palette, 0, 4, selectedVariables);
         expect(res[1]).toStrictEqual({
-                marker: { color: "transparent" }, // Model colour
-                mode: "markers",
-                name: "b",
-                type: "scatter",
-                x: [0, 1, 2, 3, 4],
-                y: [2, 4, 6, 8, 10]
-            });
+            marker: { color: "transparent" }, // Model colour
+            mode: "markers",
+            name: "b",
+            type: "scatter",
+            x: [0, 1, 2, 3, 4],
+            y: [2, 4, 6, 8, 10]
+        });
     });
 });
 


### PR DESCRIPTION
When fit data is linked to a variable, we only render the data points on a graph if the variable is selected on that graph. If the data is unlinked, we display it on all graphs. 

Also, only show 'Sum of squares' value once, after all graphs - could have put it after the relevant graph(s) only (with the linked value selected), but this seems more straightforward.

Also includes an opportunistic bug fix in `onDrop` in `selectVariables` - if a linked variable was dragged from one graph to another, it was being unlinked because we only allow selected variables (ie selected in at least one graph) to be linked. Previously we were removing the dragged variable from the first graph before adding it to the second, triggering its unlinking. Now we add before remove to avoid this. 

I also learned (thanks to failing e2e test!) that the RunPlot does indeed now need to have `graphCount` as a redraw watch, in common with the other plots, so I added that too. 