### PR TITLE
Mrc 6873 variable width legend

### DIFF
--- a/app/static/src/components/WodinLegend.vue
+++ b/app/static/src/components/WodinLegend.vue
@@ -10,13 +10,21 @@
               :stroke="config.color" stroke-width="2"/>
         <circle v-if="config.type === 'point'" cx="15" cy="5" r="2.5" :fill="config.color"/>
       </svg>
-      <p class="legend-text">{{ name }}</p>
+      <p class="legend-text" :style="{ width }">{{ name }}</p>
+    </div>
+    <div class="legend-row hidden-legend-row">
+      <svg viewBox="0 0 30 10" height="10" width="30"></svg>
+      <p class="legend-text" ref="hiddenLegendText"></p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { PropType } from 'vue';
+import { AppState, VisualisationTab } from '@/store/appState/state';
+import { FitDataGetter } from '@/store/fitData/getters';
+import { AllFitData } from '@/store/fitData/state';
+import { computed, PropType, ref } from 'vue';
+import { useStore } from 'vuex';
 
 export type LegendConfig = {
   color: string,
@@ -32,21 +40,64 @@ defineProps({
 });
 
 defineEmits(["legendClick"]);
+
+const store = useStore<AppState>();
+
+const hiddenLegendText = ref<HTMLParagraphElement | undefined>();
+
+const allFitData = computed(() => store.getters[`fitData/${FitDataGetter.allData}`] as AllFitData | null);
+
+const width = computed(() => {
+  if (!hiddenLegendText.value) return 0;
+
+  // get all variables across all the graphs on screen + fit linked variables
+  const graphConfigs = store.state.openVisualisationTab === VisualisationTab.Fit
+    ? [store.state.graphs.fitGraphConfig]
+    : store.state.graphs.config;
+  const legendLabels: string[] = [];
+  graphConfigs.forEach(cfg => {
+    cfg.selectedVariables.forEach(variable => {
+      if (legendLabels.includes(variable)) return;
+      legendLabels.push(variable);
+    });
+  });
+
+  if (allFitData.value) {
+    Object.keys(allFitData.value.linkedVariables).forEach(variable => {
+      if (legendLabels.includes(variable)) return;
+      legendLabels.push(variable);
+    });
+  }
+
+
+  // get width from hidden tag mounted in DOM to determine the max width
+  // of a legend label
+  let maxWidth = 0;
+  legendLabels.forEach(label => {
+    hiddenLegendText.value!.textContent = label;
+    const { width } = hiddenLegendText.value!.getBoundingClientRect();
+    if (width > maxWidth) maxWidth = width;
+  });
+
+
+  return `${Math.ceil(maxWidth)}px`;
+});
 </script>
 
-<style lang="css" scoped>
+<style lang="css">
 .legend {
   display: flex;
   flex-direction: column;
   justify-content: start;
-  width: min(20rem, 25%);
+  max-width: 25%;
   max-height: calc(450px - 1rem);
   overflow: auto;
   scrollbar-color: grey transparent;
   scrollbar-width: thin;
+  margin-top: 0.6rem;
 }
 
-.legend-row {
+.legend-row, .hidden-legend-row {
   display: grid;
   grid-template-columns: 30px 1fr;
   margin-inline: 0.4rem;
@@ -54,6 +105,12 @@ defineEmits(["legendClick"]);
   cursor: pointer;
   align-items: center;
   margin-block: 0.1rem;
+}
+
+.hidden-legend-row {
+  pointer-events: none;
+  visibility: hidden;
+  position:absolute;
 }
 
 .legend-text {
@@ -66,7 +123,7 @@ defineEmits(["legendClick"]);
   opacity: 0.4;
 }
 
-svg {
+.legend-row svg {
   margin-right: 0.25rem;
 }
 </style>

--- a/app/static/src/scss/style.scss
+++ b/app/static/src/scss/style.scss
@@ -62,8 +62,8 @@ $grey: #ccc;
 
 .wodin-plot-container,
 .summary-plot-container {
+    flex-grow: 1;
     padding-inline: 1rem;
-    width: calc(100% - min(20rem, 25%));
     overflow-x: hidden;
 }
 

--- a/app/static/tests/e2e/run.etest.ts
+++ b/app/static/tests/e2e/run.etest.ts
@@ -35,13 +35,16 @@ test.describe("Run Tab", () => {
         await page.mouse.move(graphBounds.x + 300, graphBounds.y + 100);
         await page.mouse.up();
 
+        // 3. Make sure graph has zoomed in
         const firstGraph = await page.locator(".wodin-plot-container").nth(0);
         const xAxis = firstGraph.locator(`g[id^="x-axes"]`);
         const ticks = xAxis.locator(".tick");
         const firstTick = await ticks.first().textContent();
         const lastTick = await ticks.last().textContent();
+        expect(firstTick).not.toBe("0");
+        expect(lastTick).not.toBe("100");
 
-        // 3. Check - using x axis ticks - that the expected x axis values are shown on all three graphs.
+        // 4. Check - using x axis ticks - that the expected x axis values are shown on all three graphs.
         await expectFirstAndLastXTick(page, 3, [firstTick!, lastTick!]);
     });
 });

--- a/app/static/tests/e2e/run.etest.ts
+++ b/app/static/tests/e2e/run.etest.ts
@@ -2,7 +2,7 @@ import { expect, test, Page } from "@playwright/test";
 import { expectGraphVariables, addGraphWithVariable } from "./utils";
 
 const expectFirstAndLastXTick = async (
-    page: Page, expectedGraphCount: number, expectedFirstAndLastTick: [number, number]
+    page: Page, expectedGraphCount: number, expectedFirstAndLastTick: [string, string]
 ) => {
     const graphs = await page.locator(".wodin-plot-container");
     expect(await graphs.count()).toBe(expectedGraphCount);
@@ -10,8 +10,8 @@ const expectFirstAndLastXTick = async (
         const graph = graphs.nth(i);
         const xAxis = graph.locator(`g[id^="x-axes"]`);
         const ticks = xAxis.locator(".tick");
-        expect(await ticks.first().textContent()).toBe(expectedFirstAndLastTick[0].toString());
-        expect(await ticks.last().textContent()).toBe(expectedFirstAndLastTick[1].toString());
+        expect(await ticks.first().textContent()).toBe(expectedFirstAndLastTick[0]);
+        expect(await ticks.last().textContent()).toBe(expectedFirstAndLastTick[1]);
     }
 };
 
@@ -26,7 +26,7 @@ test.describe("Run Tab", () => {
         await expectGraphVariables(page, 1, ["S"]);
         await expectGraphVariables(page, 2, ["I"]);
         // Sanity check that each graph has expected initial x axis ticks for full 0-100 time range
-        await expectFirstAndLastXTick(page, 3, [0, 100]);
+        await expectFirstAndLastXTick(page, 3, ["0", "100"]);
 
         // 2. Drag to zoom to an area on the first graph
         const graphBounds = (await page.locator(`:nth-match(.plot g[id^="brush"], 1)`).boundingBox())!;
@@ -35,7 +35,13 @@ test.describe("Run Tab", () => {
         await page.mouse.move(graphBounds.x + 300, graphBounds.y + 100);
         await page.mouse.up();
 
+        const firstGraph = await page.locator(".wodin-plot-container").nth(0);
+        const xAxis = firstGraph.locator(`g[id^="x-axes"]`);
+        const ticks = xAxis.locator(".tick");
+        const firstTick = await ticks.first().textContent();
+        const lastTick = await ticks.last().textContent();
+
         // 3. Check - using x axis ticks - that the expected x axis values are shown on all three graphs.
-        await expectFirstAndLastXTick(page, 3, [20, 55]);
+        await expectFirstAndLastXTick(page, 3, [firstTick!, lastTick!]);
     });
 });

--- a/app/static/tests/unit/components/wodinLegend.test.ts
+++ b/app/static/tests/unit/components/wodinLegend.test.ts
@@ -1,5 +1,8 @@
 import WodinLegend, { LegendConfig } from "@/components/WodinLegend.vue";
+import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
+import { AppState } from "@/store/appState/state";
+import { mockBasicState } from "../../mocks";
 
 describe("Wodin legend", () => {
   const getWrapper = () => {
@@ -16,8 +19,13 @@ describe("Wodin legend", () => {
       }
     };
 
+    const store = new Vuex.Store<AppState>({
+      state: mockBasicState()
+    });
+
     return shallowMount(WodinLegend, {
-      props: { legendConfigs }
+      props: { legendConfigs },
+      global: { plugins: [store] }
     });
   };
 
@@ -26,8 +34,8 @@ describe("Wodin legend", () => {
     const legend = wrapper.find("div");
     expect(legend.classes()).toContain("legend");
     const legendRows = legend.findAll("div");
-    expect(legendRows.length).toBe(2);
-    const [ sRow, iRow ] = legendRows;
+    expect(legendRows.length).toBe(3);
+    const [ sRow, iRow, hiddenRow ] = legendRows;
 
     expect(sRow.classes()).toContain("legend-row");
     expect(sRow.classes()).not.toContain("faded");
@@ -38,6 +46,9 @@ describe("Wodin legend", () => {
     expect(iRow.classes()).toContain("faded");
     expect(iRow.find("circle").exists()).toBe(true);
     expect(iRow.text()).toBe("I");
+
+    expect(hiddenRow.classes()).toContain("legend-row");
+    expect(hiddenRow.classes()).toContain("hidden-legend-row");
   });
 
   test("emits correct legend row", async () => {


### PR DESCRIPTION
the general strategy is to collect up all the labels that can appear on the legend (excluded those that are hidden in the graph config) and fill in a paragraph tag one by one and find the longest width, we then set the legend text width equal to that

this should ensure that the legend width is the same across all different graphs and never longer than it needs to be because it ignores hidden variables

unfortunately, this is another one of those features thats hard to test, i cant really test the width value at all because the width depends on font family, font size, text content, which can all change, a test that checks the numerical value of the width is far too brittle