### PR TITLE
Mrc 6896 Pt 4 Graph actions to mutations

### DIFF
--- a/app/static/src/components/WodinPlot.vue
+++ b/app/static/src/components/WodinPlot.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, watch, onMounted, PropType, shallowRef } from "vue";
+import { computed, defineComponent, ref, watch, onMounted, PropType } from "vue";
 import { useStore } from "vuex";
 import { Metadata, WodinPlotData, fadePlotStyle } from "../plot";
 import WodinPlotDataSummary from "./WodinPlotDataSummary.vue";
@@ -22,7 +22,7 @@ import { Chart, Scales, ZoomProperties } from "@reside-ic/skadi-chart";
 import { AppState } from "@/store/appState/state";
 import { tooltipCallback } from "@/utils";
 import WodinLegend, { LegendConfig } from "./WodinLegend.vue";
-import { GraphsAction, UpdateConfigPayload } from "@/store/graphs/actions";
+import { GraphsMutation, UpdateConfigPayload } from "@/store/graphs/mutations";
 
 export default defineComponent({
     name: "WodinPlot",
@@ -51,7 +51,13 @@ export default defineComponent({
         const startTime = 0;
 
         const plot = ref<null | HTMLDivElement>(null); // Picks up the element with 'plot' ref in the template
-        const baseData = shallowRef<WodinPlotData>({ lines: [], points: [] });
+        const baseData = computed<WodinPlotData>(() => {
+            const emptyData = { lines: [], points: [] };
+            const visibleData = store.state.graphs.visibleData[props.graphGroupId];
+            if (!visibleData) return emptyData;
+
+            return visibleData.find(({ configId }) => configId === props.config.id)?.data || emptyData;
+        });
 
         const hasPlotData = computed(() => !!baseData.value.lines.length || !!baseData.value.points.length);
 
@@ -69,7 +75,7 @@ export default defineComponent({
               id: props.config.id,
               value: newXYRanges
             };
-            store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
+            store.commit(`graphs/${GraphsMutation.UpdateConfig}`, payload);
         };
 
         const getLegendConfigs = (data: WodinPlotData) => {
@@ -125,10 +131,7 @@ export default defineComponent({
             if (legendFilteredData) {
                 data = legendFilteredData;
             } else {
-                data = store.state.graphs.visibleData[props.graphGroupId]
-                    .find(x => x.configId === props.config.id)!
-                    .data;
-                baseData.value = data;
+                data = baseData.value;
                 legendConfigs.value = getLegendConfigs(baseData.value);
             }
 
@@ -150,25 +153,27 @@ export default defineComponent({
 
         onMounted(drawSkadiChart);
 
-        watch(
-          [() => props.graphGroupId, () => props.config],
-          ([, newGraphConfig], [, oldGraphConfig]) => {
-          if (plotStyle.value !== fadePlotStyle) {
-            drawSkadiChart();
-            // if a user locks the y axis then we have to store the y axis range that
-            // the graph automatically calculates or an existing y axis range
-            if (newGraphConfig.lockYAxis && !oldGraphConfig.lockYAxis) {
-              const maxExtentsY = autoscaledMaxExtentsY.value!;
-              const yRange = newGraphConfig.yAxisRange
-                  || [maxExtentsY.start, maxExtentsY.end];
+        watch([() => props.config], ([newCfg], [oldCfg]) => {
+          if (plotStyle.value === fadePlotStyle) return;
 
-              const payload: UpdateConfigPayload = {
-                  id: props.config.id,
-                  value: { yAxisRange: yRange }
-              };
-              store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
-            }
+          // if a user locks the y axis then we have to store the y axis range that
+          // the graph automatically calculates or an existing y axis range
+          if (newCfg.lockYAxis && !oldCfg.lockYAxis) {
+            const maxExtentsY = autoscaledMaxExtentsY.value!;
+            const yRange = newCfg.yAxisRange
+                || [maxExtentsY.start, maxExtentsY.end];
+
+            const payload: UpdateConfigPayload = {
+                id: props.config.id,
+                value: { yAxisRange: yRange }
+            };
+            store.commit(`graphs/${GraphsMutation.UpdateConfig}`, payload);
           }
+        });
+
+        watch(baseData, () => {
+          if (plotStyle.value === fadePlotStyle) return;
+          drawSkadiChart();
         });
 
         return {

--- a/app/static/src/components/WodinPlot.vue
+++ b/app/static/src/components/WodinPlot.vue
@@ -55,7 +55,6 @@ export default defineComponent({
             const emptyData = { lines: [], points: [] };
             const visibleData = store.state.graphs.visibleData[props.graphGroupId];
             if (!visibleData) return emptyData;
-
             return visibleData.find(({ configId }) => configId === props.config.id)?.data || emptyData;
         });
 

--- a/app/static/src/components/graphConfig/ConfigGroup.vue
+++ b/app/static/src/components/graphConfig/ConfigGroup.vue
@@ -92,13 +92,9 @@ export default defineComponent({
         const graphGroupId = computed(() => store.state.openVisualisationTab);
 
         const configs = computed(() => {
-            const graphGroup = store.state.graphs.syncedGraphGroups[graphGroupId.value];
-            if (!graphGroup) return [];
-
-            const configGroup = store.state.graphs.syncedConfigGroups[graphGroup.syncedConfigGroupId];
-            if (!configGroup) return [];
-
-            return configGroup.configIds.map(id => store.state.graphs.configs.find(c => c.id === id)!);
+            const { syncedConfigGroupId } = store.state.graphs.syncedGraphGroups[graphGroupId.value];
+            const { configIds } = store.state.graphs.syncedConfigGroups[syncedConfigGroupId];
+            return configIds.map(id => store.state.graphs.configs.find(c => c.id === id)!);
         });
 
         const hiddenVariables = computed(() => {

--- a/app/static/src/components/graphConfig/ConfigGroup.vue
+++ b/app/static/src/components/graphConfig/ConfigGroup.vue
@@ -64,10 +64,10 @@ import { useStore } from "vuex";
 import VueFeather from "vue-feather";
 import { AppState } from "@/store/appState/state";
 import GraphSettings from "./GraphSettings.vue";
-import { GraphsAction, UpdateConfigPayload, UpdateSyncedConfigGroupPayload } from "@/store/graphs/actions";
 import { GraphConfig } from "@/store/graphs/state";
 import VariableBadge from "./VariableBadge.vue";
 import { newUid } from "@/utils";
+import { GraphsMutation, UpdateConfigPayload, UpdateSyncedConfigGroupPayload } from "@/store/graphs/mutations";
 
 enum DragData {
     Var = "variable",
@@ -89,12 +89,16 @@ export default defineComponent({
 
         // by convention we have the graph group id is the same string as the
         // openVisualisationTab
-        const graphGroup = computed(() => store.state.openVisualisationTab);
+        const graphGroupId = computed(() => store.state.openVisualisationTab);
 
         const configs = computed(() => {
-            const { syncedConfigGroupId } = store.state.graphs.syncedGraphGroups[graphGroup.value];
-            const { configIds } = store.state.graphs.syncedConfigGroups[syncedConfigGroupId];
-            return configIds.map(id => store.state.graphs.configs.find(c => c.id === id)!);
+            const graphGroup = store.state.graphs.syncedGraphGroups[graphGroupId.value];
+            if (!graphGroup) return [];
+
+            const configGroup = store.state.graphs.syncedConfigGroups[graphGroup.syncedConfigGroupId];
+            if (!configGroup) return [];
+
+            return configGroup.configIds.map(id => store.state.graphs.configs.find(c => c.id === id)!);
         });
 
         const hiddenVariables = computed(() => {
@@ -105,20 +109,20 @@ export default defineComponent({
 
         const addGraph = () => {
             const newId = newUid();
-            store.dispatch(`graphs/${GraphsAction.AddConfig}`, newId);
-            const { syncedConfigGroupId } = store.state.graphs.syncedGraphGroups[graphGroup.value];
+            store.commit(`graphs/${GraphsMutation.AddConfig}`, newId);
+            const { syncedConfigGroupId } = store.state.graphs.syncedGraphGroups[graphGroupId.value];
             const configGroup = store.state.graphs.syncedConfigGroups[syncedConfigGroupId];
             const newConfigGroup = { ...configGroup };
             newConfigGroup.configIds = [ ...newConfigGroup.configIds, newId ];
-            store.dispatch(`graphs/${GraphsAction.UpdateSyncedConfigGroup}`, {
+            store.commit(`graphs/${GraphsMutation.UpdateSyncedConfigGroup}`, {
                 id: syncedConfigGroupId,
                 value: newConfigGroup,
             } as UpdateSyncedConfigGroupPayload);
-            store.dispatch(`graphs/${GraphsAction.UpdateVisibleGraphGroups}`, [graphGroup.value]);
+            store.commit(`graphs/${GraphsMutation.UpdateVisibleGraphGroups}`, [graphGroupId.value]);
         };
 
         const deleteGraph = (configId: string) => {
-            store.dispatch(`graphs/${GraphsAction.DeleteConfig}`, configId);
+            store.commit(`graphs/${GraphsMutation.DeleteConfig}`, configId);
         };
 
         const startDrag = (event: DragEvent, configId: string, variable: string) => {
@@ -137,7 +141,7 @@ export default defineComponent({
         const endDrag = () => dragging.value = false;
 
         const updateSelectedVariables = (configId: string, newVariables: string[]) => {
-            store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, {
+            store.commit(`graphs/${GraphsMutation.UpdateConfig}`, {
                 id: configId,
                 value: { selectedVariables: newVariables }
             } as UpdateConfigPayload)

--- a/app/static/src/components/graphConfig/GraphSettings.vue
+++ b/app/static/src/components/graphConfig/GraphSettings.vue
@@ -15,7 +15,7 @@
 import { defineComponent, computed, PropType } from "vue";
 import { useStore } from "vuex";
 import { GraphConfig } from "@/store/graphs/state";
-import { GraphsAction, UpdateConfigPayload } from "@/store/graphs/actions";
+import { GraphsMutation, UpdateConfigPayload } from "@/store/graphs/mutations";
 
 export default defineComponent({
     name: "GraphSettings",
@@ -37,7 +37,7 @@ export default defineComponent({
                         yAxisRange: null,
                     },
                 };
-                store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
+                store.commit(`graphs/${GraphsMutation.UpdateConfig}`, payload);
             }
         });
 
@@ -48,7 +48,7 @@ export default defineComponent({
                     id: props.config.id,
                     value: { lockYAxis: newValue },
                 };
-                store.dispatch(`graphs/${GraphsAction.UpdateConfig}`, payload);
+                store.commit(`graphs/${GraphsMutation.UpdateConfig}`, payload);
             }
         });
 

--- a/app/static/src/components/mixins/baseSensitivity.ts
+++ b/app/static/src/components/mixins/baseSensitivity.ts
@@ -8,7 +8,7 @@ import { sensitivityUpdateRequiredExplanation, verifyValidPlotSettingsTime } fro
 import { Dict } from "../../types/utilTypes";
 import { BaseSensitivityMutation } from "../../store/sensitivity/mutations";
 import { BaseSensitivityAction } from "../../store/sensitivity/actions";
-import { GraphsGetter } from "../../store/graphs/getters";
+import { getAllSelectedVariables } from "@/store/graphs/utils";
 
 export interface BaseSensitivityMixin {
     sensitivityPrerequisitesReady: ComputedRef<boolean>;
@@ -23,7 +23,7 @@ export default (store: Store<AppState>, multiSensitivity: boolean): BaseSensitiv
     const namespace = multiSensitivity ? "multiSensitivity" : "sensitivity";
 
     const hasRunner = computed(() => store.getters[`model/${ModelGetter.hasRunner}`]);
-    const allSelectedVariables = computed(() => store.getters[`graphs/${GraphsGetter.allSelectedVariables}`]);
+    const allSelectedVariables = computed(() => getAllSelectedVariables(store.state));
 
     const sensitivityPrerequisitesReady = computed(() => {
         return hasRunner.value && !!store.state.model.odin && !store.state.model.compileRequired;

--- a/app/static/src/components/options/LinkData.vue
+++ b/app/static/src/components/options/LinkData.vue
@@ -33,7 +33,7 @@ import { useStore } from "vuex";
 import { FitDataGetter } from "../../store/fitData/getters";
 import userMessages from "../../userMessages";
 import { FitDataAction } from "../../store/fitData/actions";
-import { GraphsGetter } from "../../store/graphs/getters";
+import { getAllSelectedVariables } from "@/store/graphs/utils";
 
 export default defineComponent({
     name: "LinkData",
@@ -42,7 +42,7 @@ export default defineComponent({
         const store = useStore();
         const dataColumns = computed(() => store.getters[`${namespace}/${FitDataGetter.nonTimeColumns}`]);
         const modelSuccess = computed(() => store.state.model.odinModelResponse?.valid);
-        const selectedVariables = computed(() => store.getters[`graphs/${GraphsGetter.allSelectedVariables}`]);
+        const selectedVariables = computed(() => getAllSelectedVariables(store.state));
         const linkedVariables = computed(() => store.state.fitData.linkedVariables);
         const linkPrerequisitesMessage = computed(() => {
             const messages = [];

--- a/app/static/src/components/run/RunTab.vue
+++ b/app/static/src/components/run/RunTab.vue
@@ -65,10 +65,10 @@ import LoadingSpinner from "../LoadingSpinner.vue";
 import { AppType } from "../../store/appState/state";
 import { ModelGetter } from "../../store/model/getters";
 import RunStochasticPlot from "./RunStochasticPlot.vue";
-import { GraphsGetter } from "../../store/graphs/getters";
 import { GraphConfig } from "@/store/graphs/state";
 import { GraphsAction } from "@/store/graphs/actions";
 import { STATIC_BUILD } from "@/parseEnv";
+import { getAllSelectedVariables } from "@/store/graphs/utils";
 
 export default defineComponent({
     name: "RunTab",
@@ -101,7 +101,7 @@ export default defineComponent({
         const sumOfSquares = computed(() => store.state.modelFit?.sumOfSquares);
 
         const hasRunner = computed(() => store.getters[`model/${ModelGetter.hasRunner}`]);
-        const allSelectedVariables = computed(() => store.getters[`graphs/${GraphsGetter.allSelectedVariables}`]);
+        const allSelectedVariables = computed(() => getAllSelectedVariables(store.state));
         const graphConfigs = computed(() => store.state.graphs.config as GraphConfig[]);
 
         // Enable run button if model has initialised and compile is not required

--- a/app/static/src/excel/wodinModelOutputDownload.ts
+++ b/app/static/src/excel/wodinModelOutputDownload.ts
@@ -6,7 +6,7 @@ import { FitData } from "../store/fitData/state";
 import { AppType } from "../store/appState/state";
 import { FitState } from "../store/fit/state";
 import { FitDataGetter } from "../store/fitData/getters";
-import { GraphsGetter } from "../store/graphs/getters";
+import { getAllSelectedVariables } from "@/store/graphs/utils";
 
 export class WodinModelOutputDownload<State> extends WodinExcelDownload<State> {
     private readonly _points: number;
@@ -46,7 +46,7 @@ export class WodinModelOutputDownload<State> extends WodinExcelDownload<State> {
                 tEnd: end,
                 nPoints: this._points
             });
-            const selectedVariables = this._rootGetters[`graphs/${GraphsGetter.allSelectedVariables}`];
+            const selectedVariables = getAllSelectedVariables(this._state);
 
             const worksheet = WodinModelOutputDownload._generateModelledOutput(
                 selectedVariables,
@@ -68,7 +68,7 @@ export class WodinModelOutputDownload<State> extends WodinExcelDownload<State> {
             if (fitData && timeVariable) {
                 const times = fitData.map((row: Dict<number>) => row[timeVariable]);
                 const solutionOutput = solution({ mode: "given", times });
-                const selectedVariables = this._rootGetters[`graphs/${GraphsGetter.allSelectedVariables}`];
+                const selectedVariables = getAllSelectedVariables(this._state);
 
                 const worksheet = WodinModelOutputDownload._generateModelledOutput(
                     selectedVariables,

--- a/app/static/src/store/basic/basic.ts
+++ b/app/static/src/store/basic/basic.ts
@@ -7,7 +7,7 @@ import { model } from "../model/model";
 import { run } from "../run/run";
 import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
-import { logMutations, persistState } from "../plugins";
+import { logMutations, persistState, updateGraphs } from "../plugins";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newUid } from "../../utils";
 import { sessions } from "../sessions/sessions";
@@ -54,5 +54,5 @@ export const storeOptions: StoreOptions<BasicState> = {
         graphs,
         language
     },
-    plugins: [logMutations, persistState]
+    plugins: [logMutations, persistState, updateGraphs]
 };

--- a/app/static/src/store/fit/fit.ts
+++ b/app/static/src/store/fit/fit.ts
@@ -10,7 +10,7 @@ import { sensitivity } from "../sensitivity/sensitivity";
 import { fitData } from "../fitData/fitData";
 import { modelFit } from "../modelFit/modelFit";
 import { AppType, VisualisationTab } from "../appState/state";
-import { logMutations, persistState } from "../plugins";
+import { logMutations, persistState, updateGraphs } from "../plugins";
 import { newUid } from "../../utils";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
@@ -58,5 +58,5 @@ export const storeOptions: StoreOptions<FitState> = {
         graphs,
         language
     },
-    plugins: [logMutations, persistState]
+    plugins: [logMutations, persistState, updateGraphs]
 };

--- a/app/static/src/store/fitData/actions.ts
+++ b/app/static/src/store/fitData/actions.ts
@@ -8,7 +8,7 @@ import { RunMutation } from "../run/mutations";
 import { ModelFitMutation } from "../modelFit/mutations";
 import { ModelFitAction } from "../modelFit/actions";
 import { SensitivityMutation } from "../sensitivity/mutations";
-import { GraphsGetter } from "../graphs/getters";
+import { getAllSelectedVariables } from "../graphs/utils";
 
 export enum FitDataAction {
     Upload = "Upload",
@@ -24,7 +24,7 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     // Empty string means no link
     const { commit, state, rootState, getters, rootGetters } = context;
     const modelResponse = rootState.model.odinModelResponse;
-    const modelVariables = modelResponse?.valid ? rootGetters[`graphs/${GraphsGetter.allSelectedVariables}`] : [];
+    const modelVariables = modelResponse?.valid ? getAllSelectedVariables(rootState) : [];
     const dataColumns = getters.nonTimeColumns;
     let newLinks = {};
     if (dataColumns) {

--- a/app/static/src/store/fitData/actions.ts
+++ b/app/static/src/store/fitData/actions.ts
@@ -22,7 +22,7 @@ const updateLinkedVariables = (context: ActionContext<FitDataState, FitState>) =
     // This is called whenever new data is uploaded, or selected time variable changes, or the model changes, which
     // may partially or fully invalidate any existing links. We retain any we can from previous selection.
     // Empty string means no link
-    const { commit, state, rootState, getters, rootGetters } = context;
+    const { commit, state, rootState, getters } = context;
     const modelResponse = rootState.model.odinModelResponse;
     const modelVariables = modelResponse?.valid ? getAllSelectedVariables(rootState) : [];
     const dataColumns = getters.nonTimeColumns;

--- a/app/static/src/store/graphs/actions.ts
+++ b/app/static/src/store/graphs/actions.ts
@@ -1,142 +1,33 @@
 import { markRaw } from "vue";
-import { ActionContext, ActionTree } from "vuex";
-import { GraphsMutation } from "./mutations";
+import { ActionTree } from "vuex";
 import { AppState } from "../appState/state";
-import { ConfigId, DataWithConfigId, defaultGraphConfig, GraphConfig, GraphsState, SyncedConfigGroup, SyncedConfigGroupId, SyncedGraphGroup, SyncedGraphGroupId } from "./state";
+import { DataWithConfigId, GraphsState } from "./state";
 import { getPlotData } from "@/plotData";
 
 export enum GraphsAction {
-  AddConfig = "AddConfig",
-  UpdateConfig = "UpdateConfig",
-  DeleteConfig = "DeleteConfig",
-  UpdateSyncedConfigGroup = "UpdateSyncedConfigGroup",
-  UpdateSyncedGraphGroup = "UpdateSyncedGraphGroup",
-  UpdateVisibleGraphGroups = "UpdateVisibleGraphGroups",
+  GenerateData = "GenerateData"
 }
-
-export type UpdateConfigPayload = {
-  id: ConfigId,
-  value: Partial<GraphConfig>,
-}
-
-export type UpdateSyncedConfigGroupPayload = {
-  id: SyncedConfigGroupId,
-  value: SyncedConfigGroup,
-}
-
-export type UpdateSyncedGraphGroupPayload = {
-  id: SyncedGraphGroupId,
-  value: SyncedGraphGroup,
-}
-
-
-// utility for creating a new state and committing it after the action
-// is finished
-type Ctx = ActionContext<GraphsState, AppState>
-type CtxWithNewState = Ctx & { newState: GraphsState }
-const actionWrapper = (
-  ctx: Ctx,
-  callback: (ctxWithNewState: CtxWithNewState) => void
-) => {
-  const { state, commit } = ctx;
-  const newState = { ...state };
-
-  callback({ ...ctx, newState });
-
-  commit(GraphsMutation.SetGraphsState, newState);
-};
 
 export const actions = {
-  [GraphsAction.AddConfig](ctx, id: string) {
-    actionWrapper(ctx, ({ newState }) => {
-      newState.configs.push(defaultGraphConfig(id));
-    });
-  },
+  [GraphsAction.GenerateData](ctx) {
+    const { state, rootState } = ctx;
+    state.visibleData = Object.fromEntries(state.visibleGraphGroups.map(graphGroupId => {
+      const { syncedConfigGroupId, dataType } = state.syncedGraphGroups[graphGroupId];
+      const { configIds } = state.syncedConfigGroups[syncedConfigGroupId];
 
-
-  [GraphsAction.UpdateConfig](ctx, payload: UpdateConfigPayload) {
-    actionWrapper(ctx, ({ newState, rootState }) => {
-      const cfgIdx = newState.configs.findIndex(c => c.id === payload.id);
-      newState.configs[cfgIdx] = {
-        ...newState.configs[cfgIdx],
-        ...payload.value,
-      };
-
-      // resolve synced config updates
-      Object.values(newState.syncedConfigGroups).forEach(({ syncProperties, configIds }) => {
-        // don't update if config not in group
-        if (!configIds.includes(payload.id)) return;
-
-        const propertiesToSync = Object.fromEntries(
-          Object.entries(payload.value)
-            .filter(([property]) => syncProperties.includes(property as keyof GraphConfig))
-        );
-        // don't update if updated keys are not in synced properties
-        if (Object.keys(propertiesToSync).length === 0) return;
-
-        configIds.forEach(id => {
-          if (id === payload.id) return;
-          const cfgIdx = newState.configs.findIndex(c => c.id === id);
-          newState.configs[cfgIdx] = {
-            ...newState.configs[cfgIdx],
-            ...propertiesToSync,
-          };
-        });
+      const dataWithConfigIds: DataWithConfigId[] = configIds.map(cfgId => {
+        const config = state.configs.find(cfg => cfg.id === cfgId)!;
+        const data = markRaw(getPlotData(ctx, config, dataType));
+        return { configId: config.id, data };
       });
 
-      const allVariables = rootState.model.odinModelResponse?.metadata?.variables || [];
-      newState.configs.forEach(cfg => cfg.selectedVariables.sort((a, b) => {
-          return allVariables.indexOf(a) > allVariables.indexOf(b) ? 1 : -1
-      }));
-    });
-  },
+      return [graphGroupId, dataWithConfigIds];
+    }));
 
-
-  [GraphsAction.DeleteConfig](ctx, deleteId: string) {
-    actionWrapper(ctx, ({ newState }) => {
-      newState.configs = newState.configs.filter(c => c.id !== deleteId);
-
-      // remove all references to this config
-      Object.values(newState.syncedConfigGroups).forEach(cfgGroup => {
-        cfgGroup.configIds = cfgGroup.configIds.filter(id => id !== deleteId);
-      });
-
-      Object.keys(newState.visibleData).forEach(key => {
-        newState.visibleData[key] = newState.visibleData[key]
-          .filter(dCfg => dCfg.configId !== deleteId);
-      });
-    });
-  },
-
-
-  [GraphsAction.UpdateSyncedConfigGroup](ctx, payload: UpdateSyncedConfigGroupPayload) {
-    actionWrapper(ctx, ({ newState }) => {
-      newState.syncedConfigGroups[payload.id] = payload.value;
-    });
-  },
-
-
-  [GraphsAction.UpdateSyncedGraphGroup](ctx, payload: UpdateSyncedGraphGroupPayload) {
-    actionWrapper(ctx, ({ newState }) => {
-      newState.syncedGraphGroups[payload.id] = payload.value;
-    });
-  },
-
-
-  [GraphsAction.UpdateVisibleGraphGroups](ctx, newVisibleGraphGroups: SyncedGraphGroupId[]) {
-    actionWrapper(ctx, ({ newState }) => {
-      newState.visibleData = Object.fromEntries(newVisibleGraphGroups.map(graphGroupId => {
-        const { syncedConfigGroupId, dataType } = newState.syncedGraphGroups[graphGroupId];
-        const { configIds } = newState.syncedConfigGroups[syncedConfigGroupId];
-
-        const dataWithConfigIds: DataWithConfigId[] = configIds.map(cfgId => {
-          const config = newState.configs.find(cfg => cfg.id === cfgId)!;
-          const data = markRaw(getPlotData(ctx, config, dataType));
-          return { configId: config.id, data };
-        });
-
-        return [graphGroupId, dataWithConfigIds];
-      }));
-    });
+    // make sure config variables are in order of metadata
+    const allVariables = rootState.model.odinModelResponse?.metadata?.variables || [];
+    state.configs.forEach(cfg => cfg.selectedVariables.sort((a, b) => {
+        return allVariables.indexOf(a) > allVariables.indexOf(b) ? 1 : -1
+    }));
   },
 } satisfies ActionTree<GraphsState, AppState>;

--- a/app/static/src/store/graphs/graphs.ts
+++ b/app/static/src/store/graphs/graphs.ts
@@ -1,14 +1,47 @@
-import { GraphsState } from "./state";
+import { DataType, GraphsState } from "./state";
 import { actions } from "./actions";
 import { mutations } from "./mutations";
+import { STATIC_BUILD } from "@/parseEnv";
+import { VisualisationTab } from "../appState/state";
 
-export const defaultState = (): GraphsState => ({
-  configs: [],
-  syncedConfigGroups: {},
-  syncedGraphGroups: {},
-  visibleGraphGroups: [],
-  visibleData: {}
-});
+export enum ConfigGroupIds {
+  RunAndSens = "runAndSensitivityCfgGroup",
+  Fit = "fitCfgGroup"
+}
+
+export const defaultState = (): GraphsState => {
+  return STATIC_BUILD
+    ? {
+      configs: [],
+      syncedConfigGroups: {},
+      syncedGraphGroups: {},
+      visibleGraphGroups: [],
+      visibleData: {}
+    }
+    : {
+      configs: [],
+      syncedConfigGroups: {
+        [ConfigGroupIds.RunAndSens]: { syncProperties: ["xAxisRange"], configIds: [] },
+        [ConfigGroupIds.Fit]: { syncProperties: ["xAxisRange"], configIds: [] },
+      },
+      syncedGraphGroups: {
+        [VisualisationTab.Run]: {
+          syncedConfigGroupId: ConfigGroupIds.RunAndSens,
+          dataType: DataType.Run
+        },
+        [VisualisationTab.Fit]: {
+          syncedConfigGroupId: ConfigGroupIds.Fit,
+          dataType: DataType.Fit
+        },
+        [VisualisationTab.Sensitivity]: {
+          syncedConfigGroupId: ConfigGroupIds.RunAndSens,
+          dataType: DataType.Sensitivity
+        },
+      },
+      visibleGraphGroups: [],
+      visibleData: {}
+    }
+};
 
 export const graphs = {
   namespaced: true,

--- a/app/static/src/store/graphs/graphs.ts
+++ b/app/static/src/store/graphs/graphs.ts
@@ -6,6 +6,7 @@ export const defaultState = (): GraphsState => ({
   configs: [],
   syncedConfigGroups: {},
   syncedGraphGroups: {},
+  visibleGraphGroups: [],
   visibleData: {}
 });
 

--- a/app/static/src/store/graphs/mutations.ts
+++ b/app/static/src/store/graphs/mutations.ts
@@ -1,11 +1,90 @@
-import { GraphsState } from "./state";
+import { ConfigId, defaultGraphConfig, GraphConfig, GraphsState, SyncedConfigGroup, SyncedConfigGroupId, SyncedGraphGroup, SyncedGraphGroupId } from "./state";
 
 export enum GraphsMutation {
-    SetGraphsState = "SetGraphsState",
+  AddConfig = "AddConfig",
+  UpdateConfig = "UpdateConfig",
+  DeleteConfig = "DeleteConfig",
+  UpdateSyncedConfigGroup = "UpdateSyncedConfigGroup",
+  UpdateSyncedGraphGroup = "UpdateSyncedGraphGroup",
+  UpdateVisibleGraphGroups = "UpdateVisibleGraphGroups",
+}
+
+export type UpdateConfigPayload = {
+  id: ConfigId,
+  value: Partial<GraphConfig>,
+}
+
+export type UpdateSyncedConfigGroupPayload = {
+  id: SyncedConfigGroupId,
+  value: SyncedConfigGroup,
+}
+
+export type UpdateSyncedGraphGroupPayload = {
+  id: SyncedGraphGroupId,
+  value: SyncedGraphGroup,
 }
 
 export const mutations = {
-    [GraphsMutation.SetGraphsState](state: GraphsState, payload: GraphsState) {
-        state = payload;
-    },
+  [GraphsMutation.AddConfig](state: GraphsState, id: string) {
+    state.configs.push(defaultGraphConfig(id));
+  },
+
+  [GraphsMutation.UpdateConfig](state: GraphsState, payload: UpdateConfigPayload) {
+    const cfgIdx = state.configs.findIndex(c => c.id === payload.id);
+    state.configs[cfgIdx] = {
+      ...state.configs[cfgIdx],
+      ...payload.value,
+    };
+
+    // resolve synced config updates
+    Object.values(state.syncedConfigGroups).forEach(({ syncProperties, configIds }) => {
+      // don't update if config not in group
+      if (!configIds.includes(payload.id)) return;
+
+      const propertiesToSync = Object.fromEntries(
+        Object.entries(payload.value)
+          .filter(([property]) => syncProperties.includes(property as keyof GraphConfig))
+      );
+      // don't update if updated keys are not in synced properties
+      if (Object.keys(propertiesToSync).length === 0) return;
+
+      configIds.forEach(id => {
+        if (id === payload.id) return;
+        const cfgIdx = state.configs.findIndex(c => c.id === id);
+        state.configs[cfgIdx] = {
+          ...state.configs[cfgIdx],
+          ...propertiesToSync,
+        };
+      });
+    });
+  },
+
+  [GraphsMutation.DeleteConfig](state: GraphsState, deleteId: string) {
+    state.configs = state.configs.filter(c => c.id !== deleteId);
+
+    // remove all references to this config
+    Object.values(state.syncedConfigGroups).forEach(cfgGroup => {
+      cfgGroup.configIds = cfgGroup.configIds.filter(id => id !== deleteId);
+    });
+
+    // this will get updated by plugin but since the data update is async
+    // and this mutation is sync, it could potentially cause buggy UI for
+    // a second so remove it here anyway
+    Object.keys(state.visibleData).forEach(key => {
+      state.visibleData[key] = state.visibleData[key]
+        .filter(dCfg => dCfg.configId !== deleteId);
+    });
+  },
+
+  [GraphsMutation.UpdateSyncedConfigGroup](state: GraphsState, payload: UpdateSyncedConfigGroupPayload) {
+    state.syncedConfigGroups[payload.id] = payload.value;
+  },
+
+  [GraphsMutation.UpdateSyncedGraphGroup](state: GraphsState, payload: UpdateSyncedGraphGroupPayload) {
+    state.syncedGraphGroups[payload.id] = payload.value;
+  },
+
+  [GraphsMutation.UpdateVisibleGraphGroups](state: GraphsState, newVisibleGroups: SyncedGraphGroupId[]) {
+    state.visibleGraphGroups = newVisibleGroups;
+  },
 };

--- a/app/static/src/store/graphs/state.ts
+++ b/app/static/src/store/graphs/state.ts
@@ -74,6 +74,7 @@ export type GraphsState = {
   configs: GraphConfig[],
   syncedConfigGroups: Record<SyncedConfigGroupId, SyncedConfigGroup>,
   syncedGraphGroups: Record<SyncedGraphGroupId, SyncedGraphGroup>,
+  visibleGraphGroups: SyncedGraphGroupId[],
   visibleData: Record<SyncedGraphGroupId, DataWithConfigId[]>,
 }
 

--- a/app/static/src/store/graphs/utils.ts
+++ b/app/static/src/store/graphs/utils.ts
@@ -1,0 +1,5 @@
+import { AppState } from "../appState/state";
+
+export const getAllSelectedVariables = <T extends AppState>(state: T) => {
+  return state.graphs.configs.flatMap(cfg => cfg.selectedVariables);
+};

--- a/app/static/src/store/plugins.ts
+++ b/app/static/src/store/plugins.ts
@@ -8,6 +8,7 @@ import { BaseSensitivityMutation, SensitivityMutation } from "./sensitivity/muta
 import { FitDataMutation } from "./fitData/mutations";
 import { ModelFitMutation } from "./modelFit/mutations";
 import { GraphsAction } from "./graphs/actions";
+import { GraphsMutation } from "./graphs/mutations";
 
 export const logMutations = (store: Store<AppState>): void => {
     store.subscribe((mutation: MutationPayload) => {
@@ -53,17 +54,25 @@ const updateGraphOnMutations = [
 
     // change endTime
     `run/${RunMutation.SetEndTime}`,
+
+    // graphs mutations
+    `graphs/${GraphsMutation.AddConfig}`,
+    `graphs/${GraphsMutation.UpdateConfig}`,
+    `graphs/${GraphsMutation.DeleteConfig}`,
+    `graphs/${GraphsMutation.UpdateSyncedConfigGroup}`,
+    `graphs/${GraphsMutation.UpdateSyncedGraphGroup}`,
+    `graphs/${GraphsMutation.UpdateVisibleGraphGroups}`,
 ];
 
 export const updateGraphs = (store: Store<AppState>) => {
     let timeout: NodeJS.Timeout | undefined = undefined;
-    store.subscribe((mutation, state) => {
+    store.subscribe(mutation => {
         if (updateGraphOnMutations.includes(mutation.type)) {
             if (timeout) globalThis.clearTimeout(timeout);
             timeout = globalThis.setTimeout(() => {
                 store.dispatch(
-                    `graphs/${GraphsAction.UpdateVisibleGraphGroups}`,
-                    [...Object.keys(state.graphs.visibleData)],
+                    `graphs/${GraphsAction.GenerateData}`,
+                    null,
                     { root: true }
                 );
             }, 0);

--- a/app/static/src/store/stochastic/stochastic.ts
+++ b/app/static/src/store/stochastic/stochastic.ts
@@ -9,7 +9,7 @@ import { code } from "../code/code";
 import { sensitivity } from "../sensitivity/sensitivity";
 import { AppType, VisualisationTab } from "../appState/state";
 import { newUid } from "../../utils";
-import { logMutations, persistState } from "../plugins";
+import { logMutations, persistState, updateGraphs } from "../plugins";
 import { sessions } from "../sessions/sessions";
 import { versions } from "../versions/versions";
 import { graphs } from "../graphs/graphs";
@@ -54,5 +54,5 @@ export const storeOptions: StoreOptions<StochasticState> = {
         graphs,
         language
     },
-    plugins: [logMutations, persistState]
+    plugins: [logMutations, persistState, updateGraphs]
 };


### PR DESCRIPTION
theres a lot of code movement here so the diff is actually smaller than you think!

main changes:
* graph actions -> graph mutations: they pretty much do the same thing but now there is a `GenerateData` graph action which reacts to changes in graph config via the plugin
* in `WodinPlot.vue`, `baseData` is now just a computed value since we can get it from the store, the watcher that draws the plot now watches the data, if the data changes, then the plot must change
* actually registered the plugin in all the stores
* default graph state is now a bit cleverer - as i was coding, i had to put checks on whether a given key exists on `syncedConfigGroups` or `syncedGraphGroups` but i dont want to think about that especially when the component received the graph group id via a prop for example. I have instead made it so the state is initialised with some structure and if we are in static build, the initial graph state has no structure (we will setup the correct structure before any of the components are mounted)