### PR TITLE
Mrc 6896 Pt 5 Old variables in model state and graph config styling

### DIFF
--- a/app/static/src/components/graphConfig/ConfigGroup.vue
+++ b/app/static/src/components/graphConfig/ConfigGroup.vue
@@ -23,7 +23,6 @@
                     <variable-badge :variable="variable"
                                     :inHidden="false"
                                     @dragstart="event => startDrag(event, config.id, variable)"
-                                    @dragend="endDrag"
                                     @removeVariable="variable => removeVariable(config, variable)"></variable-badge>
                 </template>
                 <div v-if="!config.selectedVariables.length"
@@ -48,8 +47,7 @@
             <template v-for="variable in hiddenVariables" :key="variable">
                 <variable-badge :variable="variable"
                                 :inHidden="false"
-                                @dragstart="event => startDrag(event, hiddenConfigId, variable)"
-                                @dragend="endDrag"></variable-badge>
+                                @dragstart="event => startDrag(event, hiddenConfigId, variable)"></variable-badge>
             </template>
             <div v-if="!hiddenVariables.length" class="drop-zone-instruction p-2 me-4">
                 Drag variables here to hide them on all graphs.
@@ -134,8 +132,6 @@ export default defineComponent({
             dragging.value = true;
         };
 
-        const endDrag = () => dragging.value = false;
-
         const updateSelectedVariables = (configId: string, newVariables: string[]) => {
             store.commit(`graphs/${GraphsMutation.UpdateConfig}`, {
                 id: configId,
@@ -175,6 +171,8 @@ export default defineComponent({
                 addVariable(config!, variable);
                 if (!copy) removeVariable(srcConfig!, variable);
             }
+
+            dragging.value = false;
         };
 
         return {
@@ -183,7 +181,6 @@ export default defineComponent({
             addGraph,
             deleteGraph,
             startDrag,
-            endDrag,
             removeVariable,
             onDrop,
             hiddenConfigId,
@@ -192,3 +189,20 @@ export default defineComponent({
     }
 });
 </script>
+
+<style scoped lang="scss">
+.graph-config-panel {
+    border-width: 1px;
+    border-style: solid;
+    border-color: #ccc;
+    padding: 4px;
+    .selected-variables-panel {
+        width: 100%;
+
+        .variable {
+            font-size: large;
+            cursor: pointer;
+        }
+    }
+}
+</style>

--- a/app/static/src/components/graphConfig/ConfigGroup.vue
+++ b/app/static/src/components/graphConfig/ConfigGroup.vue
@@ -23,6 +23,7 @@
                     <variable-badge :variable="variable"
                                     :inHidden="false"
                                     @dragstart="event => startDrag(event, config.id, variable)"
+                                    @dragend="endDrag"
                                     @removeVariable="variable => removeVariable(config, variable)"></variable-badge>
                 </template>
                 <div v-if="!config.selectedVariables.length"
@@ -47,7 +48,8 @@
             <template v-for="variable in hiddenVariables" :key="variable">
                 <variable-badge :variable="variable"
                                 :inHidden="false"
-                                @dragstart="event => startDrag(event, hiddenConfigId, variable)"></variable-badge>
+                                @dragstart="event => startDrag(event, hiddenConfigId, variable)"
+                                @dragend="endDrag"></variable-badge>
             </template>
             <div v-if="!hiddenVariables.length" class="drop-zone-instruction p-2 me-4">
                 Drag variables here to hide them on all graphs.
@@ -132,6 +134,8 @@ export default defineComponent({
             dragging.value = true;
         };
 
+        const endDrag = () => dragging.value = false;
+
         const updateSelectedVariables = (configId: string, newVariables: string[]) => {
             store.commit(`graphs/${GraphsMutation.UpdateConfig}`, {
                 id: configId,
@@ -171,8 +175,6 @@ export default defineComponent({
                 addVariable(config!, variable);
                 if (!copy) removeVariable(srcConfig!, variable);
             }
-
-            dragging.value = false;
         };
 
         return {
@@ -181,6 +183,7 @@ export default defineComponent({
             addGraph,
             deleteGraph,
             startDrag,
+            endDrag,
             removeVariable,
             onDrop,
             hiddenConfigId,

--- a/app/static/src/components/graphConfig/VariableBadge.vue
+++ b/app/static/src/components/graphConfig/VariableBadge.vue
@@ -3,8 +3,7 @@
           :class="inHidden ? 'mb-2' : ''"
           :style="style"
           draggable="true"
-          @dragstart="$event => $emit('dragstart', $event)"
-          @dragend="$event => $emit('dragend', $event)">
+          @dragstart="$event => $emit('dragstart', $event)">
         <span class="variable-name">{{ variable }}</span>
         <span v-if="!inHidden" class="variable-delete">
           <button @click="() => $emit('removeVariable', variable)"
@@ -20,7 +19,7 @@ import { default as Color } from "color";
 import { AppState } from "@/store/appState/state";
 
 export default defineComponent({
-    emits: ["dragstart", "dragend", "removeVariable"],
+    emits: ["dragstart", "removeVariable"],
     props: {
         variable: {
             type: String,

--- a/app/static/src/components/graphConfig/VariableBadge.vue
+++ b/app/static/src/components/graphConfig/VariableBadge.vue
@@ -3,7 +3,8 @@
           :class="inHidden ? 'mb-2' : ''"
           :style="style"
           draggable="true"
-          @dragstart="$event => $emit('dragstart', $event)">
+          @dragstart="$event => $emit('dragstart', $event)"
+          @dragend="$event => $emit('dragend', $event)">
         <span class="variable-name">{{ variable }}</span>
         <span v-if="!inHidden" class="variable-delete">
           <button @click="() => $emit('removeVariable', variable)"
@@ -19,7 +20,7 @@ import { default as Color } from "color";
 import { AppState } from "@/store/appState/state";
 
 export default defineComponent({
-    emits: ["dragstart", "removeVariable"],
+    emits: ["dragstart", "dragend", "removeVariable"],
     props: {
         variable: {
             type: String,

--- a/app/static/src/store/model/actions.ts
+++ b/app/static/src/store/model/actions.ts
@@ -15,7 +15,8 @@ import { ErrorsMutation } from "../errors/mutations";
 import { BaseSensitivityMutation, SensitivityMutation } from "../sensitivity/mutations";
 import { defaultSensitivityParamSettings } from "../sensitivity/sensitivity";
 import { MultiSensitivityMutation } from "../multiSensitivity/mutations";
-import { GraphsAction, UpdateSelectedVariablesPayload } from "../graphs/actions";
+import { GraphConfig } from "../graphs/state";
+import { GraphsMutation, UpdateConfigPayload } from "../graphs/mutations";
 
 export enum ModelAction {
     FetchOdinRunner = "FetchOdinRunner",
@@ -68,13 +69,24 @@ const compileModelAndUpdateStore = (context: ActionContext<ModelState, AppState>
         const variables = state.odinModelResponse.metadata?.variables || [];
         commit(ModelMutation.SetPaletteModel, paletteModel(variables));
 
-        // Retain variable selections. Newly added variables will be selected by default in the first graph
-        const selectedVariables = variables.filter((s) => !rootState.graphs.config[0].unselectedVariables.includes(s));
-        dispatch(
-            `graphs/${GraphsAction.UpdateSelectedVariables}`,
-            { id: rootState.graphs.config[0].id, selectedVariables } as UpdateSelectedVariablesPayload,
-            { root: true }
-        );
+        // add any new variables to first graph and remove any invalid variables from
+        // all graphs
+        const newVariables = variables.filter(v => !state.oldVariables.includes(v));
+        rootState.graphs.configs.map((cfg, i) => {
+            const validSelectedVariables = cfg.selectedVariables.filter(v => variables.includes(v));
+            const payload: UpdateConfigPayload = {
+                id: cfg.id,
+                value: {
+                    selectedVariables: [
+                        ...validSelectedVariables,
+                        ...(i === 0 ? newVariables : [])
+                    ]
+                }
+            };
+            commit(`graphs/${GraphsMutation.UpdateConfig}`, payload, { root: true });
+        });
+
+        commit(ModelMutation.SetOldVariables, variables);
 
         if (state.compileRequired) {
             commit(ModelMutation.SetCompileRequired, false);

--- a/app/static/src/store/model/actions.ts
+++ b/app/static/src/store/model/actions.ts
@@ -15,7 +15,6 @@ import { ErrorsMutation } from "../errors/mutations";
 import { BaseSensitivityMutation, SensitivityMutation } from "../sensitivity/mutations";
 import { defaultSensitivityParamSettings } from "../sensitivity/sensitivity";
 import { MultiSensitivityMutation } from "../multiSensitivity/mutations";
-import { GraphConfig } from "../graphs/state";
 import { GraphsMutation, UpdateConfigPayload } from "../graphs/mutations";
 
 export enum ModelAction {

--- a/app/static/src/store/model/model.ts
+++ b/app/static/src/store/model/model.ts
@@ -10,7 +10,8 @@ export const defaultState: ModelState = {
     odinModelResponse: null,
     odin: null,
     paletteModel: null,
-    odinModelCodeError: null
+    odinModelCodeError: null,
+    oldVariables: [],
 };
 
 export const model = {

--- a/app/static/src/store/model/mutations.ts
+++ b/app/static/src/store/model/mutations.ts
@@ -10,7 +10,8 @@ export enum ModelMutation {
     SetOdinResponse = "SetOdinResponse",
     SetOdin = "SetOdin",
     SetCompileRequired = "SetCompileRequired",
-    SetPaletteModel = "SetPaletteModel"
+    SetPaletteModel = "SetPaletteModel",
+    SetOldVariables = "SetOldVariables",
 }
 
 export const mutations: MutationTree<ModelState> = {
@@ -40,5 +41,9 @@ export const mutations: MutationTree<ModelState> = {
 
     [ModelMutation.SetPaletteModel](state: ModelState, payload: Palette | null) {
         state.paletteModel = payload;
-    }
+    },
+
+    [ModelMutation.SetOldVariables](state: ModelState, payload: string[]) {
+        state.oldVariables = payload;
+    },
 };

--- a/app/static/src/store/model/state.ts
+++ b/app/static/src/store/model/state.ts
@@ -13,4 +13,5 @@ export interface ModelState {
     paletteModel: null | Palette;
     // TODO: rename to simply error
     odinModelCodeError: WodinError | null;
+    oldVariables: string[];
 }


### PR DESCRIPTION
main changes:
* forgot to copy over graph config styling so have copied that over
* added old variables to model state and better logic for making sure we retain selected variables between model compiles

some questions i had, after model recompile, surely we want to affect other parts of the graph config too? do we not want to reset the x and y axes for example? what about log scale and lock y axis settings?

i personally think its reasonable to reset the axes and log and lock y axis setting, if you agree i can do it in this branch