### PR TITLE
mrc-6151 get script and css from base url

### DIFF
--- a/app/server/views/app.mustache
+++ b/app/server/views/app.mustache
@@ -25,7 +25,7 @@
     {{/hotReload}}
     {{^hotReload}}
         <script type="module" src="{{& baseUrl}}/wodin.js"></script>
-        <link rel="stylesheet" href="/wodin.css"/>
+        <link rel="stylesheet" href="{{& baseUrl}}/wodin.css"/>
     {{/hotReload}}
     <script async src="{{& mathjaxSrc}}"></script>
 </html>

--- a/app/server/views/app.mustache
+++ b/app/server/views/app.mustache
@@ -24,7 +24,7 @@
         <link rel="stylesheet" href="http://localhost:5173/src/scss/style.scss"/>
     {{/hotReload}}
     {{^hotReload}}
-        <script type="module" src="/wodin.js"></script>
+        <script type="module" src="{{& baseUrl}}/wodin.js"></script>
         <link rel="stylesheet" href="/wodin.css"/>
     {{/hotReload}}
     <script async src="{{& mathjaxSrc}}"></script>


### PR DESCRIPTION
Deploy to epimodels with latest wodin main image is resulting in apps not rendering, because they are trying to fetch wodin.js and wodin.css from "/" rather than relative to baseUrl.  This branch fixes this issue and is deployed to wodin-dev e.g. https://wodin-dev.dide.ic.ac.uk/msc-idm-2022/apps/heterogeneity-1

There's another issue, which is that a lot of the site index.html files are trying to use bootstrap.css from their site base url, which is not being found, resulting in unstyled pages e.g. https://wodin-dev.dide.ic.ac.uk/msc-idm-2022/ . I forget what we'd agreed to do there - did we say that sites ought to just use bootstrap themselves? Given that we'd like to redeploy this soon for the Royal Society app, and that we never got round to updating all the sites individually, we could just make bootstrap.css available again in the wodin container (temporarily...?) What do you think?

