### PR TITLE
Mrc 6357 - Ability to filter traces on a graph

### DIFF
--- a/app/static/src/components/run/RunStochasticPlot.vue
+++ b/app/static/src/components/run/RunStochasticPlot.vue
@@ -4,7 +4,7 @@
         :placeholder-message="placeholderMessage"
         :end-time="endTime"
         :plot-data="allPlotData"
-        :redrawWatches="solution ? [solution, graphCount] : []"
+        :redrawWatches="solution ? [solution, graphCount, selectedVariables] : []"
         :linked-x-axis="linkedXAxis"
         :fit-plot="false"
         :graph-index="graphIndex"
@@ -94,7 +94,8 @@ export default defineComponent({
             graphCount,
             allPlotData,
             solution,
-            updateXAxis
+            updateXAxis,
+            selectedVariables
         };
     }
 });

--- a/app/static/src/components/run/RunTab.vue
+++ b/app/static/src/components/run/RunTab.vue
@@ -57,7 +57,7 @@
 
 <script lang="ts">
 import { useStore } from "vuex";
-import { computed, defineComponent, Ref, ref } from "vue";
+import { computed, defineComponent, onMounted, PropType, Ref, ref } from "vue";
 import VueFeather from "vue-feather";
 import { LayoutAxis } from "plotly.js-basic-dist-min";
 import { RunMutation } from "../../store/run/mutations";
@@ -74,6 +74,8 @@ import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
+import { GraphConfig } from "@/store/graphs/state";
+import { GraphsAction } from "@/store/graphs/actions";
 
 export default defineComponent({
     name: "RunTab",
@@ -88,9 +90,10 @@ export default defineComponent({
     },
     props: {
         hideRunButton: { type: Boolean, default: false },
-        hideDownloadButton: { type: Boolean, default: false }
+        hideDownloadButton: { type: Boolean, default: false },
+        visibleVars: { type: String as PropType<string | null>, default: null }
     },
-    setup() {
+    setup(props) {
         const store = useStore();
 
         const showDownloadOutput = ref(false);
@@ -107,7 +110,7 @@ export default defineComponent({
 
         const hasRunner = computed(() => store.getters[`model/${ModelGetter.hasRunner}`]);
         const allSelectedVariables = computed(() => store.getters[`graphs/${GraphsGetter.allSelectedVariables}`]);
-        const graphConfigs = computed(() => store.state.graphs.config);
+        const graphConfigs = computed(() => store.state.graphs.config as GraphConfig[]);
 
         // Enable run button if model has initialised and compile is not required
         const canRunModel = computed(() => {
@@ -148,6 +151,18 @@ export default defineComponent({
         const updateXAxis = (newAxis: Partial<LayoutAxis>) => {
             xAxis.value = newAxis;
         };
+
+        onMounted(() => {
+            if (props.visibleVars) {
+                const visibleVars = props.visibleVars.split(",").map(s => s.trim());
+                graphConfigs.value.forEach((_, graphIndex) => {
+                    store.dispatch(`graphs/${GraphsAction.UpdateSelectedVariables}`, {
+                        graphIndex,
+                        selectedVariables: visibleVars
+                    });
+                });
+            }
+        });
 
         return {
             canRunModel,

--- a/app/static/src/components/run/RunTab.vue
+++ b/app/static/src/components/run/RunTab.vue
@@ -76,6 +76,7 @@ import RunStochasticPlot from "./RunStochasticPlot.vue";
 import { GraphsGetter } from "../../store/graphs/getters";
 import { GraphConfig } from "@/store/graphs/state";
 import { GraphsAction } from "@/store/graphs/actions";
+import { STATIC_BUILD } from "@/parseEnv";
 
 export default defineComponent({
     name: "RunTab",
@@ -153,7 +154,7 @@ export default defineComponent({
         };
 
         onMounted(() => {
-            if (props.visibleVars) {
+            if (props.visibleVars && STATIC_BUILD) {
                 const visibleVars = props.visibleVars.split(",").map(s => s.trim());
                 graphConfigs.value.forEach((_, graphIndex) => {
                     store.dispatch(`graphs/${GraphsAction.UpdateSelectedVariables}`, {

--- a/app/static/src/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/components/sensitivity/SensitivityTab.vue
@@ -47,6 +47,7 @@ import { SensitivityMutation } from "../../store/sensitivity/mutations";
 import baseSensitivity from "../mixins/baseSensitivity";
 import { GraphConfig } from "@/store/graphs/state";
 import { GraphsAction } from "@/store/graphs/actions";
+import { STATIC_BUILD } from "@/parseEnv";
 
 export default defineComponent({
     name: "SensitivityTab",
@@ -107,7 +108,7 @@ export default defineComponent({
         const error = computed(() => store.state.sensitivity.result?.error);
 
         onMounted(() => {
-            if (props.visibleVars) {
+            if (props.visibleVars && STATIC_BUILD) {
                 const visibleVars = props.visibleVars.split(",").map(s => s.trim());
                 graphConfigs.value.forEach((_, graphIndex) => {
                     store.dispatch(`graphs/${GraphsAction.UpdateSelectedVariables}`, {

--- a/app/static/src/components/sensitivity/SensitivityTab.vue
+++ b/app/static/src/components/sensitivity/SensitivityTab.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, PropType, onMounted } from "vue";
 import { useStore } from "vuex";
 import SensitivitySummaryDownload from "@/components/sensitivity/SensitivitySummaryDownload.vue";
 import SensitivityTracesPlot from "./SensitivityTracesPlot.vue";
@@ -45,6 +45,8 @@ import LoadingSpinner from "../LoadingSpinner.vue";
 import LoadingButton from "../LoadingButton.vue";
 import { SensitivityMutation } from "../../store/sensitivity/mutations";
 import baseSensitivity from "../mixins/baseSensitivity";
+import { GraphConfig } from "@/store/graphs/state";
+import { GraphsAction } from "@/store/graphs/actions";
 
 export default defineComponent({
     name: "SensitivityTab",
@@ -59,9 +61,10 @@ export default defineComponent({
     },
     props: {
         hideSensitivityButton: { type: Boolean, default: false },
-        hideDownloadButton: { type: Boolean, default: false }
+        hideDownloadButton: { type: Boolean, default: false },
+        visibleVars: { type: String as PropType<string | null>, default: null }
     },
-    setup() {
+    setup(props) {
         const store = useStore();
         const { sensitivityPrerequisitesReady, updateMsg } = baseSensitivity(store, false);
         const namespace = "sensitivity";
@@ -76,7 +79,7 @@ export default defineComponent({
             );
         });
 
-        const graphConfigs = computed(() => store.state.graphs.config);
+        const graphConfigs = computed(() => store.state.graphs.config as GraphConfig[]);
 
         const runSensitivity = () => {
             store.commit(`${namespace}/${SensitivityMutation.SetLoading}`, true);
@@ -102,6 +105,18 @@ export default defineComponent({
         );
 
         const error = computed(() => store.state.sensitivity.result?.error);
+
+        onMounted(() => {
+            if (props.visibleVars) {
+                const visibleVars = props.visibleVars.split(",").map(s => s.trim());
+                graphConfigs.value.forEach((_, graphIndex) => {
+                    store.dispatch(`graphs/${GraphsAction.UpdateSelectedVariables}`, {
+                        graphIndex,
+                        selectedVariables: visibleVars
+                    });
+                });
+            }
+        });
 
         return {
             graphConfigs,

--- a/app/static/tests/unit/components/run/runStochasticPlot.test.ts
+++ b/app/static/tests/unit/components/run/runStochasticPlot.test.ts
@@ -86,7 +86,7 @@ describe("RunPlot for stochastic", () => {
         expect(wodinPlot.props("fadePlot")).toBe(false);
         expect(wodinPlot.props("placeholderMessage")).toBe("Model has not been run.");
         expect(wodinPlot.props("endTime")).toBe(99);
-        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution, 1]);
+        expect(wodinPlot.props("redrawWatches")).toStrictEqual([mockSolution, 1, selectedVariables]);
         expect(wodinPlot.props("recalculateOnRelayout")).toBe(true);
         expect(wodinPlot.props("linkedXAxis")).toStrictEqual(linkedXAxis);
         expect(wodinPlot.props("graphIndex")).toBe(0);

--- a/config-static/index.html
+++ b/config-static/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div class="main">
-    <div class="container mt-5">
+    <div class="container mt-5 mb-10">
         <h1 class="mb-5">Example WODIN paper</h1>
         <span style="width: 100%;" class="d-flex justify-content-between mb-5">
             <span style="width: 35%;">
@@ -15,7 +15,7 @@
                 <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
             </span>
             <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic" hide-run-button hide-download-button></div>
+                <div class="w-run-graph" data-w-store="basic" hide-run-button hide-download-button visible-vars="I, R"></div>
                 <span style="display: flex; justify-content: space-evenly;">
                     <div class="w-par" name="beta" description="test" min="1" max="6" step="0.000001" data-w-store="basic" style="width: 20%;"></div>
                     <div class="w-par" name="sigma" description="test" min="0.1" max="4" step="0.000001" data-w-store="basic" style="width: 20%;"></div>
@@ -26,7 +26,7 @@
         </span>
         <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
         <p>run this thing please</p>
-        <div class="w-sens-graph" data-w-store="fit" hide-sensitivity-button hide-download-button></div>
+        <div class="w-sens-graph" data-w-store="fit" hide-sensitivity-button hide-download-button visible-vars="E, I, onset"></div>
         <span style="display: flex; justify-content: space-evenly;">
             <div class="w-par" name="R_0" description="test" min="1" max="4" step="0.000001" data-w-store="fit" style="width: 20%;"></div>
             <div class="w-par" name="L" description="test" min="0.01" max="4" step="0.000001" data-w-store="fit" style="width: 20%;"></div>
@@ -34,7 +34,7 @@
         </span>
         <span style="width: 100%;" class="d-flex justify-content-between mt-5">
             <div style="width: 60%;">
-                <div class="w-run-graph" data-w-store="stochastic" hide-run-button hide-download-button></div>
+                <div class="w-run-graph" data-w-store="stochastic" hide-run-button hide-download-button visible-vars="I_det, I, I (mean), S, S (mean)"></div>
                 <span style="display: flex; justify-content: space-evenly;">
                     <div class="w-par" name="beta" description="test" min="1" max="4" step="0.000001" data-w-store="stochastic" style="width: 20%;"></div>
                     <div class="w-par" name="nu" description="test" min="0.01" max="0.75" step="0.000001" data-w-store="stochastic" style="width: 20%;"></div>


### PR DESCRIPTION
I am on the fence about testing this:

This doesn't add any new features to wodin, wodin has graph controls on the side where you can select or deselect variables. This is just another way to achieve that filtering. Also this PR is temporary and once the d3 graph stuff is made into a package, we should rip this out (guess ill make a ticket for it?)

So personally, i dont think its worth testing this, itll just be extra stuff to remove later

I also think after this PR, we can start incorporating this into OJs word document as we have most of the necessary features and i would like to start properly packaging up the d3 stuff so we can stop making small ephemeral changes to wodin

I did find a bug, stochastic plot needs a redraw watch on the selected parameters, currently changing selected variables in normal wodin would not update the stochastic graph, but this made me think our graph code and organisation is needlessly hard to parse, i think it can be simplified a lot, i think i am smelling a **REFACTOR**! that refactor would also make it easy to port d3 graph into normal wodin if we wish to in the future, or port any other graphing library in for that matter