### PR TITLE
Mrc 6896 Pt 3 Refactor wodin plot and add plugin for redraw watches

### DIFF
--- a/app/static/src/components/WodinPlot.vue
+++ b/app/static/src/components/WodinPlot.vue
@@ -17,12 +17,12 @@ import { computed, defineComponent, ref, watch, onMounted, PropType, shallowRef 
 import { useStore } from "vuex";
 import { Metadata, WodinPlotData, fadePlotStyle } from "../plot";
 import WodinPlotDataSummary from "./WodinPlotDataSummary.vue";
-import { GraphsMutation, SetGraphConfigPayload } from "../store/graphs/mutations";
-import { fitGraphId, GraphConfig } from "../store/graphs/state";
+import { GraphConfig } from "../store/graphs/state";
 import { Chart, Scales, ZoomProperties } from "@reside-ic/skadi-chart";
 import { AppState } from "@/store/appState/state";
 import { tooltipCallback } from "@/utils";
 import WodinLegend, { LegendConfig } from "./WodinLegend.vue";
+import { GraphsAction, UpdateConfigPayload } from "@/store/graphs/actions";
 
 export default defineComponent({
     name: "WodinPlot",
@@ -30,22 +30,17 @@ export default defineComponent({
     props: {
         fadePlot: Boolean,
         placeholderMessage: String,
+        // need to check out fit plot in more detail to see why this is passed in
         endTime: {
             type: Number,
             required: true
         },
-        plotData: {
-            type: Function as PropType<(start: number, end: number, points: number) => WodinPlotData>,
-            required: true
-        },
-        // Only used as an indicator that redraw is required when this changes - the data to display is calculated by
-        // plotData function using these solutions
-        redrawWatches: {
-            type: Array as PropType<unknown[]>,
-            required: true
-        },
-        graphConfig: {
+        config: {
             type: Object as PropType<GraphConfig>,
+            required: true
+        },
+        graphGroupId: {
+            type: String,
             required: true
         }
     },
@@ -57,41 +52,24 @@ export default defineComponent({
 
         const plot = ref<null | HTMLDivElement>(null); // Picks up the element with 'plot' ref in the template
         const baseData = shallowRef<WodinPlotData>({ lines: [], points: [] });
-        const nPoints = 1000; // TODO: appropriate value could be derived from width of element
 
         const hasPlotData = computed(() => !!baseData.value.lines.length || !!baseData.value.points.length);
 
         const updateAxes = (zoomProperties: ZoomProperties) => {
             if (!zoomProperties) return;
+
             const newXYRanges = {
               xAxisRange: zoomProperties.x,
-              yAxisRange: zoomProperties.eventType === "dblclick" && !props.graphConfig.settings.lockYAxis
+              yAxisRange: zoomProperties.eventType === "dblclick" && !props.config.lockYAxis
                 ? null
                 : zoomProperties.y,
             };
 
-            if (props.graphConfig.id === fitGraphId) {
-              store.commit(`graphs/${GraphsMutation.SetGraphConfig}`, {
-                id: fitGraphId,
-                settings: { ...newXYRanges }
-              } as SetGraphConfigPayload);
-            } else {
-              const allGraphConfigs = store.state.graphs.config;
-              const allUpdatedConfigs = allGraphConfigs.map(cfg => ({
-                ...cfg,
-                settings: {
-                  ...cfg.settings,
-                  xAxisRange: newXYRanges.xAxisRange,
-                  yAxisRange: cfg.id === props.graphConfig.id
-                    ? newXYRanges.yAxisRange
-                    : cfg.settings.yAxisRange
-                }
-              }));
-              store.commit(
-                `graphs/${GraphsMutation.SetAllGraphConfigs}`,
-                JSON.parse(JSON.stringify(allUpdatedConfigs))
-              );
-            }
+            const payload: UpdateConfigPayload = {
+              id: props.config.id,
+              value: newXYRanges
+            };
+            store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
         };
 
         const getLegendConfigs = (data: WodinPlotData) => {
@@ -133,7 +111,7 @@ export default defineComponent({
         const autoscaledMaxExtentsY = ref<Scales["y"]>();
 
         const drawSkadiChart = (legendFilteredData: null | WodinPlotData = null) => {
-            const settings = props.graphConfig.settings;
+            const settings = props.config;
             const maxXExtents = { start: startTime, end: props.endTime };
             const xRange = settings.xAxisRange
               ? { start: settings.xAxisRange[0], end: settings.xAxisRange[1] }
@@ -147,7 +125,9 @@ export default defineComponent({
             if (legendFilteredData) {
                 data = legendFilteredData;
             } else {
-                data = props.plotData(ranges.x.start, ranges.x.end, nPoints);
+                data = store.state.graphs.visibleData[props.graphGroupId]
+                    .find(x => x.configId === props.config.id)!
+                    .data;
                 baseData.value = data;
                 legendConfigs.value = getLegendConfigs(baseData.value);
             }
@@ -171,20 +151,22 @@ export default defineComponent({
         onMounted(drawSkadiChart);
 
         watch(
-          [() => props.redrawWatches, () => props.graphConfig],
+          [() => props.graphGroupId, () => props.config],
           ([, newGraphConfig], [, oldGraphConfig]) => {
           if (plotStyle.value !== fadePlotStyle) {
             drawSkadiChart();
             // if a user locks the y axis then we have to store the y axis range that
             // the graph automatically calculates or an existing y axis range
-            if (newGraphConfig.settings.lockYAxis && !oldGraphConfig.settings.lockYAxis) {
+            if (newGraphConfig.lockYAxis && !oldGraphConfig.lockYAxis) {
               const maxExtentsY = autoscaledMaxExtentsY.value!;
-              const yRange = newGraphConfig.settings.yAxisRange
-                || [maxExtentsY.start, maxExtentsY.end];
-              store.commit(`graphs/${GraphsMutation.SetGraphConfig}`, {
-                  id: props.graphConfig.id,
-                  settings: { yAxisRange: yRange }
-              } as SetGraphConfigPayload);
+              const yRange = newGraphConfig.yAxisRange
+                  || [maxExtentsY.start, maxExtentsY.end];
+
+              const payload: UpdateConfigPayload = {
+                  id: props.config.id,
+                  value: { yAxisRange: yRange }
+              };
+              store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
             }
           }
         });

--- a/app/static/src/serialise.ts
+++ b/app/static/src/serialise.ts
@@ -17,7 +17,6 @@ import {
     SerialisedModelFitState,
     SerialisedMultiSensitivityState
 } from "./types/serialisationTypes";
-import { defaultGraphSettings } from "./store/graphs/state";
 import { Dict } from "./types/utilTypes";
 import { MultiSensitivityState } from "./store/multiSensitivity/state";
 
@@ -166,24 +165,4 @@ export const deserialiseState = (targetState: AppState, serialised: SerialisedAp
         ...serialised,
         persisted: true
     });
-
-    // Initialise selected variables if required
-    const { model, graphs } = targetState;
-    if (
-        model.odinModelResponse?.metadata?.variables &&
-        !graphs.config[0].selectedVariables.length &&
-        !graphs.config[0].unselectedVariables?.length
-    ) {
-        const selectedVariables = [...(model.odinModelResponse?.metadata?.variables || [])];
-        const unselectedVariables: string[] = [];
-
-        targetState.graphs.config = [
-            {
-                id: graphs!.config[0].id,
-                selectedVariables,
-                unselectedVariables,
-                settings: defaultGraphSettings()
-            }
-        ];
-    }
 };

--- a/app/static/src/serialise.ts
+++ b/app/static/src/serialise.ts
@@ -15,10 +15,12 @@ import {
     SerialisedRunResult,
     SerialisedSensitivityResult,
     SerialisedModelFitState,
-    SerialisedMultiSensitivityState
+    SerialisedMultiSensitivityState,
+    SerialisedGraphsState
 } from "./types/serialisationTypes";
 import { Dict } from "./types/utilTypes";
 import { MultiSensitivityState } from "./store/multiSensitivity/state";
+import { GraphsState } from "./store/graphs/state";
 
 function serialiseCode(code: CodeState): CodeState {
     return {
@@ -139,6 +141,14 @@ function serialiseModelFit(modelFit: ModelFitState): SerialisedModelFitState {
     };
 }
 
+function serialiseGraphs(graphs: GraphsState): SerialisedGraphsState {
+    return {
+        configs: graphs.configs,
+        syncedConfigGroups: graphs.syncedConfigGroups,
+        syncedGraphGroups: graphs.syncedGraphGroups,
+    };
+}
+
 export const serialiseState = (state: AppState): string => {
     const result: SerialisedAppState = {
         openVisualisationTab: state.openVisualisationTab,
@@ -147,7 +157,7 @@ export const serialiseState = (state: AppState): string => {
         run: serialiseRun(state.run),
         sensitivity: serialiseSensitivity(state.sensitivity),
         multiSensitivity: serialiseMultiSensitivity(state.multiSensitivity),
-        graphs: state.graphs
+        graphs: serialiseGraphs(state.graphs),
     };
 
     if (state.appType === AppType.Fit) {

--- a/app/static/src/store/plugins.ts
+++ b/app/static/src/store/plugins.ts
@@ -4,6 +4,10 @@ import { StateUploadMutations } from "./appState/mutations";
 import { RunMutation } from "./run/mutations";
 import { RunAction } from "./run/actions";
 import { SensitivityAction } from "./sensitivity/actions";
+import { BaseSensitivityMutation, SensitivityMutation } from "./sensitivity/mutations";
+import { FitDataMutation } from "./fitData/mutations";
+import { ModelFitMutation } from "./modelFit/mutations";
+import { GraphsAction } from "./graphs/actions";
 
 export const logMutations = (store: Store<AppState>): void => {
     store.subscribe((mutation: MutationPayload) => {
@@ -16,6 +20,53 @@ export const persistState = (store: Store<AppState>): void => {
         if (!StateUploadMutations.includes(mutation.type) && !mutation.type.startsWith("errors")) {
             const { dispatch } = store;
             dispatch("QueueStateUpload");
+        }
+    });
+};
+
+const updateGraphOnMutations = [
+    // run button
+    `run/${RunMutation.SetResultOde}`,
+    `run/${RunMutation.SetParameterSetResult}`,
+    `run/${RunMutation.SetResultDiscrete}`,
+
+    // parameter set changes
+    `run/${RunMutation.DeleteParameterSet}`,
+    `sensitivity/${SensitivityMutation.ParameterSetDeleted}`,
+    `run/${RunMutation.SwapParameterSet}`,
+    `sensitivity/${SensitivityMutation.ParameterSetSwapped}`,
+    `run/${RunMutation.ToggleParameterSetHidden}`,
+    `run/${RunMutation.SaveParameterDisplayName}`,
+
+    // fit data changes
+    `fitData/${FitDataMutation.SetData}`,
+    `fitData/${FitDataMutation.SetTimeVariable}`,
+    `fitData/${FitDataMutation.SetLinkedVariable}`,
+    `fitData/${FitDataMutation.SetLinkedVariables}`,
+
+    // fit button
+    `modelFit/${ModelFitMutation.SetResult}`,
+
+    // run sensitivity
+    `sensitivity/${BaseSensitivityMutation.SetResult}`,
+    `sensitivity/${SensitivityMutation.SetParameterSetResults}`,
+
+    // change endTime
+    `run/${RunMutation.SetEndTime}`,
+];
+
+export const updateGraphs = (store: Store<AppState>) => {
+    let timeout: NodeJS.Timeout | undefined = undefined;
+    store.subscribe((mutation, state) => {
+        if (updateGraphOnMutations.includes(mutation.type)) {
+            if (timeout) globalThis.clearTimeout(timeout);
+            timeout = globalThis.setTimeout(() => {
+                store.dispatch(
+                    `graphs/${GraphsAction.UpdateVisibleGraphGroups}`,
+                    [...Object.keys(state.graphs.visibleData)],
+                    { root: true }
+                );
+            }, 0);
         }
     });
 };

--- a/app/static/src/types/serialisationTypes.ts
+++ b/app/static/src/types/serialisationTypes.ts
@@ -73,6 +73,8 @@ export interface SerialisedModelFitState {
     error: null | WodinError;
 }
 
+export type SerialisedGraphsState = Omit<GraphsState, "visibleData">
+
 export interface SerialisedAppState {
     openVisualisationTab: VisualisationTab;
     code: CodeState;
@@ -80,7 +82,7 @@ export interface SerialisedAppState {
     run: SerialisedRunState;
     sensitivity: SerialisedSensitivityState;
     multiSensitivity: SerialisedMultiSensitivityState;
-    graphs: GraphsState;
+    graphs: SerialisedGraphsState;
     fitData?: FitDataState;
     modelFit?: SerialisedModelFitState;
 }


### PR DESCRIPTION
This one can just be reviewed like normal i think, main changes:
* refactored wodin plot so it just needs to know what graph group it is part of and what config this relates to, it can then pull out the corresponding data from the store
* redraw watches are now replaced with a store plugin that youve basically already reviewed in the previous attempt at this!
* we remove data when we serialise graphs state but preserve everything else