### PR TITLE
Mrc 6388 - Add support for store types and store instances

### DIFF
--- a/app/static/src/wodinStatic.ts
+++ b/app/static/src/wodinStatic.ts
@@ -28,13 +28,14 @@ const boot = async () => {
     await waitForBlockingScripts(blockingScripts);
 
     // find all stores the user has put in the page
-    const storesInPage = getStoresInPage();
+    const { storesInPage, storeTypesInPage } = getStoresInPage();
 
     // get relevant store configs and model code
-    const configAndModelObj = await getConfigAndModelForStores(storesInPage);
+    const configAndModelObj = await getConfigAndModelForStores(storeTypesInPage);
 
     storesInPage.forEach(async s => {
-        const { config, modelResponse } = configAndModelObj[s];
+        const storeType = s.split("-")[0];
+        const { config, modelResponse } = configAndModelObj[storeType];
         const originalStoreOptions = getStoreOptions(config.appType) as StoreOptions<AppState>;
 
         // recursively deep copy state because without this we would have multiple

--- a/app/static/src/wodinStatic.ts
+++ b/app/static/src/wodinStatic.ts
@@ -34,7 +34,7 @@ const boot = async () => {
     const configAndModelObj = await getConfigAndModelForStores(storeTypesInPage);
 
     storesInPage.forEach(async s => {
-        const storeType = s.split("-")[0];
+        const storeType = s.split(":")[0];
         const { config, modelResponse } = configAndModelObj[storeType];
         const originalStoreOptions = getStoreOptions(config.appType) as StoreOptions<AppState>;
 

--- a/app/static/src/wodinStaticUtils.ts
+++ b/app/static/src/wodinStaticUtils.ts
@@ -58,7 +58,7 @@ export const getStoresInPage = () => {
     const storesInPage: string[] = []
     stores.forEach(el => {
         const elStore = el.getAttribute("data-w-store")!;
-        const storeType = elStore.split("-")[0];
+        const storeType = elStore.split(":")[0];
         if (!storesInPage.includes(elStore)) storesInPage.push(elStore);
         if (!storeTypesInPage.includes(storeType)) storeTypesInPage.push(storeType);
     });

--- a/app/static/src/wodinStaticUtils.ts
+++ b/app/static/src/wodinStaticUtils.ts
@@ -12,6 +12,7 @@ import { storeOptions as fitStoreOptions } from "./store/fit/fit";
 import { storeOptions as stochasticStoreOptions } from "./store/stochastic/stochastic";
 import ParameterSlider from "./componentsStatic/ParameterSlider.vue";
 import { registerRerunModel, registerRerunSensitivity } from "./store/plugins";
+import { RunMutation } from "./store/run/mutations";
 
 const { Basic, Fit, Stochastic } = AppType;
 export const getStoreOptions = (appType: AppType) => {
@@ -53,18 +54,19 @@ export const waitForBlockingScripts = async (blockingScripts: string[]) => {
 
 export const getStoresInPage = () => {
     const stores = document.querySelectorAll("[data-w-store]")!;
+    const storeTypesInPage: string[] = []
     const storesInPage: string[] = []
     stores.forEach(el => {
         const elStore = el.getAttribute("data-w-store")!;
-        if (!storesInPage.includes(elStore)) {
-            storesInPage.push(elStore);
-        }
+        const storeType = elStore.split("-")[0];
+        if (!storesInPage.includes(elStore)) storesInPage.push(elStore);
+        if (!storeTypesInPage.includes(storeType)) storeTypesInPage.push(storeType);
     });
-    return storesInPage;
+    return { storesInPage, storeTypesInPage };
 };
 
 // TODO more tolerant error handling, maybe one config didnt work (for error handling PR)
-export type StaticConfig = { appType: AppType, defaultCode: string[] };
+export type StaticConfig = { appType: AppType, defaultCode: string[], endTime?: number };
 type ConfigAndModel = { config: StaticConfig, modelResponse: OdinModelResponse };
 
 export const getConfigAndModelForStores = async (storesInPage: string[]) => {
@@ -120,13 +122,14 @@ export const initialiseStore = async (
         appType: config.appType,
         basicProp: "",
         defaultCode: config.defaultCode,
-        endTime: 100,
+        endTime: config.endTime || 100,
         readOnlyCode: true,
         stateUploadIntervalMillis: 2_000_000,
         maxReplicatesRun: 100,
         maxReplicatesDisplay: 50
     } as AppConfig
     store.commit(AppStateMutation.SetConfig, appConfigPayload);
+    store.commit(`run/${RunMutation.SetEndTime}`, config.endTime || 100);
     store.commit(`model/${ModelMutation.SetOdinRunnerOde}`, odinjs);
     store.commit(`model/${ModelMutation.SetOdinRunnerDiscrete}`, dust);
     store.commit(`model/${ModelMutation.SetOdinResponse}`, modelResponse);

--- a/app/static/tests/unit/wodinStaticUtils.test.ts
+++ b/app/static/tests/unit/wodinStaticUtils.test.ts
@@ -74,14 +74,14 @@ describe("wodin static utils", () => {
     });
 
     test("get stores in page returns unique list of store types and store instances", async () => {
-        const testStores = ["type-1", "type-1", "anotherType-2"];
+        const testStores = ["type-1", "type-1:2", "anotherType-2"];
         vi.spyOn(document, "querySelectorAll").mockImplementation(() => {
             return testStores.map(s => ({ getAttribute: vi.fn().mockImplementation(() => s) })) as any
         });
         const storesInPage = getStoresInPage();
         expect(storesInPage).toStrictEqual({
-            storeTypesInPage: ["type", "anotherType"],
-            storesInPage: ["type-1", "anotherType-2"]
+            storeTypesInPage: ["type-1", "anotherType-2"],
+            storesInPage: ["type-1", "type-1:2", "anotherType-2"]
         });
     });
 

--- a/config-static/index.html
+++ b/config-static/index.html
@@ -15,30 +15,39 @@
                 <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
             </span>
             <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
+                <div class="w-run-graph" data-w-store="basic-1" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
                 <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic" style="width: 20%;"></div>
-                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic" style="width: 20%;"></div>
-                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic" style="width: 20%;"></div>
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-1" style="width: 20%;"></div>
+                </span>
+            </div>
+            <div style="width: 65%;">
+                <div class="w-run-graph" data-w-store="basic-2" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
+                <span style="display: flex; justify-content: space-evenly;">
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-2" style="width: 20%;"></div>
                 </span>
             </div>
         </span>
         <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
         <p>run this thing please</p>
-        <div class="w-sens-graph" data-w-store="fit" w-hide-sensitivity-button w-hide-download-button w-visible-vars="E, I, onset"></div>
+        <div class="w-sens-graph" data-w-store="fit-1" w-hide-sensitivity-button w-hide-download-button w-visible-vars="E, I, onset"></div>
         <span style="display: flex; justify-content: space-evenly;">
-            <div class="w-par" w-name="R_0" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="fit" style="width: 20%;"></div>
-            <div class="w-par" w-name="L" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit" style="width: 20%;"></div>
-            <div class="w-par" w-name="D" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit" style="width: 20%;"></div>
+            <div class="w-par" w-name="R_0" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
+            <div class="w-par" w-name="L" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
+            <div class="w-par" w-name="D" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
         </span>
         <span style="width: 100%;" class="d-flex justify-content-between mt-5">
             <div style="width: 60%;">
-                <div class="w-run-graph" data-w-store="stochastic" w-hide-run-button w-hide-download-button w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
+                <div class="w-run-graph" data-w-store="stochastic-1" w-hide-run-button w-hide-download-button w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
                 <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="stochastic" style="width: 20%;"></div>
-                    <div class="w-par" w-name="nu" w-description="test" w-min="0.01" w-max="0.75" w-step="0.000001" data-w-store="stochastic" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="10" w-max="2000" w-step="1" data-w-store="stochastic" style="width: 20%;"></div>
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="nu" w-description="test" w-min="0.01" w-max="0.75" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="10" w-max="2000" w-step="1" data-w-store="stochastic-1" style="width: 20%;"></div>
                 </span>
             </div>
             

--- a/config-static/index.html
+++ b/config-static/index.html
@@ -15,39 +15,39 @@
                 <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
             </span>
             <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic-1" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
+                <div class="w-run-graph" data-w-store="basic" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
                 <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic" style="width: 20%;"></div>
+                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic" style="width: 20%;"></div>
+                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic" style="width: 20%;"></div>
                 </span>
             </div>
             <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic-2" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
+                <div class="w-run-graph" data-w-store="basic:2" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
                 <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic:2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic:2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic:2" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic:2" style="width: 20%;"></div>
                 </span>
             </div>
         </span>
         <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
         <p>run this thing please</p>
-        <div class="w-sens-graph" data-w-store="fit-1" w-hide-sensitivity-button w-hide-download-button w-visible-vars="E, I, onset"></div>
+        <div class="w-sens-graph" data-w-store="fit:1" w-hide-sensitivity-button w-hide-download-button w-visible-vars="E, I, onset"></div>
         <span style="display: flex; justify-content: space-evenly;">
-            <div class="w-par" w-name="R_0" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
-            <div class="w-par" w-name="L" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
-            <div class="w-par" w-name="D" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
+            <div class="w-par" w-name="R_0" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="fit:1" style="width: 20%;"></div>
+            <div class="w-par" w-name="L" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit:1" style="width: 20%;"></div>
+            <div class="w-par" w-name="D" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit:1" style="width: 20%;"></div>
         </span>
         <span style="width: 100%;" class="d-flex justify-content-between mt-5">
             <div style="width: 60%;">
-                <div class="w-run-graph" data-w-store="stochastic-1" w-hide-run-button w-hide-download-button w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
+                <div class="w-run-graph" data-w-store="stochastic:1" w-hide-run-button w-hide-download-button w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
                 <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="nu" w-description="test" w-min="0.01" w-max="0.75" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="10" w-max="2000" w-step="1" data-w-store="stochastic-1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="stochastic:1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="nu" w-description="test" w-min="0.01" w-max="0.75" w-step="0.000001" data-w-store="stochastic:1" style="width: 20%;"></div>
+                    <div class="w-par" w-name="N" w-description="test" w-min="10" w-max="2000" w-step="1" data-w-store="stochastic:1" style="width: 20%;"></div>
                 </span>
             </div>
             


### PR DESCRIPTION
We need a concept of a store type and a store instance, because users may want to use a store defined in the static config multiple times while keeping the parameter values in the multiple stores instances separate. So I am updating the `data-w-store` to be of the format `<storeType>-<storeInstanceId>`, where the store type must be one of the store folder names in static config and the store instance id is whatever the user wants (we will have an error in the future if the user uses a `-` in their `storeInstanceId` this is added to the error handling PR: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-6140/Build-time-error-handling)

Before this PR if you had a setup defined in `index.html` in the static config and have the run graphs use the same store then updating slider in graph 1 would update graph 2 as well which is not the behaviour we want