### PR TITLE
mrc-5443 Copy variable on drag if Ctrl key is pressed

### DIFF
--- a/app/static/src/app/components/graphConfig/GraphConfig.vue
+++ b/app/static/src/app/components/graphConfig/GraphConfig.vue
@@ -26,7 +26,7 @@
                 </span>
             </template>
             <div v-if="!selectedVariables.length" class="drop-zone-instruction p-2 me-4">
-                Drag variables here to select them for this graph. Press the Ctrl key on drag to make a copy of a
+                Drag variables here to select them for this graph. Press the Ctrl or ⌘ key on drag to make a copy of a
                 variable.
             </div>
         </div>

--- a/app/static/src/app/components/graphConfig/GraphConfig.vue
+++ b/app/static/src/app/components/graphConfig/GraphConfig.vue
@@ -27,6 +27,7 @@
             </template>
             <div v-if="!selectedVariables.length" class="drop-zone-instruction p-2 me-4">
                 Drag variables here to select them for this graph.
+                Press the Ctrl key on drag to make a copy of a variable.
             </div>
         </div>
     </div>

--- a/app/static/src/app/components/graphConfig/GraphConfig.vue
+++ b/app/static/src/app/components/graphConfig/GraphConfig.vue
@@ -26,8 +26,8 @@
                 </span>
             </template>
             <div v-if="!selectedVariables.length" class="drop-zone-instruction p-2 me-4">
-                Drag variables here to select them for this graph.
-                Press the Ctrl key on drag to make a copy of a variable.
+                Drag variables here to select them for this graph. Press the Ctrl key on drag to make a copy of a
+                variable.
             </div>
         </div>
     </div>

--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -19,8 +19,8 @@ export default (
     const thisSrcGraphConfig = hasHiddenVariables ? "hidden" : graphIndex!.toString();
 
     const startDrag = (evt: DragEvent, variable: string) => {
-        const { dataTransfer, ctrlKey } = evt;
-        const copy = !hasHiddenVariables && ctrlKey;
+        const { dataTransfer, ctrlKey, metaKey } = evt;
+        const copy = !hasHiddenVariables && (ctrlKey || metaKey);
         dataTransfer!.dropEffect = "move";
         dataTransfer!.effectAllowed = "move";
         dataTransfer!.setData("variable", variable);

--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -19,8 +19,8 @@ export default (
     const thisSrcGraphConfig = hasHiddenVariables ? "hidden" : graphIndex!.toString();
 
     const startDrag = (evt: DragEvent, variable: string) => {
-        const { dataTransfer } = evt;
-        const copy = !hasHiddenVariables && evt.ctrlKey;
+        const { dataTransfer, ctrlKey } = evt;
+        const copy = !hasHiddenVariables && ctrlKey;
         dataTransfer!.dropEffect = "move";
         dataTransfer!.effectAllowed = "move";
         dataTransfer!.setData("variable", variable);
@@ -64,7 +64,17 @@ export default (
             }
 
             if (srcGraphConfig !== "hidden" && !copy) {
-                removeVariable(parseInt(srcGraphConfig, 10), variable);
+                // Remove variable from all graphs where it occurs if this is HiddenVariables, otherwise from source
+                // graph only
+                if (hasHiddenVariables) {
+                    store.state.graphs.config.forEach((config, index) => {
+                        if (config.selectedVariables.includes(variable)) {
+                            removeVariable(index, variable);
+                        }
+                    });
+                } else {
+                    removeVariable(parseInt(srcGraphConfig, 10), variable);
+                }
             }
         }
     };

--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -18,8 +18,8 @@ export default (
 ): SelectVariablesMixin => {
     const thisSrcGraphConfig = hasHiddenVariables ? "hidden" : graphIndex!.toString();
 
-    const startDrag = (evt: DragEvent, variable: string) => {
-        const { dataTransfer, ctrlKey, metaKey } = evt;
+    const startDrag = (event: DragEvent, variable: string) => {
+        const { dataTransfer, ctrlKey, metaKey } = event;
         const copy = !hasHiddenVariables && (ctrlKey || metaKey);
         dataTransfer!.dropEffect = "move";
         dataTransfer!.effectAllowed = "move";

--- a/app/static/src/app/components/mixins/selectVariables.ts
+++ b/app/static/src/app/components/mixins/selectVariables.ts
@@ -20,10 +20,12 @@ export default (
 
     const startDrag = (evt: DragEvent, variable: string) => {
         const { dataTransfer } = evt;
+        const copy = !hasHiddenVariables && evt.ctrlKey;
         dataTransfer!.dropEffect = "move";
         dataTransfer!.effectAllowed = "move";
         dataTransfer!.setData("variable", variable);
         dataTransfer!.setData("srcGraphConfig", thisSrcGraphConfig);
+        dataTransfer!.setData("copyVar", copy.toString());
 
         emit("setDragging", true);
     };
@@ -53,13 +55,15 @@ export default (
         const variable = dataTransfer!.getData("variable");
         const srcGraphConfig = dataTransfer!.getData("srcGraphConfig");
         if (srcGraphConfig !== thisSrcGraphConfig) {
+            const copy = !hasHiddenVariables && dataTransfer!.getData("copyVar") === "true";
+
             // add to this graph if necessary - do this before remove so, if a linked variable, it is not unlinked
             if (!hasHiddenVariables && !selectedVariables.value.includes(variable)) {
                 const newVars = [...selectedVariables.value, variable];
                 updateSelectedVariables(graphIndex!, newVars);
             }
 
-            if (srcGraphConfig !== "hidden") {
+            if (srcGraphConfig !== "hidden" && !copy) {
                 removeVariable(parseInt(srcGraphConfig, 10), variable);
             }
         }

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -330,7 +330,7 @@ test.describe("Code Tab tests", () => {
             sourcePosition: { x: 5, y: 5 },
             targetPosition: { x: 5, y: 5 }
         };
-        await sVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"), dragPositions );
+        await sVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"), dragPositions);
 
         await expectGraphVariables(page, 0, ["I", "R"]);
         await expectGraphVariables(page, 1, ["S"]);

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -312,7 +312,7 @@ test.describe("Code Tab tests", () => {
         await expectGraphVariables(page, 0, ["I", "R"]);
     });
 
-    test("can add a graph, drag a variable onto it and delete it", async ({ page }) => {
+    test("can add a graph, drag variables onto it and delete it", async ({ page }) => {
         // Add graph
         await page.click("#add-graph-btn");
 
@@ -331,6 +331,14 @@ test.describe("Code Tab tests", () => {
         await expectGraphVariables(page, 0, ["I", "R"]);
         await expectGraphVariables(page, 1, ["S"]);
         await expect(page.locator(".hidden-variables-panel .variable")).toHaveCount(0);
+
+        // Drag a variable with Ctrl key to make copy
+        const iVariable = await page.locator(":nth-match(.graph-config-panel .variable, 1)");
+        await page.keyboard.down("Control");
+        await iVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"));
+        await page.keyboard.up("Control");
+        await expectGraphVariables(page, 0, ["R"]);
+        await expectGraphVariables(page, 1, ["S", "I"]);
 
         // Delete second graph
         await page.click(":nth-match(.graph-config-panel .delete-graph, 2)");

--- a/app/static/tests/e2e/code.etest.ts
+++ b/app/static/tests/e2e/code.etest.ts
@@ -326,7 +326,11 @@ test.describe("Code Tab tests", () => {
 
         // Drag variable to second graph
         const sVariable = await page.locator(":nth-match(.graph-config-panel .variable, 1)");
-        await sVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"));
+        const dragPositions = {
+            sourcePosition: { x: 5, y: 5 },
+            targetPosition: { x: 5, y: 5 }
+        };
+        await sVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"), dragPositions );
 
         await expectGraphVariables(page, 0, ["I", "R"]);
         await expectGraphVariables(page, 1, ["S"]);
@@ -335,9 +339,9 @@ test.describe("Code Tab tests", () => {
         // Drag a variable with Ctrl key to make copy
         const iVariable = await page.locator(":nth-match(.graph-config-panel .variable, 1)");
         await page.keyboard.down("Control");
-        await iVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"));
+        await iVariable.dragTo(page.locator(":nth-match(.graph-config-panel .drop-zone, 2)"), dragPositions);
         await page.keyboard.up("Control");
-        await expectGraphVariables(page, 0, ["R"]);
+        await expectGraphVariables(page, 0, ["I", "R"]);
         await expectGraphVariables(page, 1, ["S", "I"]);
 
         // Delete second graph

--- a/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
+++ b/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
@@ -93,7 +93,7 @@ describe("GraphConfig", () => {
         const wrapper = getWrapper();
         const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
         const setData = jest.fn();
-        await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: false });
+        await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: false, metaKey: false });
         expect(setData.mock.calls[0][0]).toBe("variable");
         expect(setData.mock.calls[0][1]).toStrictEqual("S");
         expect(setData.mock.calls[1][0]).toStrictEqual("srcGraphConfig");
@@ -107,7 +107,16 @@ describe("GraphConfig", () => {
         const wrapper = getWrapper();
         const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
         const setData = jest.fn();
-        await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: true });
+        await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: true, metaKey: false });
+        expect(setData.mock.calls[2][0]).toBe("copyVar");
+        expect(setData.mock.calls[2][1]).toBe("true");
+    });
+
+    it("start drag sets values copyVar to true in event when meta key pressed", async () => {
+        const wrapper = getWrapper();
+        const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
+        const setData = jest.fn();
+        await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: false, metaKey: true });
         expect(setData.mock.calls[2][0]).toBe("copyVar");
         expect(setData.mock.calls[2][1]).toBe("true");
     });
@@ -200,7 +209,7 @@ describe("GraphConfig", () => {
         } as any);
         expect(wrapper.find(".drop-zone-instruction").text()).toBe(
             "Drag variables here to select them for this graph. " +
-                "Press the Ctrl key on drag to make a copy of a variable."
+                "Press the Ctrl or ⌘ key on drag to make a copy of a variable."
         );
     });
 

--- a/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
+++ b/app/static/tests/unit/components/graphConfig/graphConfig.test.ts
@@ -94,13 +94,9 @@ describe("GraphConfig", () => {
         const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
         const setData = jest.fn();
         await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: false, metaKey: false });
-        expect(setData.mock.calls[0][0]).toBe("variable");
-        expect(setData.mock.calls[0][1]).toStrictEqual("S");
-        expect(setData.mock.calls[1][0]).toStrictEqual("srcGraphConfig");
-        expect(setData.mock.calls[1][1]).toStrictEqual("0");
-        expect(setData.mock.calls[2][0]).toBe("copyVar");
-        expect(setData.mock.calls[2][1]).toBe("false");
-        expect(wrapper.emitted("setDragging")![0]).toStrictEqual([true]);
+        expect(setData).toHaveBeenNthCalledWith(1, "variable", "S");
+        expect(setData).toHaveBeenNthCalledWith(2, "srcGraphConfig", "0");
+        expect(setData).toHaveBeenNthCalledWith(3, "copyVar", "false");
     });
 
     it("start drag sets values copyVar to true in event when Ctrl key pressed", async () => {
@@ -108,8 +104,7 @@ describe("GraphConfig", () => {
         const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
         const setData = jest.fn();
         await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: true, metaKey: false });
-        expect(setData.mock.calls[2][0]).toBe("copyVar");
-        expect(setData.mock.calls[2][1]).toBe("true");
+        expect(setData).toHaveBeenNthCalledWith(3, "copyVar", "true");
     });
 
     it("start drag sets values copyVar to true in event when meta key pressed", async () => {
@@ -117,8 +112,7 @@ describe("GraphConfig", () => {
         const s = wrapper.findAll(".graph-config-panel .badge").at(0)!;
         const setData = jest.fn();
         await s.trigger("dragstart", { dataTransfer: { setData }, ctrlKey: false, metaKey: true });
-        expect(setData.mock.calls[2][0]).toBe("copyVar");
-        expect(setData.mock.calls[2][1]).toBe("true");
+        expect(setData).toHaveBeenNthCalledWith(3, "copyVar", "true");
     });
 
     it("ending drag emits setDragging", async () => {
@@ -148,13 +142,13 @@ describe("GraphConfig", () => {
         expect(mockUpdateSelectedVariables.mock.calls[1][1]).toStrictEqual({ graphIndex: 1, selectedVariables: ["J"] });
     });
 
-    it("onDrop does not attempt to remove variable if source was hidden variables", async () => {
+    it("onDrop does not attempt to remove variable if source is hidden, even with Ctrl key", async () => {
         const wrapper = getWrapper();
         const dataTransfer = {
             getData: (s: string) => {
                 if (s === "variable") return "I";
                 if (s === "srcGraphConfig") return "hidden";
-                if (s === "copyVar") return "false";
+                if (s === "copyVar") return "true";
                 return null;
             }
         };

--- a/app/static/tests/unit/components/graphConfig/hiddenVariables.test.ts
+++ b/app/static/tests/unit/components/graphConfig/hiddenVariables.test.ts
@@ -33,6 +33,9 @@ describe("HiddenVariables", () => {
                         config: [
                             {
                                 selectedVariables: ["S", "J"]
+                            },
+                            {
+                                selectedVariables: ["S"]
                             }
                         ]
                     },
@@ -88,6 +91,8 @@ describe("HiddenVariables", () => {
         expect(setData.mock.calls[0][1]).toStrictEqual("I");
         expect(setData.mock.calls[1][0]).toStrictEqual("srcGraphConfig");
         expect(setData.mock.calls[1][1]).toStrictEqual("hidden");
+        expect(setData.mock.calls[2][0]).toStrictEqual("copyVar");
+        expect(setData.mock.calls[2][1]).toStrictEqual("false");
         expect(wrapper.emitted("setDragging")![0]).toStrictEqual([true]);
     });
 
@@ -98,19 +103,21 @@ describe("HiddenVariables", () => {
         expect(wrapper.emitted("setDragging")![0]).toStrictEqual([false]);
     });
 
-    it("onDrop removes variable from source", async () => {
+    it("onDrop removes variable from all configs with variable", async () => {
         const wrapper = getWrapper();
         const dataTransfer = {
             getData: (s: string) => {
                 if (s === "variable") return "S";
                 if (s === "srcGraphConfig") return "0";
+                if (s === "copyVar") return "false";
                 return null;
             }
         };
         const dropPanel = wrapper.find(".hidden-variables-panel");
         await dropPanel.trigger("drop", { dataTransfer });
-        expect(mockUpdateSelectedVariables.mock.calls.length).toBe(1);
+        expect(mockUpdateSelectedVariables.mock.calls.length).toBe(2);
         expect(mockUpdateSelectedVariables.mock.calls[0][1]).toStrictEqual({ graphIndex: 0, selectedVariables: ["J"] });
+        expect(mockUpdateSelectedVariables.mock.calls[1][1]).toStrictEqual({ graphIndex: 1, selectedVariables: [] });
     });
 
     it("shows drop zone when dragging", async () => {


### PR DESCRIPTION
If user presses Ctrl (or ⌘) key when dragging variabe to another graph, this makes a copy so graph is retained in the source as well as being added to target.

Dragging to or from Hidden variables ignore Ctrl key. 

Now that we can have variables on multiple graphs, this also means that we have to make good on the text "Drag variables here to hide them on *all* graphs" on Hidden variables, so we search all graph configs for variable to hide rather than just removing from source. 

It's not very clear to me why, but I found I now had to specify start and end positions in the e2e drag variable tests. Perhaps something to do with the text change in the drop area meaning the text wraps and height is increased in the default page size? Very odd!