### PR TITLE
Mrc 6446 - Add title and latex support into parameter slider component

### DIFF
--- a/app/static/src/componentsStatic/ParameterSlider.vue
+++ b/app/static/src/componentsStatic/ParameterSlider.vue
@@ -30,11 +30,11 @@ const store = useStore<AppState>();
 
 const props = defineProps({
   par: { type: String, required: true },
-  title: { type: String },
-  desc: { type: String },
+  title: { type: String, required: false },
+  desc: { type: String, required: false },
   min: { type: Number, required: true },
   max: { type: Number, required: true },
-  step: { type: Number }
+  step: { type: Number, required: false }
 });
 
 const value = computed(() => store.state.run.parameterValues![props.par]);

--- a/app/static/src/componentsStatic/ParameterSlider.vue
+++ b/app/static/src/componentsStatic/ParameterSlider.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="slider">
-    <div style="width: 100%;">
-      <label class="col-form-label fw-bold pb-0 label" ref="labelRef"></label>
-      <div class="desc" ref="descRef"></div>
+    <div>
+      <label class="col-form-label fw-bold pb-0 label">{{ title || par }}</label>
+      <div class="desc">{{ desc }}</div>
     </div>
-    <div style="width: 100%;">
+    <div>
       <div class="float-end value mt-2">
         {{ value }}
       </div>
@@ -23,7 +23,7 @@
 import { AppState } from '@/store/appState/state';
 import { RunAction } from '@/store/run/actions';
 import { RunMutation } from '@/store/run/mutations';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
 
 const store = useStore<AppState>();
@@ -47,18 +47,10 @@ const handleChange = (e: Event) => {
   store.dispatch(`run/${RunAction.RunModel}`);
 };
 
-const labelRef = ref<HTMLLabelElement | null>(null);
-const descRef = ref<HTMLDivElement | null>(null);
-
 onMounted(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { MathJax } = window as any;
-  if (!labelRef.value || !descRef.value || !MathJax) return;
-
-  labelRef.value.innerHTML = props.title || props.par;
-  descRef.value.innerHTML = props.desc || "";
-
-  await MathJax.typesetPromise();
+  const mathJax = (window as any).MathJax;
+  await mathJax?.typesetPromise();
 });
 </script>
 

--- a/app/static/src/componentsStatic/ParameterSlider.vue
+++ b/app/static/src/componentsStatic/ParameterSlider.vue
@@ -48,6 +48,11 @@ const handleChange = (e: Event) => {
 };
 
 onMounted(async () => {
+  // MathJax works by looking through what is mounted on the DOM
+  // and renders symbols when it loads. However, Vue components may
+  // mount after this so typesetPromise allows us to re-trigger
+  // MathJax parsing the DOM and rendering maths symbols
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mathJax = (window as any).MathJax;
   await mathJax?.typesetPromise();

--- a/app/static/src/componentsStatic/ParameterSlider.vue
+++ b/app/static/src/componentsStatic/ParameterSlider.vue
@@ -1,40 +1,65 @@
 <template>
-  <label :id="`${name}-input`" class="col-form-label fw-bold pb-0 label">{{ name }}</label>
-  <div :id="`${name}-description`" class="description">
-    {{ description }}
+  <div class="slider">
+    <div style="width: 100%;">
+      <label class="col-form-label fw-bold pb-0 label" ref="labelRef"></label>
+      <div class="desc" ref="descRef"></div>
+    </div>
+    <div style="width: 100%;">
+      <div class="float-end value mt-2">
+        {{ value }}
+      </div>
+      <input type="range"
+             class="form-range"
+             :min="min"
+             :max="max"
+             :step="step || (max - min) / 10000"
+             :value="value"
+             @input="handleChange"/>
+    </div>
   </div>
-  <div :id="`${name}-value`" class="float-end value mt-2">
-    {{ value }}
-  </div>
-  <input type="range" class="form-range" :min="min" :max="max" :step="step || (max - min) / 10000" :value="value" @input="handleChange"/>
 </template>
 
 <script setup lang="ts">
 import { AppState } from '@/store/appState/state';
 import { RunAction } from '@/store/run/actions';
 import { RunMutation } from '@/store/run/mutations';
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useStore } from 'vuex';
 
 const store = useStore<AppState>();
 
 const props = defineProps({
-  name: { type: String, required: true },
-  description: { type: String, required: false },
+  par: { type: String, required: true },
+  title: { type: String },
+  desc: { type: String },
   min: { type: Number, required: true },
   max: { type: Number, required: true },
   step: { type: Number }
 });
 
-const value = computed(() => store.state.run.parameterValues![props.name]);
+const value = computed(() => store.state.run.parameterValues![props.par]);
 
 const handleChange = (e: Event) => {
   const newVal = (e.target as HTMLInputElement).value;
   const oldParameterValues = store.state.run.parameterValues;
-  const newParameterValues = { ...oldParameterValues, [props.name]: parseFloat(newVal) };
+  const newParameterValues = { ...oldParameterValues, [props.par]: parseFloat(newVal) };
   store.commit(`run/${RunMutation.SetParameterValues}`, newParameterValues);
   store.dispatch(`run/${RunAction.RunModel}`);
 };
+
+const labelRef = ref<HTMLLabelElement | null>(null);
+const descRef = ref<HTMLDivElement | null>(null);
+
+onMounted(async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { MathJax } = window as any;
+  if (!labelRef.value || !descRef.value || !MathJax) return;
+
+  labelRef.value.innerHTML = props.title || props.par;
+  descRef.value.innerHTML = props.desc || "";
+
+  await MathJax.typesetPromise();
+});
 </script>
 
 <style lang="css" scoped>
@@ -43,12 +68,19 @@ const handleChange = (e: Event) => {
   color: grey;
 }
 
-.description {
+.desc {
   font-size: 0.85rem;
   color: rgb(82, 82, 82);
 }
 
 .label {
   font-size: 0.9rem;
+}
+
+.slider {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 </style>

--- a/app/static/tests/testUtils.ts
+++ b/app/static/tests/testUtils.ts
@@ -30,18 +30,42 @@ export const expectLeftWodinTabs = (wrapper: VueWrapper<any>, expectedTabNames: 
     expectWodinTabs(wrapper, expectedTabNames, "left");
 };
 
+// utility type that removes generic type nesting in typescript LSP
+// preview and shows the type as an actual object
+// see https://gist.github.com/palashmon/db68706d4f26d2dbf187e76409905399
 export type Prettify<T> = {
     [K in keyof T]: T[K];
 } & {};
 
+// makes the field optional if it can be undefined and removes
+// fields that can't be undefined (notice ? after foo)
+//
+// { foo: string | undefined, bar: number } -> { foo?: string | undefined }
 type OptionalKeys<T> = {
     [K in keyof T as undefined extends T[K] ? K : never]?: T[K]
 }
 
+// extracts the fields that cannot undefined
+//
+// { foo: string | undefined, bar: number } -> { bar: number }
 type RequiredKeys<T> = {
     [K in keyof T as undefined extends T[K] ? never : K]: T[K]
 }
 
+// the OptionalKeys and RequiredKeys are needed because vue now types
+// the props defined as
+// {
+//     foo: { type: String, required: true },
+//     bar: { type: String, required: false },
+// }
+//
+// as
+//
+// { foo: string, bar: string | undefined }
+//
+// but it should be
+//
+// { foo: string, bar?: string | undefined }
 export type ComponentProps<T> =
     T extends { setup?: (props: infer Props, ...otherArgs: any[]) => any }
         ? Prettify<RequiredKeys<Props> & OptionalKeys<Props>>

--- a/app/static/tests/testUtils.ts
+++ b/app/static/tests/testUtils.ts
@@ -30,6 +30,19 @@ export const expectLeftWodinTabs = (wrapper: VueWrapper<any>, expectedTabNames: 
     expectWodinTabs(wrapper, expectedTabNames, "left");
 };
 
-export type ComponentProps<
-    T extends { setup?: (props: any, ...otherArgs: any[]) => any }
-> = Parameters<NonNullable<T["setup"]>>[0]
+export type Prettify<T> = {
+    [K in keyof T]: T[K];
+} & {};
+
+type OptionalKeys<T> = {
+    [K in keyof T as undefined extends T[K] ? K : never]?: T[K]
+}
+
+type RequiredKeys<T> = {
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K]
+}
+
+export type ComponentProps<T> =
+    T extends { setup?: (props: infer Props, ...otherArgs: any[]) => any }
+        ? Prettify<RequiredKeys<Props> & OptionalKeys<Props>>
+        : never

--- a/app/static/tests/unit/componentsStatic/parameterSlider.test.ts
+++ b/app/static/tests/unit/componentsStatic/parameterSlider.test.ts
@@ -8,7 +8,7 @@ import { RunMutation } from "@/store/run/mutations";
 describe("Parameter Control", () => {
     const mockSetParameterValues = vi.fn();
 
-    type ParameterSliderProps = Parameters<NonNullable<(typeof ParameterSlider)["setup"]>>["0"]
+    type ParameterSliderProps = InstanceType<typeof ParameterSlider>["$props"]
     const getWrapper = (props?: Partial<ParameterSliderProps>) => {
         const store = new Vuex.Store<BasicState>({
             state: mockBasicState(),
@@ -28,8 +28,8 @@ describe("Parameter Control", () => {
         });
 
         const defaultProps: ParameterSliderProps = {
-            name: "a",
-            description: "test-desc",
+            par: "a",
+            desc: "test-desc",
             min: 0, max: 10, step: 100
         };
 
@@ -39,17 +39,27 @@ describe("Parameter Control", () => {
         });
     };
 
-    it("renders as expected", () => {
+    it("renders as expected", async () => {
+        (window as any).MathJax = { typesetPromise: () => {} };
         const wrapper = getWrapper();
-        const label = wrapper.find("#a-input");
+        const label = wrapper.find("label");
         expect(label.text()).toBe("a");
-        const description = wrapper.find("#a-description");
+        const description = wrapper.find(".desc");
         expect(description.text()).toBe("test-desc");
-        const value = wrapper.find("#a-value");
+        const value = wrapper.find(".value");
         expect(value.text()).toBe("1");
         const input = wrapper.find("input");
         expect(input.element.classList[0]).toBe("form-range");
         expect(input.element.value).toBe("1");
+        delete (window as any).MathJax;
+    });
+
+    it("uses title as label when provided", async () => {
+        (window as any).MathJax = { typesetPromise: () => {} };
+        const wrapper = getWrapper({ title: "test-title" });
+        const label = wrapper.find("label");
+        expect(label.text()).toBe("test-title");
+        delete (window as any).MathJax;
     });
 
     it("runs model when value changes", async () => {

--- a/app/static/tests/unit/componentsStatic/parameterSlider.test.ts
+++ b/app/static/tests/unit/componentsStatic/parameterSlider.test.ts
@@ -29,7 +29,6 @@ describe("Parameter Control", () => {
         });
 
         const defaultProps: ParameterSliderProps = {
-            title: "Alpha",
             par: "a",
             desc: "test-desc",
             min: 0, max: 10, step: 100
@@ -41,8 +40,15 @@ describe("Parameter Control", () => {
         });
     };
 
-    it("renders as expected", async () => {
+    beforeEach(() => {
         (window as any).MathJax = { typesetPromise: () => {} };
+    });
+
+    afterEach(() => {
+        delete (window as any).MathJax;
+    });
+
+    it("renders as expected", async () => {
         const wrapper = getWrapper();
         const label = wrapper.find("label");
         expect(label.text()).toBe("a");
@@ -53,15 +59,12 @@ describe("Parameter Control", () => {
         const input = wrapper.find("input");
         expect(input.element.classList[0]).toBe("form-range");
         expect(input.element.value).toBe("1");
-        delete (window as any).MathJax;
     });
 
     it("uses title as label when provided", async () => {
-        (window as any).MathJax = { typesetPromise: () => {} };
         const wrapper = getWrapper({ title: "test-title" });
         const label = wrapper.find("label");
         expect(label.text()).toBe("test-title");
-        delete (window as any).MathJax;
     });
 
     it("runs model when value changes", async () => {

--- a/config-static/index.html
+++ b/config-static/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8">
     <title>Example WODIN paper</title>
     <link rel="stylesheet" href="./wodin.css"/>
+    <script>
+    MathJax = {
+        tex: {
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            packages: {'[+]': ['boldsymbol']}
+        },
+        loader: {load: ['[tex]/boldsymbol']},
+    };
+    </script>
+    <style>
+        .par-group {
+            display: flex;
+            justify-content: space-evenly;
+        }
+
+        .par-group .w-par {
+            width: 20%;
+        }
+    </style>
 </head>
 <body>
 <div class="main">
@@ -13,41 +32,114 @@
             <span style="width: 35%;">
                 <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
                 <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
+                <div class="w-par"
+                         w-par="beta"
+                         w-title="$\boldsymbol{\beta}$"
+                         w-desc="How infectious the disease is"
+                         w-min="1"
+                         w-max="6"
+                         data-w-store="basic-1"></div>
             </span>
-            <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic-1" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
-                <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-1" style="width: 20%;"></div>
-                </span>
-            </div>
-            <div style="width: 65%;">
-                <div class="w-run-graph" data-w-store="basic-2" w-hide-run-button w-hide-download-button w-visible-vars="I, R"></div>
-                <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="6" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="sigma" w-description="test" w-min="0.1" w-max="4" w-step="0.000001" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="I0" w-description="test" w-min="1" w-max="1000" w-step="1" data-w-store="basic-2" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="1000" w-max="10000000" w-step="10" data-w-store="basic-2" style="width: 20%;"></div>
-                </span>
-            </div>
+            <div class="w-run-graph"
+                 data-w-store="basic-1"
+                 w-hide-run-button
+                 w-hide-download-button
+                 w-visible-vars="I"
+                 style="width: 65%;"></div>
         </span>
+        <div style="width: 100%;">
+            <div class="w-run-graph"
+                 data-w-store="basic-2"
+                 w-hide-run-button
+                 w-hide-download-button></div>
+            <span class="par-group">
+                <div class="w-par"
+                     w-par="beta"
+                     w-title="$\boldsymbol{\beta}$"
+                     w-desc="How infectious the disease is"
+                     w-min="1"
+                     w-max="6"
+                     data-w-store="basic-2"></div>
+                <div class="w-par"
+                     w-par="sigma"
+                     w-title="$\boldsymbol{\sigma}$"
+                     w-desc="The recovery rate"
+                     w-min="0.1"
+                     w-max="4"
+                     data-w-store="basic-2"></div>
+                <div class="w-par"
+                     w-par="I0"
+                     w-title="$\boldsymbol{I_{0}}$"
+                     w-desc="Initial number of infected people"
+                     w-min="1"
+                     w-max="1000"
+                     w-step="1"
+                     data-w-store="basic-2"></div>
+                <div class="w-par"
+                     w-par="N"
+                     w-title="Total population ($N$)"
+                     w-desc="The total population - this doesn't change"
+                     w-min="1000"
+                     w-max="10000000"
+                     data-w-store="basic-2"></div>
+            </span>
+        </div>
         <p>look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste look model so fancy wow its so cool the colorful lines are awesome, wonder what else i can write to emulate research code, okay im bored, time to copy and paste</p>
         <p>run this thing please</p>
-        <div class="w-sens-graph" data-w-store="fit-1" w-hide-sensitivity-button w-hide-download-button w-visible-vars="E, I, onset"></div>
-        <span style="display: flex; justify-content: space-evenly;">
-            <div class="w-par" w-name="R_0" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
-            <div class="w-par" w-name="L" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
-            <div class="w-par" w-name="D" w-description="test" w-min="0.01" w-max="4" w-step="0.000001" data-w-store="fit-1" style="width: 20%;"></div>
+        <div class="w-sens-graph"
+             data-w-store="fit-1"
+             w-hide-sensitivity-button
+             w-hide-download-button
+             w-visible-vars="E, I, onset"></div>
+        <span class="par-group">
+            <div class="w-par"
+                 w-par="R_0"
+                 w-title="$\boldsymbol{R_{0}}$"
+                 w-desc="test"
+                 w-min="1"
+                 w-max="4"
+                 data-w-store="fit-1"></div>
+            <div class="w-par"
+                 w-par="L"
+                 w-desc="test"
+                 w-min="0.01"
+                 w-max="4"
+                 data-w-store="fit-1"></div>
+            <div class="w-par"
+                 w-par="D"
+                 w-desc="test"
+                 w-min="0.01"
+                 w-max="4"
+                 w-step="0.000001"
+                 data-w-store="fit-1"></div>
         </span>
         <span style="width: 100%;" class="d-flex justify-content-between mt-5">
             <div style="width: 60%;">
-                <div class="w-run-graph" data-w-store="stochastic-1" w-hide-run-button w-hide-download-button w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
-                <span style="display: flex; justify-content: space-evenly;">
-                    <div class="w-par" w-name="beta" w-description="test" w-min="1" w-max="4" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="nu" w-description="test" w-min="0.01" w-max="0.75" w-step="0.000001" data-w-store="stochastic-1" style="width: 20%;"></div>
-                    <div class="w-par" w-name="N" w-description="test" w-min="10" w-max="2000" w-step="1" data-w-store="stochastic-1" style="width: 20%;"></div>
+                <div class="w-run-graph"
+                     data-w-store="stochastic-1"
+                     w-hide-run-button
+                     w-hide-download-button
+                     w-visible-vars="I_det, I, I (mean), S, S (mean)"></div>
+                <span class="par-group">
+                    <div class="w-par"
+                         w-par="beta"
+                         w-desc="test"
+                         w-min="1"
+                         w-max="4"
+                         data-w-store="stochastic-1"></div>
+                    <div class="w-par"
+                         w-par="nu"
+                         w-desc="test"
+                         w-min="0.01"
+                         w-max="0.75"
+                         data-w-store="stochastic-1"></div>
+                    <div class="w-par"
+                         w-par="N"
+                         w-desc="test"
+                         w-min="10"
+                         w-max="2000"
+                         w-step="1"
+                         data-w-store="stochastic-1"></div>
                 </span>
             </div>
             


### PR DESCRIPTION
This adds a `title` prop to the parameter slider component. I have renamed the `name` prop to `par` prop, name seemed too confusing with title around.

We already had support for latex however we didnt have support for latex packages or other configuration for latex, for now i am just including it as a script at the top of the static config index html file.